### PR TITLE
ritz: Add source_roots support for import resolution

### DIFF
--- a/projects/ritz/build.py
+++ b/projects/ritz/build.py
@@ -582,7 +582,7 @@ def get_binaries(pkg_dir: Path, config: dict) -> list[tuple[str, Path, list[Path
     return binaries
 
 
-def compile_binary(name: str, src_path: Path, out_dir: Path, additional_sources: list[Path] = None, keep_artifacts: bool = False, use_cache: bool = True, profile: dict = None, dependencies: dict[str, DependencySpec] = None, pkg_dir: Path = None) -> Path:
+def compile_binary(name: str, src_path: Path, out_dir: Path, additional_sources: list[Path] = None, keep_artifacts: bool = False, use_cache: bool = True, profile: dict = None, dependencies: dict[str, DependencySpec] = None, pkg_dir: Path = None, source_roots: list[str] = None) -> Path:
     """Compile Ritz source file(s) to a binary.
 
     Args:
@@ -595,6 +595,7 @@ def compile_binary(name: str, src_path: Path, out_dir: Path, additional_sources:
         profile: Build profile dict with opt_level, debug, lto settings (RFC #109)
         dependencies: RFC #109 dependency specs for namespace resolution
         pkg_dir: Package directory for project root (defaults to ROOT for standalone builds)
+        source_roots: List of source directories to search for imports (e.g., ["src", "kernel/src"])
 
     Uses separate compilation model:
     1. Discover all source files via import resolution
@@ -633,6 +634,8 @@ def compile_binary(name: str, src_path: Path, out_dir: Path, additional_sources:
             for name, spec in dependencies.items()
         }
         cmd.extend(["--deps", json.dumps(deps_json)])
+    if source_roots:
+        cmd.extend(["--sources", json.dumps(source_roots)])
 
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
@@ -719,6 +722,9 @@ def compile_binary(name: str, src_path: Path, out_dir: Path, additional_sources:
                     for name, spec in dependencies.items()
                 }
                 compile_cmd.extend(["--deps", json.dumps(deps_json)])
+            # Pass source roots if any (for import resolution)
+            if source_roots:
+                compile_cmd.extend(["--sources", json.dumps(source_roots)])
 
             result = subprocess.run(compile_cmd, capture_output=True, text=True)
             if result.returncode != 0:
@@ -818,6 +824,16 @@ def build_package(pkg_dir: Path, config: dict, keep_artifacts: bool = False, use
 
     # Parse dependencies (RFC #109 Phase 2)
     dependencies = parse_dependencies(config, pkg_dir)
+
+    # Get source roots for import resolution
+    # Check both top-level and inside [package] (TOML puts keys in current section)
+    source_roots = config.get("sources")
+    if source_roots is None:
+        source_roots = config.get("package", {}).get("sources")
+    # Convert single string to list
+    if isinstance(source_roots, str):
+        source_roots = [source_roots]
+
     if dependencies:
         print(f"📦 Building {pkg_name} ({profile['name']}) with {len(dependencies)} dependencies...")
     else:
@@ -847,7 +863,8 @@ def build_package(pkg_dir: Path, config: dict, keep_artifacts: bool = False, use
             use_cache=use_cache,
             profile=profile,
             dependencies=dependencies,
-            pkg_dir=pkg_dir
+            pkg_dir=pkg_dir,
+            source_roots=source_roots
         )
         if bin_path:
             try:

--- a/projects/ritz/ritz0/emitter_llvmlite.py
+++ b/projects/ritz/ritz0/emitter_llvmlite.py
@@ -754,7 +754,17 @@ class LLVMEmitter:
         return self.builder.call(fn, [string_ptr])
 
     def _emit_global_var(self, var_def: rast.VarDef) -> None:
-        """Emit a module-level mutable variable."""
+        """Emit a module-level mutable variable.
+
+        With separate compilation:
+        - Variables from the current source file get definitions (with initializers)
+        - Variables from other files get external declarations only (no initializer)
+
+        Linkage rules:
+        - pub var: external linkage (visible to linker, can be shared across modules)
+        - var (private): internal linkage (hidden from linker, module-local)
+        - imported var: external linkage (declaration only, defined elsewhere)
+        """
         # Determine the type
         if var_def.type is not None:
             ty = self._ritz_type_to_llvm(var_def.type)
@@ -770,43 +780,62 @@ class LLVMEmitter:
 
         # Create the global variable
         gvar = ir.GlobalVariable(self.module, ty, name=var_def.name)
-        gvar.linkage = "internal"  # Visible within module only
 
-        # Set initializer
-        if var_def.value is not None:
-            if isinstance(var_def.value, rast.IntLit):
-                if isinstance(ty, ir.PointerType):
-                    # Pointer initialized with integer literal (e.g., 0) -> null pointer
-                    gvar.initializer = ir.Constant(ty, None)
-                else:
-                    gvar.initializer = ir.Constant(ty, var_def.value.value)
-            elif isinstance(var_def.value, rast.UnaryOp) and var_def.value.op == '-':
-                # Handle negative integer literals like -1
-                if isinstance(var_def.value.operand, rast.IntLit):
-                    gvar.initializer = ir.Constant(ty, -var_def.value.operand.value)
-                else:
-                    raise ValueError(f"Complex unary op initializer not supported: {var_def.value}")
-            elif isinstance(var_def.value, rast.Cast):
-                # Handle `0 as *i8` style initialization
-                if isinstance(var_def.value.expr, rast.IntLit):
+        # Check if this variable is from the current source file or imported
+        is_from_current_file = self._should_emit_body(var_def)
+
+        if is_from_current_file:
+            # This is a definition - set linkage based on visibility
+            if var_def.is_pub:
+                # pub var: default (external) linkage so other modules can access it
+                # Note: Don't explicitly set "external" because LLVM treats that
+                # as a declaration without initializer. Just leave linkage unset
+                # for a global definition with external visibility.
+                pass  # Default linkage is external for global definitions
+            else:
+                # private var: internal linkage, hidden from linker
+                gvar.linkage = "internal"
+
+            # Set initializer for definitions
+            if var_def.value is not None:
+                if isinstance(var_def.value, rast.IntLit):
                     if isinstance(ty, ir.PointerType):
-                        # Cast to pointer type with zero -> null pointer
+                        # Pointer initialized with integer literal (e.g., 0) -> null pointer
                         gvar.initializer = ir.Constant(ty, None)
                     else:
-                        gvar.initializer = ir.Constant(ty, var_def.value.expr.value)
+                        gvar.initializer = ir.Constant(ty, var_def.value.value)
+                elif isinstance(var_def.value, rast.UnaryOp) and var_def.value.op == '-':
+                    # Handle negative integer literals like -1
+                    if isinstance(var_def.value.operand, rast.IntLit):
+                        gvar.initializer = ir.Constant(ty, -var_def.value.operand.value)
+                    else:
+                        raise ValueError(f"Complex unary op initializer not supported: {var_def.value}")
+                elif isinstance(var_def.value, rast.Cast):
+                    # Handle `0 as *i8` style initialization
+                    if isinstance(var_def.value.expr, rast.IntLit):
+                        if isinstance(ty, ir.PointerType):
+                            # Cast to pointer type with zero -> null pointer
+                            gvar.initializer = ir.Constant(ty, None)
+                        else:
+                            gvar.initializer = ir.Constant(ty, var_def.value.expr.value)
+                    else:
+                        raise ValueError(f"Complex cast initializer not supported: {var_def.value}")
+                elif isinstance(var_def.value, rast.NullLit):
+                    # Handle `null` initialization for pointer types
+                    if isinstance(ty, ir.PointerType):
+                        gvar.initializer = ir.Constant(ty, None)
+                    else:
+                        raise ValueError(f"null can only initialize pointer types, not {ty}")
                 else:
-                    raise ValueError(f"Complex cast initializer not supported: {var_def.value}")
-            elif isinstance(var_def.value, rast.NullLit):
-                # Handle `null` initialization for pointer types
-                if isinstance(ty, ir.PointerType):
-                    gvar.initializer = ir.Constant(ty, None)
-                else:
-                    raise ValueError(f"null can only initialize pointer types, not {ty}")
+                    raise ValueError(f"Unsupported global var initializer: {var_def.value}")
             else:
-                raise ValueError(f"Unsupported global var initializer: {var_def.value}")
+                # Zero initialize
+                gvar.initializer = ir.Constant(ty, None)  # zeroinitializer
         else:
-            # Zero initialize
-            gvar.initializer = ir.Constant(ty, None)  # zeroinitializer
+            # This is an imported variable - external declaration only
+            # No initializer, just a reference to a symbol defined elsewhere
+            gvar.linkage = "external"
+            # No initializer for external declarations
 
         # Store in lookup table
         self.globals[var_def.name] = (gvar, ty)

--- a/projects/ritz/ritz0/import_resolver.py
+++ b/projects/ritz/ritz0/import_resolver.py
@@ -133,7 +133,8 @@ class ImportResolver:
         self,
         project_root: Optional[str] = None,
         use_cache: bool = True,
-        dependencies: Optional[Dict[str, DependencyMapping]] = None
+        dependencies: Optional[Dict[str, DependencyMapping]] = None,
+        source_roots: Optional[List[str]] = None
     ):
         # Track which files have been processed to avoid cycles
         self.processed_files: Set[str] = set()
@@ -176,6 +177,16 @@ class ImportResolver:
         self.import_aliases: Dict[str, Dict[str, str]] = {}
         # RFC #109 Phase 2: Dependency mappings for namespace resolution
         self.dependencies: Dict[str, DependencyMapping] = dependencies or {}
+        # Source roots: directories to search for imports (e.g., ["src", "kernel/src"])
+        # These are searched after relative imports but before project root
+        self.source_roots: List[Path] = []
+        if source_roots:
+            for sr in source_roots:
+                sr_path = Path(sr)
+                if not sr_path.is_absolute() and self.project_root:
+                    sr_path = self.project_root / sr_path
+                if sr_path.exists():
+                    self.source_roots.append(sr_path.resolve())
 
     # ============================================================================
     # Export Map Building
@@ -705,8 +716,9 @@ class ImportResolver:
 
         Resolution order:
         1. Relative to importing file: foo.ritz, foo/bar.ritz
-        2. From project root: ritzlib/sys.ritz
-        3. From RITZ_PATH directories
+        2. From source roots (e.g., ["src", "kernel/src"])
+        3. From project root: ritzlib/sys.ritz
+        4. From RITZ_PATH directories
         """
         base_dir = Path(from_file).parent
 
@@ -733,7 +745,16 @@ class ImportResolver:
         if candidate.exists():
             return str(candidate.resolve())
 
-        # Try 2: From project root
+        # Try 2: From source roots (e.g., ["src", "kernel/src"])
+        for source_root in self.source_roots:
+            candidate = source_root / relative_path
+            if candidate.exists():
+                return str(candidate.resolve())
+            candidate = source_root / flat_name
+            if candidate.exists():
+                return str(candidate.resolve())
+
+        # Try 4: From project root
         if self.project_root:
             candidate = self.project_root / relative_path
             if candidate.exists():
@@ -742,7 +763,7 @@ class ImportResolver:
             if candidate.exists():
                 return str(candidate.resolve())
 
-        # Try 3: From RITZ_PATH directories
+        # Try 5: From RITZ_PATH directories
         for import_path in self.import_paths:
             candidate = import_path / relative_path
             if candidate.exists():
@@ -1258,7 +1279,8 @@ def resolve_imports(
     source_path: str,
     project_root: Optional[str] = None,
     use_cache: bool = True,
-    dependencies: Optional[Dict[str, DependencyMapping]] = None
+    dependencies: Optional[Dict[str, DependencyMapping]] = None,
+    source_roots: Optional[List[str]] = None
 ) -> rast.Module:
     """Convenience function to resolve all imports in a module.
 
@@ -1268,18 +1290,20 @@ def resolve_imports(
         project_root: Optional explicit project root (auto-detected if not provided)
         use_cache: Whether to use .ritz-meta caching (default True)
         dependencies: RFC #109 dependency mappings for namespace resolution
+        source_roots: List of source directories to search for imports
 
     Returns:
         New module with all imported items merged in
     """
-    resolver = ImportResolver(project_root, use_cache=use_cache, dependencies=dependencies)
+    resolver = ImportResolver(project_root, use_cache=use_cache, dependencies=dependencies, source_roots=source_roots)
     return resolver.resolve(module, source_path)
 
 
 def collect_all_source_files(
     source_path: str,
     project_root: Optional[str] = None,
-    dependencies: Optional[Dict[str, DependencyMapping]] = None
+    dependencies: Optional[Dict[str, DependencyMapping]] = None,
+    source_roots: Optional[List[str]] = None
 ) -> List[str]:
     """Collect all source files needed for a module (main + all imports).
 
@@ -1290,6 +1314,7 @@ def collect_all_source_files(
         source_path: Path to the main source file
         project_root: Optional explicit project root (auto-detected if not provided)
         dependencies: RFC #109 dependency mappings for namespace resolution
+        source_roots: List of source directories to search for imports
 
     Returns:
         List of absolute paths to all required source files, in dependency order
@@ -1307,7 +1332,7 @@ def collect_all_source_files(
     # Don't use cache - this is just for discovery, not compilation.
     # Using cache here would write stub metadata that could interfere
     # with later compilation that needs full function bodies.
-    resolver = ImportResolver(project_root, use_cache=False, dependencies=dependencies)
+    resolver = ImportResolver(project_root, use_cache=False, dependencies=dependencies, source_roots=source_roots)
     source_path = str(Path(source_path).resolve())
 
     # Parse main module

--- a/projects/ritz/ritz0/list_deps.py
+++ b/projects/ritz/ritz0/list_deps.py
@@ -48,14 +48,16 @@ if __name__ == "__main__":
     parser.add_argument("source", help="Source file to analyze")
     parser.add_argument("--deps", help="JSON dependency specification")
     parser.add_argument("--project-root", help="Explicit project root for import resolution")
+    parser.add_argument("--sources", help="JSON list of source directories to search for imports")
     args = parser.parse_args()
 
     source_path = args.source
     dependencies = parse_deps_arg(args.deps) if args.deps else None
     project_root = args.project_root
+    source_roots = json.loads(args.sources) if args.sources else None
 
     try:
-        files = collect_all_source_files(source_path, project_root=project_root, dependencies=dependencies)
+        files = collect_all_source_files(source_path, project_root=project_root, dependencies=dependencies, source_roots=source_roots)
         for f in files:
             print(f)
     except Exception as e:

--- a/projects/ritz/ritz0/ritz0.py
+++ b/projects/ritz/ritz0/ritz0.py
@@ -63,6 +63,7 @@ def _filter_by_target_os(module: rast.Module, target_os: str) -> rast.Module:
 def compile_file(source_path: str, output_path: str, no_runtime: bool = False,
                   check_names: bool = False, check_ownership: bool = False,
                   check_types: bool = False, dependencies: dict = None,
+                  source_roots: list = None,
                   target: str = 'x86_64-unknown-linux-gnu',
                   target_os: str = 'linux') -> bool:
     """Compile a single Ritz source file to LLVM IR.
@@ -78,6 +79,7 @@ def compile_file(source_path: str, output_path: str, no_runtime: bool = False,
         check_ownership: Check ownership/borrowing rules before IR emission
         check_types: Check types are compatible before IR emission
         dependencies: RFC #109 dependency mappings for namespace resolution
+        source_roots: List of source directories to search for imports
         target: Target triple (default: x86_64-unknown-linux-gnu)
         target_os: Target OS for conditional compilation (default: linux)
     """
@@ -109,7 +111,7 @@ def compile_file(source_path: str, output_path: str, no_runtime: bool = False,
         # Note: use_cache=False because the cache creates stub functions without bodies,
         # which is incompatible with our current merged-module architecture.
         # For separate compilation, the cache would be appropriate.
-        module = resolve_imports(module, source_path, use_cache=False, dependencies=dependencies)
+        module = resolve_imports(module, source_path, use_cache=False, dependencies=dependencies, source_roots=source_roots)
 
         # Filter out items that don't match target_os
         # This must happen after import resolution but before name resolution
@@ -253,6 +255,8 @@ def main():
                         help='Enable type checking (catches type errors before IR generation)')
     parser.add_argument('--deps',
                         help='JSON dependency specification for RFC #109 namespacing')
+    parser.add_argument('--sources',
+                        help='JSON list of source directories to search for imports (e.g., ["src", "kernel/src"])')
     parser.add_argument('--target', default='x86_64-unknown-linux-gnu',
                         help='Target triple (default: x86_64-unknown-linux-gnu). '
                              'Use x86_64-none-elf for freestanding/kernel builds.')
@@ -346,12 +350,19 @@ def main():
                     sources=spec["sources"]
                 )
 
+        # Parse source roots if provided
+        source_roots = None
+        if args.sources:
+            import json
+            source_roots = json.loads(args.sources)
+
         success = compile_file(args.source[0], args.output,
                                no_runtime=args.no_runtime,
                                check_names=args.check_names,
                                check_ownership=not args.no_check_ownership,
                                check_types=args.check_types,
                                dependencies=dependencies,
+                               source_roots=source_roots,
                                target=args.target,
                                target_os=args.target_os)
         sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

Migrated from ritz-lang/ritz#174

Adds support for `sources` configuration in `ritz.toml` to specify directories that should be searched for import resolution.

### Changes
- Add `source_roots` parameter to `ImportResolver` to search configured source directories for imports
- Update `resolve_imports` and `collect_all_source_files` convenience functions  
- Add `--sources` CLI argument to `ritz0.py` and `list_deps.py`
- Update `build.py` to read `sources` from `ritz.toml` and pass to compiler
- Fix pub var linkage for separate compilation (global vars from imported files are external declarations)

### Problem Solved
Projects with nested directory structures (like Harland's `kernel/src/`) couldn't resolve imports across sibling directories.

### Solution
With `sources = ["kernel/src"]` in `ritz.toml`, the resolver now searches source roots.

## Closes
- #1 (migration tracking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)