### PR TITLE
goliath: Fix ownership semantics and ritz0 compatibility

### DIFF
--- a/projects/goliath/src/blob_id.ritz
+++ b/projects/goliath/src/blob_id.ritz
@@ -68,27 +68,27 @@ pub fn blob_id_empty() -> BlobId
     id.hash[31] = 0x55
     id
 
-# Compare two BlobIds for equality
-pub fn blob_id_eq(a: BlobId, b: BlobId) -> bool
+# Compare two BlobIds for equality (const borrow - doesn't consume)
+pub fn blob_id_eq(a: *BlobId, b: *BlobId) -> bool
     var i: i32 = 0
     while i < 32
-        if a.hash[i] != b.hash[i]
+        if (*a).hash[i] != (*b).hash[i]
             return false
         i = i + 1
     true
 
-# Check if a BlobId is zero
-pub fn blob_id_is_zero(id: BlobId) -> bool
+# Check if a BlobId is zero (const borrow)
+pub fn blob_id_is_zero(id: *BlobId) -> bool
     var i: i32 = 0
     while i < 32
-        if id.hash[i] != 0
+        if (*id).hash[i] != 0
             return false
         i = i + 1
     true
 
 # Get a pointer to the hash bytes
-pub fn blob_id_bytes(id: BlobId) -> *u8
-    @id.hash[0]
+pub fn blob_id_bytes(id: *BlobId) -> *u8
+    @(*id).hash[0]
 
 # Compute BlobId from data using SHA-256
 # TODO: Implement when cryptosec.sha256 is available
@@ -106,11 +106,11 @@ pub fn blob_id_compute(data: *u8, len: u64) -> BlobId
 
     blob_id_zero()
 
-# Copy a BlobId
-pub fn blob_id_copy(src: BlobId) -> BlobId
+# Copy a BlobId (const borrow)
+pub fn blob_id_copy(src: *BlobId) -> BlobId
     var dst: BlobId
     var i: i32 = 0
     while i < 32
-        dst.hash[i] = src.hash[i]
+        dst.hash[i] = (*src).hash[i]
         i = i + 1
     dst

--- a/projects/goliath/src/blob_store.ritz
+++ b/projects/goliath/src/blob_store.ritz
@@ -3,7 +3,7 @@
 # BlobStore is the trait for storing and retrieving content blobs.
 # Implementations: MemoryBlobStore (G1), DiskBlobStore (G2)
 
-import ritzlib.sys { write }
+import ritzlib.sys { sys_mmap, sys_munmap, PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS }
 import blob_id { BlobId, blob_id_eq, blob_id_zero, blob_id_is_zero, blob_id_compute, blob_id_copy }
 import error { Error, ErrorCode, error_new }
 
@@ -33,19 +33,12 @@ pub struct MemoryBlobStore
 pub fn memory_store_new() -> MemoryBlobStore
     # Allocate initial entry array
     let entry_size: u64 = 56  # sizeof(BlobEntry) - approximate
-    let alloc_size: u64 = entry_size * INITIAL_CAPACITY as u64
+    let alloc_size: i64 = (entry_size * INITIAL_CAPACITY as u64) as i64
 
-    # TODO: Use proper allocator
-    # For now, use mmap
-    import ritzlib.sys { mmap }
-    let entries: *BlobEntry = mmap(
-        0 as *u8,
-        alloc_size,
-        3,    # PROT_READ | PROT_WRITE
-        34,   # MAP_PRIVATE | MAP_ANONYMOUS
-        -1,
-        0
-    ) as *BlobEntry
+    # Use mmap for allocation
+    let prot: i32 = PROT_READ + PROT_WRITE
+    let flags: i32 = MAP_PRIVATE + MAP_ANONYMOUS
+    let entries: *BlobEntry = sys_mmap(0, alloc_size, prot, flags, -1, 0) as *BlobEntry
 
     # Initialize all entries as unused
     var i: i32 = 0
@@ -62,23 +55,23 @@ pub fn memory_store_new() -> MemoryBlobStore
     }
 
 # Find an entry by BlobId
-fn store_find(store: MemoryBlobStore, id: BlobId) -> *BlobEntry
+fn store_find(store: *MemoryBlobStore, id: *BlobId) -> *BlobEntry
     var i: i32 = 0
-    while i < store.capacity
-        let entry: *BlobEntry = store.entries + i
-        if (*entry).used and blob_id_eq((*entry).id, id)
+    while i < (*store).capacity
+        let entry: *BlobEntry = (*store).entries + i
+        if (*entry).used and blob_id_eq(@(*entry).id, id)
             return entry
         i = i + 1
     0 as *BlobEntry
 
 # Check if a blob exists
-pub fn memory_store_exists(store: MemoryBlobStore, id: BlobId) -> bool
+pub fn memory_store_exists(store: *MemoryBlobStore, id: *BlobId) -> bool
     let entry: *BlobEntry = store_find(store, id)
     entry != 0 as *BlobEntry
 
 # Get a blob's data
 # Returns null if not found
-pub fn memory_store_get(store: MemoryBlobStore, id: BlobId) -> *u8
+pub fn memory_store_get(store: *MemoryBlobStore, id: *BlobId) -> *u8
     let entry: *BlobEntry = store_find(store, id)
     if entry == 0 as *BlobEntry
         return 0 as *u8
@@ -86,7 +79,7 @@ pub fn memory_store_get(store: MemoryBlobStore, id: BlobId) -> *u8
 
 # Get a blob's size
 # Returns 0 if not found
-pub fn memory_store_get_size(store: MemoryBlobStore, id: BlobId) -> u64
+pub fn memory_store_get_size(store: *MemoryBlobStore, id: *BlobId) -> u64
     let entry: *BlobEntry = store_find(store, id)
     if entry == 0 as *BlobEntry
         return 0
@@ -94,19 +87,19 @@ pub fn memory_store_get_size(store: MemoryBlobStore, id: BlobId) -> u64
 
 # Store a blob, returns its BlobId
 # If blob already exists, returns existing ID (deduplication)
-pub fn memory_store_put(store:& MemoryBlobStore, data: *u8, size: u64) -> BlobId
+pub fn memory_store_put(store: *MemoryBlobStore, data: *u8, size: u64) -> BlobId
     # Compute content hash
-    let id: BlobId = blob_id_compute(data, size)
+    var id: BlobId = blob_id_compute(data, size)
 
     # Check if already exists (deduplication)
-    if memory_store_exists(*store, id)
-        return id
+    if memory_store_exists(store, @id)
+        return blob_id_copy(@id)
 
     # Find a free slot
     var slot: *BlobEntry = 0 as *BlobEntry
     var i: i32 = 0
-    while i < store.capacity
-        let entry: *BlobEntry = store.entries + i
+    while i < (*store).capacity
+        let entry: *BlobEntry = (*store).entries + i
         if not (*entry).used
             slot = entry
             break
@@ -118,15 +111,9 @@ pub fn memory_store_put(store:& MemoryBlobStore, data: *u8, size: u64) -> BlobId
         return blob_id_zero()
 
     # Allocate storage for data
-    import ritzlib.sys { mmap }
-    let data_copy: *u8 = mmap(
-        0 as *u8,
-        size,
-        3,    # PROT_READ | PROT_WRITE
-        34,   # MAP_PRIVATE | MAP_ANONYMOUS
-        -1,
-        0
-    ) as *u8
+    let prot: i32 = PROT_READ + PROT_WRITE
+    let flags: i32 = MAP_PRIVATE + MAP_ANONYMOUS
+    let data_copy: *u8 = sys_mmap(0, size as i64, prot, flags, -1, 0)
 
     # Copy data
     var j: u64 = 0
@@ -135,58 +122,55 @@ pub fn memory_store_put(store:& MemoryBlobStore, data: *u8, size: u64) -> BlobId
         j = j + 1
 
     # Store entry
-    (*slot).id = id
+    (*slot).id = blob_id_copy(@id)
     (*slot).data = data_copy
     (*slot).size = size
     (*slot).used = true
 
-    store.count = store.count + 1
-    store.total_size = store.total_size + size
+    (*store).count = (*store).count + 1
+    (*store).total_size = (*store).total_size + size
 
-    id
+    blob_id_copy(@id)
 
 # Delete a blob
-pub fn memory_store_delete(store:& MemoryBlobStore, id: BlobId) -> bool
-    let entry: *BlobEntry = store_find(*store, id)
+pub fn memory_store_delete(store: *MemoryBlobStore, id: *BlobId) -> bool
+    let entry: *BlobEntry = store_find(store, id)
     if entry == 0 as *BlobEntry
         return false
 
     # Free data
-    import ritzlib.sys { munmap }
-    munmap((*entry).data, (*entry).size)
+    sys_munmap((*entry).data, (*entry).size as i64)
 
     # Mark as unused
-    store.total_size = store.total_size - (*entry).size
-    store.count = store.count - 1
+    (*store).total_size = (*store).total_size - (*entry).size
+    (*store).count = (*store).count - 1
     (*entry).used = false
 
     true
 
 # Get total number of blobs
-pub fn memory_store_count(store: MemoryBlobStore) -> i32
-    store.count
+pub fn memory_store_count(store: *MemoryBlobStore) -> i32
+    (*store).count
 
 # Get total size of all blobs
-pub fn memory_store_total_size(store: MemoryBlobStore) -> u64
-    store.total_size
+pub fn memory_store_total_size(store: *MemoryBlobStore) -> u64
+    (*store).total_size
 
 # Free the blob store
-pub fn memory_store_free(store:& MemoryBlobStore)
+pub fn memory_store_free(store: *MemoryBlobStore)
     # Free all blob data
     var i: i32 = 0
-    while i < store.capacity
-        let entry: *BlobEntry = store.entries + i
+    while i < (*store).capacity
+        let entry: *BlobEntry = (*store).entries + i
         if (*entry).used
-            import ritzlib.sys { munmap }
-            munmap((*entry).data, (*entry).size)
+            sys_munmap((*entry).data, (*entry).size as i64)
         i = i + 1
 
     # Free entry array
-    import ritzlib.sys { munmap }
     let entry_size: u64 = 56
-    munmap(store.entries as *u8, entry_size * store.capacity as u64)
+    sys_munmap((*store).entries as *u8, (entry_size * (*store).capacity as u64) as i64)
 
-    store.entries = 0 as *BlobEntry
-    store.capacity = 0
-    store.count = 0
-    store.total_size = 0
+    (*store).entries = 0 as *BlobEntry
+    (*store).capacity = 0
+    (*store).count = 0
+    (*store).total_size = 0

--- a/projects/goliath/src/dir_entry.ritz
+++ b/projects/goliath/src/dir_entry.ritz
@@ -30,7 +30,7 @@ pub struct DirEntry
     metadata: Metadata  # Size, timestamps, permissions
 
 # Create a new file entry
-pub fn dir_entry_file(name: *u8, name_len: u8, blob_id: BlobId, size: u64) -> DirEntry
+pub fn dir_entry_file(name: *u8, name_len: u8, blob_id: *BlobId, size: u64) -> DirEntry
     var entry: DirEntry
 
     # Copy name
@@ -42,7 +42,7 @@ pub fn dir_entry_file(name: *u8, name_len: u8, blob_id: BlobId, size: u64) -> Di
     entry.name_len = name_len
 
     entry.kind = ENTRY_FILE
-    entry.blob_id = blob_id
+    entry.blob_id = blob_id_copy(blob_id)
 
     entry.metadata.size = size
     entry.metadata.created = 0  # TODO: get current time
@@ -52,7 +52,7 @@ pub fn dir_entry_file(name: *u8, name_len: u8, blob_id: BlobId, size: u64) -> Di
     entry
 
 # Create a new directory entry
-pub fn dir_entry_dir(name: *u8, name_len: u8, blob_id: BlobId) -> DirEntry
+pub fn dir_entry_dir(name: *u8, name_len: u8, blob_id: *BlobId) -> DirEntry
     var entry: DirEntry
 
     # Copy name
@@ -64,7 +64,7 @@ pub fn dir_entry_dir(name: *u8, name_len: u8, blob_id: BlobId) -> DirEntry
     entry.name_len = name_len
 
     entry.kind = ENTRY_DIRECTORY
-    entry.blob_id = blob_id
+    entry.blob_id = blob_id_copy(blob_id)
 
     entry.metadata.size = 0
     entry.metadata.created = 0
@@ -74,29 +74,29 @@ pub fn dir_entry_dir(name: *u8, name_len: u8, blob_id: BlobId) -> DirEntry
     entry
 
 # Check if entry is a file
-pub fn dir_entry_is_file(entry: DirEntry) -> bool
-    entry.kind == ENTRY_FILE
+pub fn dir_entry_is_file(entry: *DirEntry) -> bool
+    (*entry).kind == ENTRY_FILE
 
 # Check if entry is a directory
-pub fn dir_entry_is_dir(entry: DirEntry) -> bool
-    entry.kind == ENTRY_DIRECTORY
+pub fn dir_entry_is_dir(entry: *DirEntry) -> bool
+    (*entry).kind == ENTRY_DIRECTORY
 
 # Get entry name pointer
-pub fn dir_entry_name(entry: DirEntry) -> *u8
-    @entry.name[0]
+pub fn dir_entry_name(entry: *DirEntry) -> *u8
+    @(*entry).name[0]
 
 # Get entry name length
-pub fn dir_entry_name_len(entry: DirEntry) -> u8
-    entry.name_len
+pub fn dir_entry_name_len(entry: *DirEntry) -> u8
+    (*entry).name_len
 
 # Compare entry name with a string
-pub fn dir_entry_name_eq(entry: DirEntry, name: *u8, len: u8) -> bool
-    if entry.name_len != len
+pub fn dir_entry_name_eq(entry: *DirEntry, name: *u8, len: u8) -> bool
+    if (*entry).name_len != len
         return false
 
     var i: i32 = 0
     while i < len as i32
-        if entry.name[i] != *(name + i)
+        if (*entry).name[i] != *(name + i)
             return false
         i = i + 1
 
@@ -112,41 +112,41 @@ pub fn dir_serialized_size(entry_count: u32) -> u64
     4 + (entry_count as u64 * 320)  # sizeof(DirEntry) ~ 320 bytes
 
 # Serialize a directory entry to bytes
-pub fn dir_entry_serialize(entry: DirEntry, out: *u8)
+pub fn dir_entry_serialize(entry: *DirEntry, out: *u8)
     # Name (256 bytes)
     var i: i32 = 0
     while i < 256
-        *(out + i) = entry.name[i]
+        *(out + i) = (*entry).name[i]
         i = i + 1
 
     # name_len (1 byte)
-    *(out + 256) = entry.name_len
+    *(out + 256) = (*entry).name_len
 
     # kind (1 byte)
-    *(out + 257) = entry.kind
+    *(out + 257) = (*entry).kind
 
     # blob_id (32 bytes)
     i = 0
     while i < 32
-        *(out + 258 + i) = entry.blob_id.hash[i]
+        *(out + 258 + i) = (*entry).blob_id.hash[i]
         i = i + 1
 
     # metadata (24 bytes)
     # size: u64 at offset 290
     let size_ptr: *u64 = (out + 290) as *u64
-    *size_ptr = entry.metadata.size
+    *size_ptr = (*entry).metadata.size
 
     # created: u64 at offset 298
     let created_ptr: *u64 = (out + 298) as *u64
-    *created_ptr = entry.metadata.created
+    *created_ptr = (*entry).metadata.created
 
     # modified: u64 at offset 306
     let modified_ptr: *u64 = (out + 306) as *u64
-    *modified_ptr = entry.metadata.modified
+    *modified_ptr = (*entry).metadata.modified
 
     # mode: u32 at offset 314
     let mode_ptr: *u32 = (out + 314) as *u32
-    *mode_ptr = entry.metadata.mode
+    *mode_ptr = (*entry).metadata.mode
 
 # Deserialize a directory entry from bytes
 pub fn dir_entry_deserialize(data: *u8) -> DirEntry

--- a/projects/goliath/src/main.ritz
+++ b/projects/goliath/src/main.ritz
@@ -21,17 +21,10 @@ pub import namespace { Namespace, namespace_new, namespace_read, namespace_write
 pub import path { path_is_absolute, path_is_root, path_validate }
 
 # Entry point for standalone testing
-import ritzlib.sys { write }
-
-fn print(msg: *u8, len: i64)
-    write(1, msg, len)
+import ritzlib.sys { sys_write }
 
 pub fn main() -> i32
     # Basic sanity check
-    let msg: *u8 = "Goliath Filesystem - Content Addressable Storage\n"
-    print(msg, 50)
-
-    let msg2: *u8 = "Run tests with: make test\n"
-    print(msg2, 27)
-
+    sys_write(1, "Goliath Filesystem - Content Addressable Storage\n", 50)
+    sys_write(1, "Run tests with: make test\n", 27)
     0

--- a/projects/goliath/src/namespace.ritz
+++ b/projects/goliath/src/namespace.ritz
@@ -3,7 +3,7 @@
 # A namespace maps human-readable paths to BlobIDs.
 # This is the mutable layer on top of the immutable blob store.
 
-import ritzlib.sys { write, mmap, munmap }
+import ritzlib.sys { sys_mmap, sys_munmap, PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS }
 import blob_id { BlobId, blob_id_zero, blob_id_eq, blob_id_is_zero, blob_id_copy }
 import blob_store { MemoryBlobStore, memory_store_get, memory_store_get_size, memory_store_put, memory_store_exists }
 import dir_entry { DirEntry, EntryKind, Metadata, dir_entry_file, dir_entry_dir, dir_entry_is_file, dir_entry_is_dir, dir_entry_name_eq, dir_entry_serialize, dir_entry_deserialize, dir_serialized_size }
@@ -35,13 +35,13 @@ pub fn namespace_new(store: *MemoryBlobStore) -> Namespace
         root: root_id
     }
 
-# Get the root directory BlobId
-pub fn namespace_root(ns: Namespace) -> BlobId
-    ns.root
+# Get the root directory BlobId (copy)
+pub fn namespace_root(ns: *Namespace) -> BlobId
+    blob_id_copy(@(*ns).root)
 
 # Read directory blob and get entry count
-fn read_dir_count(ns: Namespace, dir_id: BlobId) -> i32
-    let data: *u8 = memory_store_get(*ns.store, dir_id)
+fn read_dir_count(ns: *Namespace, dir_id: *BlobId) -> i32
+    let data: *u8 = memory_store_get((*ns).store, dir_id)
     if data == 0 as *u8
         return -1
 
@@ -50,23 +50,23 @@ fn read_dir_count(ns: Namespace, dir_id: BlobId) -> i32
     *count_ptr as i32
 
 # Read directory entry at index
-fn read_dir_entry(ns: Namespace, dir_id: BlobId, index: i32) -> DirEntry
-    let data: *u8 = memory_store_get(*ns.store, dir_id)
+fn read_dir_entry(ns: *Namespace, dir_id: *BlobId, index: i32) -> DirEntry
+    let data: *u8 = memory_store_get((*ns).store, dir_id)
 
     # Entries start at offset 4
     let entry_offset: i32 = 4 + index * 320
     dir_entry_deserialize(data + entry_offset)
 
 # Find entry in directory by name
-fn find_entry_in_dir(ns: Namespace, dir_id: BlobId, name: *u8, name_len: u8) -> i32
+fn find_entry_in_dir(ns: *Namespace, dir_id: *BlobId, name: *u8, name_len: u8) -> i32
     let count: i32 = read_dir_count(ns, dir_id)
     if count < 0
         return -1
 
     var i: i32 = 0
     while i < count
-        let entry: DirEntry = read_dir_entry(ns, dir_id, i)
-        if dir_entry_name_eq(entry, name, name_len)
+        var entry: DirEntry = read_dir_entry(ns, dir_id, i)
+        if dir_entry_name_eq(@entry, name, name_len)
             return i
         i = i + 1
 
@@ -74,16 +74,16 @@ fn find_entry_in_dir(ns: Namespace, dir_id: BlobId, name: *u8, name_len: u8) -> 
 
 # Resolve a path to its BlobId
 # Returns zero BlobId if not found
-pub fn namespace_resolve(ns: Namespace, path: *u8, len: u64) -> BlobId
+pub fn namespace_resolve(ns: *Namespace, path: *u8, len: u64) -> BlobId
     if not path_is_absolute(path, len)
         return blob_id_zero()
 
     # Root path
     if path_is_root(path, len)
-        return ns.root
+        return blob_id_copy(@(*ns).root)
 
     # Walk the path
-    var current_dir: BlobId = ns.root
+    var current_dir: BlobId = blob_id_copy(@(*ns).root)
     var pos: u64 = 0
     var next: u64 = 0
 
@@ -97,50 +97,50 @@ pub fn namespace_resolve(ns: Namespace, path: *u8, len: u64) -> BlobId
         let comp_start: *u8 = path + pos + skip
 
         # Find this component in current directory
-        let entry_idx: i32 = find_entry_in_dir(ns, current_dir, comp_start, comp_len as u8)
+        let entry_idx: i32 = find_entry_in_dir(ns, @current_dir, comp_start, comp_len as u8)
         if entry_idx < 0
             return blob_id_zero()  # Not found
 
-        let entry: DirEntry = read_dir_entry(ns, current_dir, entry_idx)
+        var entry: DirEntry = read_dir_entry(ns, @current_dir, entry_idx)
 
         # Check if we've reached the final component
         pos = pos + skip + next
         if pos >= len or next == 0
             # This is the target
-            return entry.blob_id
+            return blob_id_copy(@entry.blob_id)
 
         # Must be a directory to continue
-        if not dir_entry_is_dir(entry)
+        if not dir_entry_is_dir(@entry)
             return blob_id_zero()
 
-        current_dir = entry.blob_id
+        current_dir = blob_id_copy(@entry.blob_id)
 
     blob_id_zero()
 
 # Check if a path exists
-pub fn namespace_exists(ns: Namespace, path: *u8, len: u64) -> bool
-    let id: BlobId = namespace_resolve(ns, path, len)
-    not blob_id_is_zero(id)
+pub fn namespace_exists(ns: *Namespace, path: *u8, len: u64) -> bool
+    var id: BlobId = namespace_resolve(ns, path, len)
+    not blob_id_is_zero(@id)
 
 # Read file content
 # Returns null if not found or not a file
-pub fn namespace_read(ns: Namespace, path: *u8, len: u64) -> *u8
-    let id: BlobId = namespace_resolve(ns, path, len)
-    if blob_id_is_zero(id)
+pub fn namespace_read(ns: *Namespace, path: *u8, len: u64) -> *u8
+    var id: BlobId = namespace_resolve(ns, path, len)
+    if blob_id_is_zero(@id)
         return 0 as *u8
 
-    memory_store_get(*ns.store, id)
+    memory_store_get((*ns).store, @id)
 
 # Get file size
-pub fn namespace_file_size(ns: Namespace, path: *u8, len: u64) -> u64
-    let id: BlobId = namespace_resolve(ns, path, len)
-    if blob_id_is_zero(id)
+pub fn namespace_file_size(ns: *Namespace, path: *u8, len: u64) -> u64
+    var id: BlobId = namespace_resolve(ns, path, len)
+    if blob_id_is_zero(@id)
         return 0
 
-    memory_store_get_size(*ns.store, id)
+    memory_store_get_size((*ns).store, @id)
 
 # Write/create a file
-pub fn namespace_write(ns:& Namespace, path: *u8, len: u64, data: *u8, data_len: u64) -> ErrorCode
+pub fn namespace_write(ns: *Namespace, path: *u8, len: u64, data: *u8, data_len: u64) -> ErrorCode
     if not path_validate(path, len)
         return ERR_INVALID_PATH
 
@@ -152,10 +152,10 @@ pub fn namespace_write(ns:& Namespace, path: *u8, len: u64, data: *u8, data_len:
     var parent_id: BlobId
 
     if parent_len == 0 or parent_len == 1
-        parent_id = ns.root
+        parent_id = blob_id_copy(@(*ns).root)
     else
-        parent_id = namespace_resolve(*ns, path, parent_len)
-        if blob_id_is_zero(parent_id)
+        parent_id = namespace_resolve(ns, path, parent_len)
+        if blob_id_is_zero(@parent_id)
             return ERR_NOT_FOUND
 
     # Get basename
@@ -168,17 +168,17 @@ pub fn namespace_write(ns:& Namespace, path: *u8, len: u64, data: *u8, data_len:
         base_len = base_len + 1
 
     # Store the file content
-    let file_id: BlobId = memory_store_put(ns.store, data, data_len)
-    if blob_id_is_zero(file_id)
+    var file_id: BlobId = memory_store_put((*ns).store, data, data_len)
+    if blob_id_is_zero(@file_id)
         return ERR_OUT_OF_SPACE
 
     # Update parent directory
-    let result: ErrorCode = update_dir_entry(ns, parent_id, base_name, base_len as u8, file_id, data_len, false)
+    let result: ErrorCode = update_dir_entry(ns, @parent_id, base_name, base_len as u8, @file_id, data_len, false)
 
     result
 
 # Create a directory
-pub fn namespace_mkdir(ns:& Namespace, path: *u8, len: u64) -> ErrorCode
+pub fn namespace_mkdir(ns: *Namespace, path: *u8, len: u64) -> ErrorCode
     if not path_validate(path, len)
         return ERR_INVALID_PATH
 
@@ -186,7 +186,7 @@ pub fn namespace_mkdir(ns:& Namespace, path: *u8, len: u64) -> ErrorCode
         return ERR_ALREADY_EXISTS
 
     # Check if already exists
-    if namespace_exists(*ns, path, len)
+    if namespace_exists(ns, path, len)
         return ERR_ALREADY_EXISTS
 
     # Get parent directory
@@ -194,10 +194,10 @@ pub fn namespace_mkdir(ns:& Namespace, path: *u8, len: u64) -> ErrorCode
     var parent_id: BlobId
 
     if parent_len == 0 or parent_len == 1
-        parent_id = ns.root
+        parent_id = blob_id_copy(@(*ns).root)
     else
-        parent_id = namespace_resolve(*ns, path, parent_len)
-        if blob_id_is_zero(parent_id)
+        parent_id = namespace_resolve(ns, path, parent_len)
+        if blob_id_is_zero(@parent_id)
             return ERR_NOT_FOUND
 
     # Get basename
@@ -214,18 +214,18 @@ pub fn namespace_mkdir(ns:& Namespace, path: *u8, len: u64) -> ErrorCode
     empty_dir[2] = 0
     empty_dir[3] = 0
 
-    let dir_id: BlobId = memory_store_put(ns.store, @empty_dir[0], 4)
-    if blob_id_is_zero(dir_id)
+    var dir_id: BlobId = memory_store_put((*ns).store, @empty_dir[0], 4)
+    if blob_id_is_zero(@dir_id)
         return ERR_OUT_OF_SPACE
 
     # Update parent directory
-    let result: ErrorCode = update_dir_entry(ns, parent_id, base_name, base_len as u8, dir_id, 0, true)
+    let result: ErrorCode = update_dir_entry(ns, @parent_id, base_name, base_len as u8, @dir_id, 0, true)
 
     result
 
 # Helper: update a directory with a new or modified entry
-fn update_dir_entry(ns:& Namespace, dir_id: BlobId, name: *u8, name_len: u8, blob_id: BlobId, size: u64, is_dir: bool) -> ErrorCode
-    let old_data: *u8 = memory_store_get(*ns.store, dir_id)
+fn update_dir_entry(ns: *Namespace, dir_id: *BlobId, name: *u8, name_len: u8, blob_id: *BlobId, size: u64, is_dir: bool) -> ErrorCode
+    let old_data: *u8 = memory_store_get((*ns).store, dir_id)
     if old_data == 0 as *u8
         return ERR_NOT_FOUND
 
@@ -233,7 +233,7 @@ fn update_dir_entry(ns:& Namespace, dir_id: BlobId, name: *u8, name_len: u8, blo
     let old_count: i32 = *count_ptr as i32
 
     # Check if entry exists
-    let existing_idx: i32 = find_entry_in_dir(*ns, dir_id, name, name_len)
+    let existing_idx: i32 = find_entry_in_dir(ns, dir_id, name, name_len)
 
     var new_count: i32
     if existing_idx >= 0
@@ -246,7 +246,9 @@ fn update_dir_entry(ns:& Namespace, dir_id: BlobId, name: *u8, name_len: u8, blo
 
     # Allocate new directory blob
     let new_size: u64 = dir_serialized_size(new_count as u32)
-    let new_data: *u8 = mmap(0 as *u8, new_size, 3, 34, -1, 0) as *u8
+    let prot: i32 = PROT_READ + PROT_WRITE
+    let flags: i32 = MAP_PRIVATE + MAP_ANONYMOUS
+    let new_data: *u8 = sys_mmap(0, new_size as i64, prot, flags, -1, 0)
 
     # Write count
     let new_count_ptr: *u32 = new_data as *u32
@@ -257,8 +259,8 @@ fn update_dir_entry(ns:& Namespace, dir_id: BlobId, name: *u8, name_len: u8, blo
     var i: i32 = 0
     while i < old_count
         if i != existing_idx
-            let entry: DirEntry = read_dir_entry(*ns, dir_id, i)
-            dir_entry_serialize(entry, new_data + 4 + write_idx * 320)
+            var entry: DirEntry = read_dir_entry(ns, dir_id, i)
+            dir_entry_serialize(@entry, new_data + 4 + write_idx * 320)
             write_idx = write_idx + 1
         i = i + 1
 
@@ -269,27 +271,25 @@ fn update_dir_entry(ns:& Namespace, dir_id: BlobId, name: *u8, name_len: u8, blo
     else
         new_entry = dir_entry_file(name, name_len, blob_id, size)
 
-    dir_entry_serialize(new_entry, new_data + 4 + write_idx * 320)
+    dir_entry_serialize(@new_entry, new_data + 4 + write_idx * 320)
 
     # Store new directory blob
-    let new_dir_id: BlobId = memory_store_put(ns.store, new_data, new_size)
-    munmap(new_data, new_size)
+    var new_dir_id: BlobId = memory_store_put((*ns).store, new_data, new_size)
+    sys_munmap(new_data, new_size as i64)
 
-    if blob_id_is_zero(new_dir_id)
+    if blob_id_is_zero(@new_dir_id)
         return ERR_OUT_OF_SPACE
 
     # Update root if this was root directory
-    if blob_id_eq(dir_id, ns.root)
-        ns.root = new_dir_id
-    else
-        # TODO: Update parent directories recursively
-        # For now, only works with root-level entries
-        pass
+    if blob_id_eq(dir_id, @(*ns).root)
+        (*ns).root = blob_id_copy(@new_dir_id)
+    # else: TODO: Update parent directories recursively
+    # For now, only works with root-level entries
 
     ERR_OK
 
 # Delete a file or empty directory
-pub fn namespace_delete(ns:& Namespace, path: *u8, len: u64) -> ErrorCode
+pub fn namespace_delete(ns: *Namespace, path: *u8, len: u64) -> ErrorCode
     if not path_validate(path, len)
         return ERR_INVALID_PATH
 
@@ -301,17 +301,17 @@ pub fn namespace_delete(ns:& Namespace, path: *u8, len: u64) -> ErrorCode
 
 # List directory contents
 # Returns entry count, fills entries array
-pub fn namespace_list(ns: Namespace, path: *u8, len: u64, entries: *DirEntry, max_entries: i32) -> i32
+pub fn namespace_list(ns: *Namespace, path: *u8, len: u64, entries: *DirEntry, max_entries: i32) -> i32
     var dir_id: BlobId
 
     if path_is_root(path, len)
-        dir_id = ns.root
+        dir_id = blob_id_copy(@(*ns).root)
     else
         dir_id = namespace_resolve(ns, path, len)
-        if blob_id_is_zero(dir_id)
+        if blob_id_is_zero(@dir_id)
             return -1
 
-    let count: i32 = read_dir_count(ns, dir_id)
+    let count: i32 = read_dir_count(ns, @dir_id)
     if count < 0
         return -1
 
@@ -321,7 +321,7 @@ pub fn namespace_list(ns: Namespace, path: *u8, len: u64, entries: *DirEntry, ma
 
     var i: i32 = 0
     while i < copy_count
-        *(entries + i) = read_dir_entry(ns, dir_id, i)
+        *(entries + i) = read_dir_entry(ns, @dir_id, i)
         i = i + 1
 
     count


### PR DESCRIPTION
## Summary

- **blob_id**: Use pointer-based APIs (`*BlobId`) for const borrow semantics instead of consuming values
- **blob_store**: Use `sys_mmap`/`sys_munmap` from ritzlib.sys, move imports to top level
- **dir_entry**: Update serialization functions to use pointer-based APIs
- **namespace**: Fix ownership issues using `blob_id_copy(@id)` pattern throughout
- **main**: Use `sys_write` directly instead of custom print wrapper

All 7 source files now compile successfully with ritz0.

## Test plan

- [x] All source files compile with `ritz0 --no-runtime`
- [ ] Update test files to match new pointer-based APIs
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)