### PR TITLE
Migrate cryptosec to RERITZ syntax

### DIFF
--- a/projects/cryptosec/lib/aes.ritz
+++ b/projects/cryptosec/lib/aes.ritz
@@ -156,7 +156,7 @@ fn gf_mul(a: u8, b: u8) -> u8
 
 # AES-128 key expansion (10 rounds + initial)
 pub fn aes128_init(ctx: *Aes128, key: *u8) -> void
-    let rk: *u8 = &ctx.round_keys[0]
+    let rk: *u8 = @ctx.round_keys[0]
 
     # Copy original key as first round key
     mem_copy(rk, key, 16)
@@ -197,7 +197,7 @@ pub fn aes128_init(ctx: *Aes128, key: *u8) -> void
 
 # AES-256 key expansion (14 rounds + initial)
 pub fn aes256_init(ctx: *Aes256, key: *u8) -> void
-    let rk: *u8 = &ctx.round_keys[0]
+    let rk: *u8 = @ctx.round_keys[0]
 
     # Copy original key as first two round keys
     mem_copy(rk, key, 32)
@@ -297,7 +297,7 @@ fn inv_mix_column(s0: u8, s1: u8, s2: u8, s3: u8, out: *u8) -> void
 pub fn aes128_encrypt_block(ctx: *Aes128, input: *u8, output: *u8) -> void
     var state: [16]u8
     var temp: [16]u8
-    let rk: *u8 = &ctx.round_keys[0]
+    let rk: *u8 = @ctx.round_keys[0]
 
     # Initial AddRoundKey
     var i: i32 = 0
@@ -333,25 +333,25 @@ pub fn aes128_encrypt_block(ctx: *Aes128, input: *u8, output: *u8) -> void
 
         # MixColumns + AddRoundKey
         var mcol: [4]u8
-        mix_column(temp[0], temp[1], temp[2], temp[3], &mcol[0])
+        mix_column(temp[0], temp[1], temp[2], temp[3], @mcol[0])
         state[0] = mcol[0] ^ rki[0]
         state[1] = mcol[1] ^ rki[1]
         state[2] = mcol[2] ^ rki[2]
         state[3] = mcol[3] ^ rki[3]
 
-        mix_column(temp[4], temp[5], temp[6], temp[7], &mcol[0])
+        mix_column(temp[4], temp[5], temp[6], temp[7], @mcol[0])
         state[4] = mcol[0] ^ rki[4]
         state[5] = mcol[1] ^ rki[5]
         state[6] = mcol[2] ^ rki[6]
         state[7] = mcol[3] ^ rki[7]
 
-        mix_column(temp[8], temp[9], temp[10], temp[11], &mcol[0])
+        mix_column(temp[8], temp[9], temp[10], temp[11], @mcol[0])
         state[8] = mcol[0] ^ rki[8]
         state[9] = mcol[1] ^ rki[9]
         state[10] = mcol[2] ^ rki[10]
         state[11] = mcol[3] ^ rki[11]
 
-        mix_column(temp[12], temp[13], temp[14], temp[15], &mcol[0])
+        mix_column(temp[12], temp[13], temp[14], temp[15], @mcol[0])
         state[12] = mcol[0] ^ rki[12]
         state[13] = mcol[1] ^ rki[13]
         state[14] = mcol[2] ^ rki[14]
@@ -385,7 +385,7 @@ pub fn aes128_encrypt_block(ctx: *Aes128, input: *u8, output: *u8) -> void
 pub fn aes256_encrypt_block(ctx: *Aes256, input: *u8, output: *u8) -> void
     var state: [16]u8
     var temp: [16]u8
-    let rk: *u8 = &ctx.round_keys[0]
+    let rk: *u8 = @ctx.round_keys[0]
 
     # Initial AddRoundKey
     var i: i32 = 0
@@ -421,25 +421,25 @@ pub fn aes256_encrypt_block(ctx: *Aes256, input: *u8, output: *u8) -> void
 
         # MixColumns + AddRoundKey
         var mcol: [4]u8
-        mix_column(temp[0], temp[1], temp[2], temp[3], &mcol[0])
+        mix_column(temp[0], temp[1], temp[2], temp[3], @mcol[0])
         state[0] = mcol[0] ^ rki[0]
         state[1] = mcol[1] ^ rki[1]
         state[2] = mcol[2] ^ rki[2]
         state[3] = mcol[3] ^ rki[3]
 
-        mix_column(temp[4], temp[5], temp[6], temp[7], &mcol[0])
+        mix_column(temp[4], temp[5], temp[6], temp[7], @mcol[0])
         state[4] = mcol[0] ^ rki[4]
         state[5] = mcol[1] ^ rki[5]
         state[6] = mcol[2] ^ rki[6]
         state[7] = mcol[3] ^ rki[7]
 
-        mix_column(temp[8], temp[9], temp[10], temp[11], &mcol[0])
+        mix_column(temp[8], temp[9], temp[10], temp[11], @mcol[0])
         state[8] = mcol[0] ^ rki[8]
         state[9] = mcol[1] ^ rki[9]
         state[10] = mcol[2] ^ rki[10]
         state[11] = mcol[3] ^ rki[11]
 
-        mix_column(temp[12], temp[13], temp[14], temp[15], &mcol[0])
+        mix_column(temp[12], temp[13], temp[14], temp[15], @mcol[0])
         state[12] = mcol[0] ^ rki[12]
         state[13] = mcol[1] ^ rki[13]
         state[14] = mcol[2] ^ rki[14]
@@ -477,7 +477,7 @@ pub fn aes256_encrypt_block(ctx: *Aes256, input: *u8, output: *u8) -> void
 pub fn aes128_decrypt_block(ctx: *Aes128, input: *u8, output: *u8) -> void
     var state: [16]u8
     var temp: [16]u8
-    let rk: *u8 = &ctx.round_keys[0]
+    let rk: *u8 = @ctx.round_keys[0]
 
     # Initial AddRoundKey with last round key
     var i: i32 = 0
@@ -519,25 +519,25 @@ pub fn aes128_decrypt_block(ctx: *Aes128, input: *u8, output: *u8) -> void
 
         # InvMixColumns
         var imcol: [4]u8
-        inv_mix_column(temp[0], temp[1], temp[2], temp[3], &imcol[0])
+        inv_mix_column(temp[0], temp[1], temp[2], temp[3], @imcol[0])
         state[0] = imcol[0]
         state[1] = imcol[1]
         state[2] = imcol[2]
         state[3] = imcol[3]
 
-        inv_mix_column(temp[4], temp[5], temp[6], temp[7], &imcol[0])
+        inv_mix_column(temp[4], temp[5], temp[6], temp[7], @imcol[0])
         state[4] = imcol[0]
         state[5] = imcol[1]
         state[6] = imcol[2]
         state[7] = imcol[3]
 
-        inv_mix_column(temp[8], temp[9], temp[10], temp[11], &imcol[0])
+        inv_mix_column(temp[8], temp[9], temp[10], temp[11], @imcol[0])
         state[8] = imcol[0]
         state[9] = imcol[1]
         state[10] = imcol[2]
         state[11] = imcol[3]
 
-        inv_mix_column(temp[12], temp[13], temp[14], temp[15], &imcol[0])
+        inv_mix_column(temp[12], temp[13], temp[14], temp[15], @imcol[0])
         state[12] = imcol[0]
         state[13] = imcol[1]
         state[14] = imcol[2]
@@ -569,7 +569,7 @@ pub fn aes128_decrypt_block(ctx: *Aes128, input: *u8, output: *u8) -> void
 pub fn aes256_decrypt_block(ctx: *Aes256, input: *u8, output: *u8) -> void
     var state: [16]u8
     var temp: [16]u8
-    let rk: *u8 = &ctx.round_keys[0]
+    let rk: *u8 = @ctx.round_keys[0]
 
     # Initial AddRoundKey with last round key
     var i: i32 = 0
@@ -611,25 +611,25 @@ pub fn aes256_decrypt_block(ctx: *Aes256, input: *u8, output: *u8) -> void
 
         # InvMixColumns
         var imcol: [4]u8
-        inv_mix_column(temp[0], temp[1], temp[2], temp[3], &imcol[0])
+        inv_mix_column(temp[0], temp[1], temp[2], temp[3], @imcol[0])
         state[0] = imcol[0]
         state[1] = imcol[1]
         state[2] = imcol[2]
         state[3] = imcol[3]
 
-        inv_mix_column(temp[4], temp[5], temp[6], temp[7], &imcol[0])
+        inv_mix_column(temp[4], temp[5], temp[6], temp[7], @imcol[0])
         state[4] = imcol[0]
         state[5] = imcol[1]
         state[6] = imcol[2]
         state[7] = imcol[3]
 
-        inv_mix_column(temp[8], temp[9], temp[10], temp[11], &imcol[0])
+        inv_mix_column(temp[8], temp[9], temp[10], temp[11], @imcol[0])
         state[8] = imcol[0]
         state[9] = imcol[1]
         state[10] = imcol[2]
         state[11] = imcol[3]
 
-        inv_mix_column(temp[12], temp[13], temp[14], temp[15], &imcol[0])
+        inv_mix_column(temp[12], temp[13], temp[14], temp[15], @imcol[0])
         state[12] = imcol[0]
         state[13] = imcol[1]
         state[14] = imcol[2]
@@ -665,7 +665,7 @@ pub fn aes256_decrypt_block(ctx: *Aes256, input: *u8, output: *u8) -> void
 # AES-128 encryption using AES-NI
 # Note: This uses the same round_keys buffer as the software implementation
 pub fn aes128_encrypt_block_ni(ctx: *Aes128, input: *u8, output: *u8) -> void
-    var rk_ptr: *i64 = &ctx.round_keys[0] as *i64
+    var rk_ptr: *i64 = @ctx.round_keys[0] as *i64
 
     # Load input block
     var state: v2i64 = simd_loadu(input as *i64)
@@ -713,7 +713,7 @@ pub fn aes128_encrypt_block_ni(ctx: *Aes128, input: *u8, output: *u8) -> void
 # AES-128 decryption using AES-NI
 # Note: For decryption, intermediate round keys need InvMixColumns applied (aesimc)
 pub fn aes128_decrypt_block_ni(ctx: *Aes128, input: *u8, output: *u8) -> void
-    var rk_ptr: *i64 = &ctx.round_keys[0] as *i64
+    var rk_ptr: *i64 = @ctx.round_keys[0] as *i64
 
     # Load input block
     var state: v2i64 = simd_loadu(input as *i64)
@@ -769,7 +769,7 @@ pub fn aes128_decrypt_block_ni(ctx: *Aes128, input: *u8, output: *u8) -> void
 
 # AES-256 encryption using AES-NI
 pub fn aes256_encrypt_block_ni(ctx: *Aes256, input: *u8, output: *u8) -> void
-    var rk_ptr: *i64 = &ctx.round_keys[0] as *i64
+    var rk_ptr: *i64 = @ctx.round_keys[0] as *i64
 
     # Load input block
     var state: v2i64 = simd_loadu(input as *i64)
@@ -828,7 +828,7 @@ pub fn aes256_encrypt_block_ni(ctx: *Aes256, input: *u8, output: *u8) -> void
 
 # AES-256 decryption using AES-NI
 pub fn aes256_decrypt_block_ni(ctx: *Aes256, input: *u8, output: *u8) -> void
-    var rk_ptr: *i64 = &ctx.round_keys[0] as *i64
+    var rk_ptr: *i64 = @ctx.round_keys[0] as *i64
 
     # Load input block
     var state: v2i64 = simd_loadu(input as *i64)

--- a/projects/cryptosec/lib/aes_gcm.ritz
+++ b/projects/cryptosec/lib/aes_gcm.ritz
@@ -137,8 +137,8 @@ pub fn gf128_mul_pclmul(x: *GF128, y: *GF128) -> GF128
     yv_arr[0] = bitrev64(y.lo) as i64
     yv_arr[1] = bitrev64(y.hi) as i64
 
-    var xv: v2i64 = simd_loadu(&xv_arr[0])
-    var yv: v2i64 = simd_loadu(&yv_arr[0])
+    var xv: v2i64 = simd_loadu(@xv_arr[0])
+    var yv: v2i64 = simd_loadu(@yv_arr[0])
 
     # Schoolbook multiplication: [z3:z2:z1:z0] = x * y
     var r00: v2i64 = simd_clmul(xv, yv, 0x00)  # lo * lo -> bits 0-127
@@ -152,9 +152,9 @@ pub fn gf128_mul_pclmul(x: *GF128, y: *GF128) -> GF128
     var r00_arr: [2]i64
     var r11_arr: [2]i64
     var mid_arr: [2]i64
-    simd_storeu(&r00_arr[0], r00)
-    simd_storeu(&r11_arr[0], r11)
-    simd_storeu(&mid_arr[0], mid)
+    simd_storeu(@r00_arr[0], r00)
+    simd_storeu(@r11_arr[0], r11)
+    simd_storeu(@mid_arr[0], mid)
 
     # 256-bit product: [z3:z2:z1:z0] where z0 is bits 0-63
     var z0: u64 = r00_arr[0] as u64
@@ -202,7 +202,7 @@ pub fn gf128_mul_soft(x: *GF128, y: *GF128) -> GF128
     while i >= 0
         let bit: u64 = (x.hi >> (i as u64)) & 1
         if bit == 1
-            z = gf128_xor(&z, &v)
+            z = gf128_xor(@z, @v)
 
         # Multiply v by x (shift right in GF representation)
         # If LSB of v is 1, we need to XOR with reduction polynomial
@@ -221,7 +221,7 @@ pub fn gf128_mul_soft(x: *GF128, y: *GF128) -> GF128
     while i >= 0
         let bit: u64 = (x.lo >> (i as u64)) & 1
         if bit == 1
-            z = gf128_xor(&z, &v)
+            z = gf128_xor(@z, @v)
 
         let lsb: u64 = v.lo & 1
         v.lo = (v.lo >> 1) | (v.hi << 63)
@@ -262,18 +262,18 @@ fn ghash(h: *GF128, aad: *u8, aad_len: i64, ct: *u8, ct_len: i64, out: *u8) -> v
 
     var i: i64 = 0
     while i < aad_blocks
-        var bi: GF128 = gf128_from_bytes(&aad[i * 16])
-        x = gf128_xor(&x, &bi)
-        x = gf128_mul(&x, h)
+        var bi: GF128 = gf128_from_bytes(@aad[i * 16])
+        x = gf128_xor(@x, @bi)
+        x = gf128_mul(@x, h)
         i += 1
 
     # Final partial AAD block
     if aad_rem > 0
-        gcm_mem_zero(&block[0], 16)
-        gcm_mem_copy(&block[0], &aad[aad_blocks * 16], aad_rem)
-        var bi: GF128 = gf128_from_bytes(&block[0])
-        x = gf128_xor(&x, &bi)
-        x = gf128_mul(&x, h)
+        gcm_mem_zero(@block[0], 16)
+        gcm_mem_copy(@block[0], @aad[aad_blocks * 16], aad_rem)
+        var bi: GF128 = gf128_from_bytes(@block[0])
+        x = gf128_xor(@x, @bi)
+        x = gf128_mul(@x, h)
 
     # Process ciphertext
     var ct_blocks: i64 = ct_len / 16
@@ -281,18 +281,18 @@ fn ghash(h: *GF128, aad: *u8, aad_len: i64, ct: *u8, ct_len: i64, out: *u8) -> v
 
     i = 0
     while i < ct_blocks
-        var bi: GF128 = gf128_from_bytes(&ct[i * 16])
-        x = gf128_xor(&x, &bi)
-        x = gf128_mul(&x, h)
+        var bi: GF128 = gf128_from_bytes(@ct[i * 16])
+        x = gf128_xor(@x, @bi)
+        x = gf128_mul(@x, h)
         i += 1
 
     # Final partial ciphertext block
     if ct_rem > 0
-        gcm_mem_zero(&block[0], 16)
-        gcm_mem_copy(&block[0], &ct[ct_blocks * 16], ct_rem)
-        var bi: GF128 = gf128_from_bytes(&block[0])
-        x = gf128_xor(&x, &bi)
-        x = gf128_mul(&x, h)
+        gcm_mem_zero(@block[0], 16)
+        gcm_mem_copy(@block[0], @ct[ct_blocks * 16], ct_rem)
+        var bi: GF128 = gf128_from_bytes(@block[0])
+        x = gf128_xor(@x, @bi)
+        x = gf128_mul(@x, h)
 
     # Process length block [len(A)]_64 || [len(C)]_64
     # Lengths in bits
@@ -317,11 +317,11 @@ fn ghash(h: *GF128, aad: *u8, aad_len: i64, ct: *u8, ct_len: i64, out: *u8) -> v
     block[14] = ((len_ct_bits >> 8) & 0xff) as u8
     block[15] = (len_ct_bits & 0xff) as u8
 
-    var len_block: GF128 = gf128_from_bytes(&block[0])
-    x = gf128_xor(&x, &len_block)
-    x = gf128_mul(&x, h)
+    var len_block: GF128 = gf128_from_bytes(@block[0])
+    x = gf128_xor(@x, @len_block)
+    x = gf128_mul(@x, h)
 
-    gf128_to_bytes(&x, out)
+    gf128_to_bytes(@x, out)
 
 # =============================================================================
 # AES-GCM context structures
@@ -373,21 +373,21 @@ fn make_j0(nonce: *u8, nonce_len: i64, h: *GF128, j0: *u8) -> void
 
         var i: i64 = 0
         while i < blocks
-            var bi: GF128 = gf128_from_bytes(&nonce[i * 16])
-            x = gf128_xor(&x, &bi)
-            x = gf128_mul(&x, h)
+            var bi: GF128 = gf128_from_bytes(@nonce[i * 16])
+            x = gf128_xor(@x, @bi)
+            x = gf128_mul(@x, h)
             i += 1
 
         # Partial block
         if rem > 0
-            gcm_mem_zero(&block[0], 16)
-            gcm_mem_copy(&block[0], &nonce[blocks * 16], rem)
-            var bi: GF128 = gf128_from_bytes(&block[0])
-            x = gf128_xor(&x, &bi)
-            x = gf128_mul(&x, h)
+            gcm_mem_zero(@block[0], 16)
+            gcm_mem_copy(@block[0], @nonce[blocks * 16], rem)
+            var bi: GF128 = gf128_from_bytes(@block[0])
+            x = gf128_xor(@x, @bi)
+            x = gf128_mul(@x, h)
 
         # Length block (just nonce length in bits)
-        gcm_mem_zero(&block[0], 16)
+        gcm_mem_zero(@block[0], 16)
         var len_bits: u64 = (nonce_len * 8) as u64
         block[8] = ((len_bits >> 56) & 0xff) as u8
         block[9] = ((len_bits >> 48) & 0xff) as u8
@@ -398,11 +398,11 @@ fn make_j0(nonce: *u8, nonce_len: i64, h: *GF128, j0: *u8) -> void
         block[14] = ((len_bits >> 8) & 0xff) as u8
         block[15] = (len_bits & 0xff) as u8
 
-        var len_block: GF128 = gf128_from_bytes(&block[0])
-        x = gf128_xor(&x, &len_block)
-        x = gf128_mul(&x, h)
+        var len_block: GF128 = gf128_from_bytes(@block[0])
+        x = gf128_xor(@x, @len_block)
+        x = gf128_mul(@x, h)
 
-        gf128_to_bytes(&x, j0)
+        gf128_to_bytes(@x, j0)
 
 # =============================================================================
 # AES-128-GCM API
@@ -410,14 +410,14 @@ fn make_j0(nonce: *u8, nonce_len: i64, h: *GF128, j0: *u8) -> void
 
 pub fn aes128_gcm_init(ctx: *AesGcm128, key: *u8) -> void
     # Initialize AES key schedule
-    aes128_init(&ctx.aes_ctx, key)
+    aes128_init(@ctx.aes_ctx, key)
 
     # Compute hash key H = AES_K(0^128)
     var zero_block: [16]u8
     var h_bytes: [16]u8
-    gcm_mem_zero(&zero_block[0], 16)
-    aes128_encrypt_block(&ctx.aes_ctx, &zero_block[0], &h_bytes[0])
-    ctx.h = gf128_from_bytes(&h_bytes[0])
+    gcm_mem_zero(@zero_block[0], 16)
+    aes128_encrypt_block(@ctx.aes_ctx, @zero_block[0], @h_bytes[0])
+    ctx.h = gf128_from_bytes(@h_bytes[0])
 
 pub fn aes128_gcm_encrypt(ctx: *AesGcm128, nonce: *u8, nonce_len: i64, aad: *u8, aad_len: i64, pt: *u8, pt_len: i64, ct: *u8, tag: *u8) -> i64
     var j0: [16]u8
@@ -425,19 +425,19 @@ pub fn aes128_gcm_encrypt(ctx: *AesGcm128, nonce: *u8, nonce_len: i64, aad: *u8,
     var ectr: [16]u8
 
     # Compute J0
-    make_j0(nonce, nonce_len, &ctx.h, &j0[0])
+    make_j0(nonce, nonce_len, @ctx.h, @j0[0])
 
     # Initialize counter to J0
-    gcm_mem_copy(&counter[0], &j0[0], 16)
+    gcm_mem_copy(@counter[0], @j0[0], 16)
 
     # Encrypt plaintext with GCTR (counter mode)
     var i: i64 = 0
     while i < pt_len
         # Increment counter
-        inc32(&counter[0])
+        inc32(@counter[0])
 
         # Encrypt counter block
-        aes128_encrypt_block(&ctx.aes_ctx, &counter[0], &ectr[0])
+        aes128_encrypt_block(@ctx.aes_ctx, @counter[0], @ectr[0])
 
         # XOR with plaintext
         var j: i64 = 0
@@ -449,10 +449,10 @@ pub fn aes128_gcm_encrypt(ctx: *AesGcm128, nonce: *u8, nonce_len: i64, aad: *u8,
 
     # Compute authentication tag
     var s: [16]u8
-    ghash(&ctx.h, aad, aad_len, ct, pt_len, &s[0])
+    ghash(@ctx.h, aad, aad_len, ct, pt_len, @s[0])
 
     # Encrypt J0 to get the tag mask
-    aes128_encrypt_block(&ctx.aes_ctx, &j0[0], &ectr[0])
+    aes128_encrypt_block(@ctx.aes_ctx, @j0[0], @ectr[0])
 
     # Tag = S XOR E_K(J0)
     i = 0
@@ -470,10 +470,10 @@ pub fn aes128_gcm_decrypt(ctx: *AesGcm128, nonce: *u8, nonce_len: i64, aad: *u8,
 
     # Compute expected tag first
     var s: [16]u8
-    ghash(&ctx.h, aad, aad_len, ct, ct_len, &s[0])
+    ghash(@ctx.h, aad, aad_len, ct, ct_len, @s[0])
 
-    make_j0(nonce, nonce_len, &ctx.h, &j0[0])
-    aes128_encrypt_block(&ctx.aes_ctx, &j0[0], &ectr[0])
+    make_j0(nonce, nonce_len, @ctx.h, @j0[0])
+    aes128_encrypt_block(@ctx.aes_ctx, @j0[0], @ectr[0])
 
     var i: i64 = 0
     while i < 16
@@ -481,16 +481,16 @@ pub fn aes128_gcm_decrypt(ctx: *AesGcm128, nonce: *u8, nonce_len: i64, aad: *u8,
         i += 1
 
     # Constant-time tag comparison
-    if gcm_mem_eq(&computed_tag[0], tag, 16) == 0
+    if gcm_mem_eq(@computed_tag[0], tag, 16) == 0
         return 0  # Tag mismatch
 
     # Decrypt ciphertext
-    gcm_mem_copy(&counter[0], &j0[0], 16)
+    gcm_mem_copy(@counter[0], @j0[0], 16)
 
     i = 0
     while i < ct_len
-        inc32(&counter[0])
-        aes128_encrypt_block(&ctx.aes_ctx, &counter[0], &ectr[0])
+        inc32(@counter[0])
+        aes128_encrypt_block(@ctx.aes_ctx, @counter[0], @ectr[0])
 
         var j: i64 = 0
         while j < 16 && (i + j) < ct_len
@@ -506,26 +506,26 @@ pub fn aes128_gcm_decrypt(ctx: *AesGcm128, nonce: *u8, nonce_len: i64, aad: *u8,
 # =============================================================================
 
 pub fn aes256_gcm_init(ctx: *AesGcm256, key: *u8) -> void
-    aes256_init(&ctx.aes_ctx, key)
+    aes256_init(@ctx.aes_ctx, key)
 
     var zero_block: [16]u8
     var h_bytes: [16]u8
-    gcm_mem_zero(&zero_block[0], 16)
-    aes256_encrypt_block(&ctx.aes_ctx, &zero_block[0], &h_bytes[0])
-    ctx.h = gf128_from_bytes(&h_bytes[0])
+    gcm_mem_zero(@zero_block[0], 16)
+    aes256_encrypt_block(@ctx.aes_ctx, @zero_block[0], @h_bytes[0])
+    ctx.h = gf128_from_bytes(@h_bytes[0])
 
 pub fn aes256_gcm_encrypt(ctx: *AesGcm256, nonce: *u8, nonce_len: i64, aad: *u8, aad_len: i64, pt: *u8, pt_len: i64, ct: *u8, tag: *u8) -> i64
     var j0: [16]u8
     var counter: [16]u8
     var ectr: [16]u8
 
-    make_j0(nonce, nonce_len, &ctx.h, &j0[0])
-    gcm_mem_copy(&counter[0], &j0[0], 16)
+    make_j0(nonce, nonce_len, @ctx.h, @j0[0])
+    gcm_mem_copy(@counter[0], @j0[0], 16)
 
     var i: i64 = 0
     while i < pt_len
-        inc32(&counter[0])
-        aes256_encrypt_block(&ctx.aes_ctx, &counter[0], &ectr[0])
+        inc32(@counter[0])
+        aes256_encrypt_block(@ctx.aes_ctx, @counter[0], @ectr[0])
 
         var j: i64 = 0
         while j < 16 && (i + j) < pt_len
@@ -535,8 +535,8 @@ pub fn aes256_gcm_encrypt(ctx: *AesGcm256, nonce: *u8, nonce_len: i64, aad: *u8,
         i = i + 16
 
     var s: [16]u8
-    ghash(&ctx.h, aad, aad_len, ct, pt_len, &s[0])
-    aes256_encrypt_block(&ctx.aes_ctx, &j0[0], &ectr[0])
+    ghash(@ctx.h, aad, aad_len, ct, pt_len, @s[0])
+    aes256_encrypt_block(@ctx.aes_ctx, @j0[0], @ectr[0])
 
     i = 0
     while i < 16
@@ -552,25 +552,25 @@ pub fn aes256_gcm_decrypt(ctx: *AesGcm256, nonce: *u8, nonce_len: i64, aad: *u8,
     var computed_tag: [16]u8
 
     var s: [16]u8
-    ghash(&ctx.h, aad, aad_len, ct, ct_len, &s[0])
+    ghash(@ctx.h, aad, aad_len, ct, ct_len, @s[0])
 
-    make_j0(nonce, nonce_len, &ctx.h, &j0[0])
-    aes256_encrypt_block(&ctx.aes_ctx, &j0[0], &ectr[0])
+    make_j0(nonce, nonce_len, @ctx.h, @j0[0])
+    aes256_encrypt_block(@ctx.aes_ctx, @j0[0], @ectr[0])
 
     var i: i64 = 0
     while i < 16
         computed_tag[i] = s[i] ^ ectr[i]
         i += 1
 
-    if gcm_mem_eq(&computed_tag[0], tag, 16) == 0
+    if gcm_mem_eq(@computed_tag[0], tag, 16) == 0
         return 0
 
-    gcm_mem_copy(&counter[0], &j0[0], 16)
+    gcm_mem_copy(@counter[0], @j0[0], 16)
 
     i = 0
     while i < ct_len
-        inc32(&counter[0])
-        aes256_encrypt_block(&ctx.aes_ctx, &counter[0], &ectr[0])
+        inc32(@counter[0])
+        aes256_encrypt_block(@ctx.aes_ctx, @counter[0], @ectr[0])
 
         var j: i64 = 0
         while j < 16 && (i + j) < ct_len

--- a/projects/cryptosec/lib/asn1.ritz
+++ b/projects/cryptosec/lib/asn1.ritz
@@ -215,7 +215,7 @@ pub fn der_parse_element(parser: *DerParser, elem: *DerElement) -> i32
         return -1
 
     # Set content pointer
-    elem.content = &parser.data[parser.pos]
+    elem.content = @parser.data[parser.pos]
 
     # Advance past content
     parser.pos = parser.pos + elem.content_len
@@ -392,7 +392,7 @@ pub fn der_bit_string_content(elem: *DerElement, data: **u8, data_len: *u64, unu
         return -1  # Invalid unused bits count
 
     *unused_bits = ub
-    *data = &elem.content[1]
+    *data = @elem.content[1]
     *data_len = elem.content_len - 1
 
     return 0

--- a/projects/cryptosec/lib/bigint.ritz
+++ b/projects/cryptosec/lib/bigint.ritz
@@ -334,7 +334,7 @@ pub fn bigint_mul(result: *BigInt, a: *BigInt, b: *BigInt)
             if k < BIGINT_MAX_LIMBS
                 var hi: u64 = 0
                 var lo: u64 = 0
-                mul64_full(a.limbs[i], b.limbs[j], &hi, &lo)
+                mul64_full(a.limbs[i], b.limbs[j], @hi, @lo)
 
                 # Add to result[k]
                 let sum1: u64 = result.limbs[k] + lo
@@ -389,9 +389,9 @@ pub fn bigint_mod_fast(result: *BigInt, a: *BigInt, n: *BigInt)
     # Shift n left
     var shifted_n: BigInt
     while shift >= 0
-        bigint_shl_to(&shifted_n, n, shift)
-        if bigint_ge(result, &shifted_n) == 1
-            bigint_sub(result, &shifted_n)
+        bigint_shl_to(@shifted_n, n, shift)
+        if bigint_ge(result, @shifted_n) == 1
+            bigint_sub(result, @shifted_n)
         shift -= 1
 
 # Left shift by bits positions
@@ -485,11 +485,11 @@ pub fn bigint_get_bit(a: *BigInt, pos: i32) -> i32
 # This is the core RSA operation: m = s^e mod n (signature verification)
 pub fn bigint_mod_exp(result: *BigInt, base: *BigInt, exp: *BigInt, n: *BigInt)
     var r: BigInt
-    bigint_one(&r)
+    bigint_one(@r)
 
     var b: BigInt
-    bigint_copy(&b, base)
-    bigint_mod_fast(&b, &b, n)
+    bigint_copy(@b, base)
+    bigint_mod_fast(@b, @b, n)
 
     let exp_bits: i32 = bigint_bit_length(exp)
 
@@ -497,21 +497,21 @@ pub fn bigint_mod_exp(result: *BigInt, base: *BigInt, exp: *BigInt, n: *BigInt)
     while i < exp_bits
         if bigint_get_bit(exp, i) == 1
             var tmp: BigInt
-            bigint_mul(&tmp, &r, &b)
-            bigint_mod_fast(&r, &tmp, n)
+            bigint_mul(@tmp, @r, @b)
+            bigint_mod_fast(@r, @tmp, n)
 
         # Square base
         var tmp2: BigInt
-        bigint_mul(&tmp2, &b, &b)
-        bigint_mod_fast(&b, &tmp2, n)
+        bigint_mul(@tmp2, @b, @b)
+        bigint_mod_fast(@b, @tmp2, n)
 
         i += 1
 
-    bigint_copy(result, &r)
+    bigint_copy(result, @r)
 
 # result = base^exp mod n, where exp is a small u32
 # Optimized for RSA public exponent (usually 65537)
 pub fn bigint_mod_exp_u32(result: *BigInt, base: *BigInt, exp: u32, n: *BigInt)
     var e: BigInt
-    bigint_from_u64(&e, exp as u64)
-    bigint_mod_exp(result, base, &e, n)
+    bigint_from_u64(@e, exp as u64)
+    bigint_mod_exp(result, base, @e, n)

--- a/projects/cryptosec/lib/ca_store.ritz
+++ b/projects/cryptosec/lib/ca_store.ritz
@@ -8,10 +8,10 @@
 #
 # Usage:
 #   var store: CaStore
-#   ca_store_init(&store)
-#   let loaded: i32 = ca_store_load_pem_file(&store, "/etc/ssl/certs/ca-certificates.crt")
+#   ca_store_init(@store)
+#   let loaded: i32 = ca_store_load_pem_file(@store, "/etc/ssl/certs/ca-certificates.crt")
 #   # ... use store for certificate verification ...
-#   ca_store_destroy(&store)
+#   ca_store_destroy(@store)
 #
 # References:
 #   - RFC 5280 (X.509 PKI)
@@ -163,24 +163,24 @@ pub fn ca_store_add_cert_pem(store: *CaStore, pem_data: *u8, pem_len: i64) -> i3
     var der_buf: [8192]u8
     var der_len: i64 = 0
 
-    let result: i32 = pem_parse_certificate(pem_data, pem_len, &der_buf[0], 8192, &der_len)
+    let result: i32 = pem_parse_certificate(pem_data, pem_len, @der_buf[0], 8192, @der_len)
     if result != 1
         return 0
 
-    return ca_store_add_cert_der(store, &der_buf[0], der_len)
+    return ca_store_add_cert_der(store, @der_buf[0], der_len)
 
 # Load certificates from PEM bundle data (multiple certificates)
 # Returns: number of certificates loaded (>= 0)
 pub fn ca_store_load_pem_bundle(store: *CaStore, pem_data: *u8, pem_len: i64) -> i32
     var iter: PemIterator
-    pem_iterator_init(&iter, pem_data, pem_len)
+    pem_iterator_init(@iter, pem_data, pem_len)
 
     var loaded: i32 = 0
     var entry: PemEntry
     var der_buf: [8192]u8
 
     while 1
-        let result: i32 = pem_iterator_next(&iter, &entry, &der_buf[0], 8192)
+        let result: i32 = pem_iterator_next(@iter, @entry, @der_buf[0], 8192)
         if result <= 0
             break
 
@@ -220,7 +220,7 @@ pub fn ca_store_load_pem_file(store: *CaStore, path: *u8, path_len: i32) -> i32
         i += 1
     path_buf[path_len] = 0
 
-    let fd: i32 = sys_open(&path_buf[0], 0)  # O_RDONLY
+    let fd: i32 = sys_open(@path_buf[0], 0)  # O_RDONLY
     if fd < 0
         return -1
 
@@ -273,7 +273,7 @@ pub fn ca_store_find_by_subject(store: *CaStore, subject: *X509Name) -> *X509Cer
     while i < store.cert_count
         let cert: *X509Certificate = store.certs[i]
         if cert != null
-            if x509_name_equals(&cert.subject, subject) == 1
+            if x509_name_equals(@cert.subject, subject) == 1
                 return cert
         i += 1
     return null
@@ -281,7 +281,7 @@ pub fn ca_store_find_by_subject(store: *CaStore, subject: *X509Name) -> *X509Cer
 # Check if a certificate is in the store (by subject match)
 # Returns: 1 if found, 0 if not
 pub fn ca_store_contains(store: *CaStore, cert: *X509Certificate) -> i32
-    let found: *X509Certificate = ca_store_find_by_subject(store, &cert.subject)
+    let found: *X509Certificate = ca_store_find_by_subject(store, @cert.subject)
     if found != null
         return 1
     return 0
@@ -299,4 +299,4 @@ pub fn ca_store_get(store: *CaStore, index: i32) -> *X509Certificate
 # Get the certificate array for x509_verify_chain
 # Returns: pointer to array of certificate pointers
 pub fn ca_store_as_array(store: *CaStore) -> **X509Certificate
-    return &store.certs[0]
+    return @store.certs[0]

--- a/projects/cryptosec/lib/chacha20.ritz
+++ b/projects/cryptosec/lib/chacha20.ritz
@@ -62,22 +62,22 @@ pub fn chacha20_block(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
     state[3] = SIGMA3
 
     # Key (8 words)
-    state[4] = load32_le(&key[0])
-    state[5] = load32_le(&key[4])
-    state[6] = load32_le(&key[8])
-    state[7] = load32_le(&key[12])
-    state[8] = load32_le(&key[16])
-    state[9] = load32_le(&key[20])
-    state[10] = load32_le(&key[24])
-    state[11] = load32_le(&key[28])
+    state[4] = load32_le(@key[0])
+    state[5] = load32_le(@key[4])
+    state[6] = load32_le(@key[8])
+    state[7] = load32_le(@key[12])
+    state[8] = load32_le(@key[16])
+    state[9] = load32_le(@key[20])
+    state[10] = load32_le(@key[24])
+    state[11] = load32_le(@key[28])
 
     # Counter (1 word)
     state[12] = counter
 
     # Nonce (3 words)
-    state[13] = load32_le(&nonce[0])
-    state[14] = load32_le(&nonce[4])
-    state[15] = load32_le(&nonce[8])
+    state[13] = load32_le(@nonce[0])
+    state[14] = load32_le(@nonce[4])
+    state[15] = load32_le(@nonce[8])
 
     # Copy to working state
     var i: i64 = 0
@@ -89,16 +89,16 @@ pub fn chacha20_block(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
     i = 0
     while i < 10
         # Column rounds
-        quarter_round(&working[0], 0, 4, 8, 12)
-        quarter_round(&working[0], 1, 5, 9, 13)
-        quarter_round(&working[0], 2, 6, 10, 14)
-        quarter_round(&working[0], 3, 7, 11, 15)
+        quarter_round(@working[0], 0, 4, 8, 12)
+        quarter_round(@working[0], 1, 5, 9, 13)
+        quarter_round(@working[0], 2, 6, 10, 14)
+        quarter_round(@working[0], 3, 7, 11, 15)
 
         # Diagonal rounds
-        quarter_round(&working[0], 0, 5, 10, 15)
-        quarter_round(&working[0], 1, 6, 11, 12)
-        quarter_round(&working[0], 2, 7, 8, 13)
-        quarter_round(&working[0], 3, 4, 9, 14)
+        quarter_round(@working[0], 0, 5, 10, 15)
+        quarter_round(@working[0], 1, 6, 11, 12)
+        quarter_round(@working[0], 2, 7, 8, 13)
+        quarter_round(@working[0], 3, 4, 9, 14)
 
         i += 1
 
@@ -111,7 +111,7 @@ pub fn chacha20_block(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
     # Serialize to output
     i = 0
     while i < 16
-        store32_le(&out[i * 4], working[i])
+        store32_le(@out[i * 4], working[i])
         i += 1
 
 # =============================================================================
@@ -124,8 +124,8 @@ struct ChaCha20
     counter: u32
 
 pub fn chacha20_init(ctx: *ChaCha20, key: *u8, nonce: *u8) -> void
-    mem_copy(&ctx.key[0], key, 32)
-    mem_copy(&ctx.nonce[0], nonce, 12)
+    mem_copy(@ctx.key[0], key, 32)
+    mem_copy(@ctx.nonce[0], nonce, 12)
     ctx.counter = 0
 
 pub fn chacha20_set_counter(ctx: *ChaCha20, counter: u32) -> void
@@ -137,7 +137,7 @@ pub fn chacha20_encrypt(ctx: *ChaCha20, pt: *u8, pt_len: i64, ct: *u8) -> void
 
     while i < pt_len
         # Generate keystream block
-        chacha20_block(&ctx.key[0], ctx.counter, &ctx.nonce[0], &block[0])
+        chacha20_block(@ctx.key[0], ctx.counter, @ctx.nonce[0], @block[0])
         ctx.counter = ctx.counter + 1
 
         # XOR with plaintext
@@ -162,7 +162,7 @@ pub fn chacha20_xor(key: *u8, nonce: *u8, counter: u32, input: *u8, len: i64, ou
     var i: i64 = 0
 
     while i < len
-        chacha20_block(key, ctr, nonce, &block[0])
+        chacha20_block(key, ctr, nonce, @block[0])
         ctr += 1
 
         var j: i64 = 0

--- a/projects/cryptosec/lib/chacha20_avx2.ritz
+++ b/projects/cryptosec/lib/chacha20_avx2.ritz
@@ -83,35 +83,35 @@ fn qr_columns(row0: *v4i32, row1: *v4i32, row2: *v4i32, row3: *v4i32) -> void
 fn rotate_elements_1(v: v4i32) -> v4i32
     # Rotate left by 1 element: [b, c, d, a]
     var arr: [4]i32
-    simd_storeu(&arr[0], v)
+    simd_storeu(@arr[0], v)
     var tmp: [4]i32
     tmp[0] = arr[1]
     tmp[1] = arr[2]
     tmp[2] = arr[3]
     tmp[3] = arr[0]
-    simd_loadu(&tmp[0])
+    simd_loadu(@tmp[0])
 
 fn rotate_elements_2(v: v4i32) -> v4i32
     # Rotate left by 2 elements: [c, d, a, b]
     var arr: [4]i32
-    simd_storeu(&arr[0], v)
+    simd_storeu(@arr[0], v)
     var tmp: [4]i32
     tmp[0] = arr[2]
     tmp[1] = arr[3]
     tmp[2] = arr[0]
     tmp[3] = arr[1]
-    simd_loadu(&tmp[0])
+    simd_loadu(@tmp[0])
 
 fn rotate_elements_3(v: v4i32) -> v4i32
     # Rotate left by 3 elements: [d, a, b, c]
     var arr: [4]i32
-    simd_storeu(&arr[0], v)
+    simd_storeu(@arr[0], v)
     var tmp: [4]i32
     tmp[0] = arr[3]
     tmp[1] = arr[0]
     tmp[2] = arr[1]
     tmp[3] = arr[2]
-    simd_loadu(&tmp[0])
+    simd_loadu(@tmp[0])
 
 # ChaCha20 block function - AVX2 vectorized
 # Generates 64 bytes of keystream
@@ -129,28 +129,28 @@ pub fn chacha20_block_avx2(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
     row0_init[3] = SIGMA3_AVX2
 
     # Row 1: Key[0..15]
-    row1_init[0] = avx2_load32_le(&key[0])
-    row1_init[1] = avx2_load32_le(&key[4])
-    row1_init[2] = avx2_load32_le(&key[8])
-    row1_init[3] = avx2_load32_le(&key[12])
+    row1_init[0] = avx2_load32_le(@key[0])
+    row1_init[1] = avx2_load32_le(@key[4])
+    row1_init[2] = avx2_load32_le(@key[8])
+    row1_init[3] = avx2_load32_le(@key[12])
 
     # Row 2: Key[16..31]
-    row2_init[0] = avx2_load32_le(&key[16])
-    row2_init[1] = avx2_load32_le(&key[20])
-    row2_init[2] = avx2_load32_le(&key[24])
-    row2_init[3] = avx2_load32_le(&key[28])
+    row2_init[0] = avx2_load32_le(@key[16])
+    row2_init[1] = avx2_load32_le(@key[20])
+    row2_init[2] = avx2_load32_le(@key[24])
+    row2_init[3] = avx2_load32_le(@key[28])
 
     # Row 3: Counter + Nonce
     row3_init[0] = counter as i32
-    row3_init[1] = avx2_load32_le(&nonce[0])
-    row3_init[2] = avx2_load32_le(&nonce[4])
-    row3_init[3] = avx2_load32_le(&nonce[8])
+    row3_init[1] = avx2_load32_le(@nonce[0])
+    row3_init[2] = avx2_load32_le(@nonce[4])
+    row3_init[3] = avx2_load32_le(@nonce[8])
 
     # Load into SIMD vectors
-    let init0: v4i32 = simd_loadu(&row0_init[0])
-    let init1: v4i32 = simd_loadu(&row1_init[0])
-    let init2: v4i32 = simd_loadu(&row2_init[0])
-    let init3: v4i32 = simd_loadu(&row3_init[0])
+    let init0: v4i32 = simd_loadu(@row0_init[0])
+    let init1: v4i32 = simd_loadu(@row1_init[0])
+    let init2: v4i32 = simd_loadu(@row2_init[0])
+    let init3: v4i32 = simd_loadu(@row3_init[0])
 
     # Working state
     var row0: v4i32 = init0
@@ -163,7 +163,7 @@ pub fn chacha20_block_avx2(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
     while i < 10
         # Column round: operates on columns (0,4,8,12), (1,5,9,13), etc.
         # With row layout, this is just parallel operation on row elements
-        qr_columns(&row0, &row1, &row2, &row3)
+        qr_columns(@row0, @row1, @row2, @row3)
 
         # Diagonal round preparation:
         # Rotate row1 left by 1, row2 left by 2, row3 left by 3
@@ -173,7 +173,7 @@ pub fn chacha20_block_avx2(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
         row3 = rotate_elements_3(row3)
 
         # Diagonal round (now aligned as columns)
-        qr_columns(&row0, &row1, &row2, &row3)
+        qr_columns(@row0, @row1, @row2, @row3)
 
         # Undo the rotations to restore column layout
         row1 = rotate_elements_3(row1)  # rotate right by 1 = rotate left by 3
@@ -190,14 +190,14 @@ pub fn chacha20_block_avx2(key: *u8, counter: u32, nonce: *u8, out: *u8) -> void
 
     # Store to output (serialize to little-endian)
     var state_out: [16]i32
-    simd_storeu(&state_out[0], row0)
-    simd_storeu(&state_out[4], row1)
-    simd_storeu(&state_out[8], row2)
-    simd_storeu(&state_out[12], row3)
+    simd_storeu(@state_out[0], row0)
+    simd_storeu(@state_out[4], row1)
+    simd_storeu(@state_out[8], row2)
+    simd_storeu(@state_out[12], row3)
 
     i = 0
     while i < 16
-        avx2_store32_le(&out[i * 4], state_out[i])
+        avx2_store32_le(@out[i * 4], state_out[i])
         i += 1
 
 # =============================================================================
@@ -210,8 +210,8 @@ struct ChaCha20Avx2
     counter: u32
 
 pub fn chacha20_avx2_init(ctx: *ChaCha20Avx2, key: *u8, nonce: *u8) -> void
-    mem_copy(&ctx.key[0], key, 32)
-    mem_copy(&ctx.nonce[0], nonce, 12)
+    mem_copy(@ctx.key[0], key, 32)
+    mem_copy(@ctx.nonce[0], nonce, 12)
     ctx.counter = 0
 
 pub fn chacha20_avx2_set_counter(ctx: *ChaCha20Avx2, counter: u32) -> void
@@ -223,7 +223,7 @@ pub fn chacha20_avx2_encrypt(ctx: *ChaCha20Avx2, pt: *u8, pt_len: i64, ct: *u8) 
 
     while i < pt_len
         # Generate keystream block using AVX2
-        chacha20_block_avx2(&ctx.key[0], ctx.counter, &ctx.nonce[0], &block[0])
+        chacha20_block_avx2(@ctx.key[0], ctx.counter, @ctx.nonce[0], @block[0])
         ctx.counter = ctx.counter + 1
 
         # XOR with plaintext
@@ -248,7 +248,7 @@ pub fn chacha20_avx2_xor(key: *u8, nonce: *u8, counter: u32, input: *u8, len: i6
     var i: i64 = 0
 
     while i < len
-        chacha20_block_avx2(key, ctr, nonce, &block[0])
+        chacha20_block_avx2(key, ctr, nonce, @block[0])
         ctr += 1
 
         var j: i64 = 0

--- a/projects/cryptosec/lib/chacha20_poly1305.ritz
+++ b/projects/cryptosec/lib/chacha20_poly1305.ritz
@@ -45,45 +45,45 @@ pub fn chacha20_poly1305_encrypt(key: *u8, nonce: *u8, aad: *u8, aad_len: i64, p
     var poly_key: [64]u8
 
     # Generate Poly1305 one-time key (first 32 bytes of ChaCha20 block 0)
-    chacha20_block(key, 0, nonce, &poly_key[0])
+    chacha20_block(key, 0, nonce, @poly_key[0])
 
     # Encrypt plaintext starting at counter=1
     chacha20_xor(key, nonce, 1, pt, pt_len, ct)
 
     # Compute Poly1305 tag
     var poly_ctx: Poly1305
-    poly1305_init(&poly_ctx, &poly_key[0])
+    poly1305_init(@poly_ctx, @poly_key[0])
 
     # Process AAD
     if aad_len > 0
-        poly1305_update(&poly_ctx, aad, aad_len)
+        poly1305_update(@poly_ctx, aad, aad_len)
 
     # Pad AAD to 16-byte boundary
     var pad_aad: i64 = pad16_len(aad_len)
     if pad_aad > 0
         var zeros: [16]u8
-        mem_zero(&zeros[0], 16)
-        poly1305_update(&poly_ctx, &zeros[0], pad_aad)
+        mem_zero(@zeros[0], 16)
+        poly1305_update(@poly_ctx, @zeros[0], pad_aad)
 
     # Process ciphertext
     if pt_len > 0
-        poly1305_update(&poly_ctx, ct, pt_len)
+        poly1305_update(@poly_ctx, ct, pt_len)
 
     # Pad ciphertext to 16-byte boundary
     var pad_ct: i64 = pad16_len(pt_len)
     if pad_ct > 0
         var zeros: [16]u8
-        mem_zero(&zeros[0], 16)
-        poly1305_update(&poly_ctx, &zeros[0], pad_ct)
+        mem_zero(@zeros[0], 16)
+        poly1305_update(@poly_ctx, @zeros[0], pad_ct)
 
     # Add lengths as 64-bit little-endian
     var lens: [16]u8
-    store64_le(&lens[0], aad_len as u64)
-    store64_le(&lens[8], pt_len as u64)
-    poly1305_update(&poly_ctx, &lens[0], 16)
+    store64_le(@lens[0], aad_len as u64)
+    store64_le(@lens[8], pt_len as u64)
+    poly1305_update(@poly_ctx, @lens[0], 16)
 
     # Finalize tag
-    poly1305_final(&poly_ctx, tag)
+    poly1305_final(@poly_ctx, tag)
 
     pt_len
 
@@ -92,41 +92,41 @@ pub fn chacha20_poly1305_decrypt(key: *u8, nonce: *u8, aad: *u8, aad_len: i64, c
     var computed_tag: [16]u8
 
     # Generate Poly1305 one-time key
-    chacha20_block(key, 0, nonce, &poly_key[0])
+    chacha20_block(key, 0, nonce, @poly_key[0])
 
     # Verify tag first
     var poly_ctx: Poly1305
-    poly1305_init(&poly_ctx, &poly_key[0])
+    poly1305_init(@poly_ctx, @poly_key[0])
 
     # Process AAD
     if aad_len > 0
-        poly1305_update(&poly_ctx, aad, aad_len)
+        poly1305_update(@poly_ctx, aad, aad_len)
 
     var pad_aad: i64 = pad16_len(aad_len)
     if pad_aad > 0
         var zeros: [16]u8
-        mem_zero(&zeros[0], 16)
-        poly1305_update(&poly_ctx, &zeros[0], pad_aad)
+        mem_zero(@zeros[0], 16)
+        poly1305_update(@poly_ctx, @zeros[0], pad_aad)
 
     # Process ciphertext
     if ct_len > 0
-        poly1305_update(&poly_ctx, ct, ct_len)
+        poly1305_update(@poly_ctx, ct, ct_len)
 
     var pad_ct: i64 = pad16_len(ct_len)
     if pad_ct > 0
         var zeros: [16]u8
-        mem_zero(&zeros[0], 16)
-        poly1305_update(&poly_ctx, &zeros[0], pad_ct)
+        mem_zero(@zeros[0], 16)
+        poly1305_update(@poly_ctx, @zeros[0], pad_ct)
 
     var lens: [16]u8
-    store64_le(&lens[0], aad_len as u64)
-    store64_le(&lens[8], ct_len as u64)
-    poly1305_update(&poly_ctx, &lens[0], 16)
+    store64_le(@lens[0], aad_len as u64)
+    store64_le(@lens[8], ct_len as u64)
+    poly1305_update(@poly_ctx, @lens[0], 16)
 
-    poly1305_final(&poly_ctx, &computed_tag[0])
+    poly1305_final(@poly_ctx, @computed_tag[0])
 
     # Constant-time tag comparison
-    if mem_eq(&computed_tag[0], tag, 16) == 0
+    if mem_eq(@computed_tag[0], tag, 16) == 0
         return 0
 
     # Decrypt ciphertext

--- a/projects/cryptosec/lib/cpuid.ritz
+++ b/projects/cryptosec/lib/cpuid.ritz
@@ -83,12 +83,12 @@ fn cpuid_init()
     var edx: i32 = 0
 
     # First check maximum supported CPUID leaf
-    cpuid_raw(CPUID_VENDOR, 0, &eax, &ebx, &ecx, &edx)
+    cpuid_raw(CPUID_VENDOR, 0, @eax, @ebx, @ecx, @edx)
     let max_leaf: i32 = eax
 
     # Leaf 1: Basic features (AES-NI, AVX, PCLMULQDQ, OSXSAVE)
     if max_leaf >= 1
-        cpuid_raw(CPUID_FEATURES, 0, &eax, &ebx, &ecx, &edx)
+        cpuid_raw(CPUID_FEATURES, 0, @eax, @ebx, @ecx, @edx)
 
         # AES-NI: ECX bit 25
         if (ecx >> CPUID_ECX_AES) & 1 == 1
@@ -108,7 +108,7 @@ fn cpuid_init()
 
     # Leaf 7: Extended features (AVX2, SHA-NI, AVX-512F)
     if max_leaf >= 7
-        cpuid_raw(CPUID_EXT_FEATURES, 0, &eax, &ebx, &ecx, &edx)
+        cpuid_raw(CPUID_EXT_FEATURES, 0, @eax, @ebx, @ecx, @edx)
 
         # AVX2: EBX bit 5
         if (ebx >> CPUID_EBX_AVX2) & 1 == 1

--- a/projects/cryptosec/lib/ed25519.ritz
+++ b/projects/cryptosec/lib/ed25519.ritz
@@ -72,33 +72,33 @@ struct Ge25519
 
 pub fn ge_zero(p: *Ge25519)
     # Neutral element: (0, 1) = (X=0, Y=1, Z=1, T=0)
-    fe_zero(&p.X)
-    fe_one(&p.Y)
-    fe_one(&p.Z)
-    fe_zero(&p.T)
+    fe_zero(@p.X)
+    fe_one(@p.Y)
+    fe_one(@p.Z)
+    fe_zero(@p.T)
 
 fn ge_copy(out: *Ge25519, p: *Ge25519)
-    fe_copy(&out.X, &p.X)
-    fe_copy(&out.Y, &p.Y)
-    fe_copy(&out.Z, &p.Z)
-    fe_copy(&out.T, &p.T)
+    fe_copy(@out.X, @p.X)
+    fe_copy(@out.Y, @p.Y)
+    fe_copy(@out.Z, @p.Z)
+    fe_copy(@out.T, @p.T)
 
 # Point negation: -(x, y) = (-x, y)
 pub fn ge_neg(out: *Ge25519, p: *Ge25519)
     var zero: Fe25519
-    fe_zero(&zero)
-    fe_sub(&out.X, &zero, &p.X)
-    fe_copy(&out.Y, &p.Y)
-    fe_copy(&out.Z, &p.Z)
+    fe_zero(@zero)
+    fe_sub(@out.X, @zero, @p.X)
+    fe_copy(@out.Y, @p.Y)
+    fe_copy(@out.Z, @p.Z)
     var t_zero: Fe25519
-    fe_zero(&t_zero)
-    fe_sub(&out.T, &t_zero, &p.T)
+    fe_zero(@t_zero)
+    fe_sub(@out.T, @t_zero, @p.T)
 
 # Point addition using extended coordinates
 # Formula from https://hyperelliptic.org/EFD/g1p/auto-twisted-extended.html
 pub fn ge_add(r: *Ge25519, p: *Ge25519, q: *Ge25519)
     var d_const: Fe25519
-    fe_2d(&d_const)  # Use 2d for the formula
+    fe_2d(@d_const)  # Use 2d for the formula
 
     var A: Fe25519
     var B: Fe25519
@@ -112,46 +112,46 @@ pub fn ge_add(r: *Ge25519, p: *Ge25519, q: *Ge25519)
     # A = (Y1-X1)*(Y2-X2)
     var t1: Fe25519
     var t2: Fe25519
-    fe_sub(&t1, &p.Y, &p.X)
-    fe_sub(&t2, &q.Y, &q.X)
-    fe_mul(&A, &t1, &t2)
+    fe_sub(@t1, @p.Y, @p.X)
+    fe_sub(@t2, @q.Y, @q.X)
+    fe_mul(@A, @t1, @t2)
 
     # B = (Y1+X1)*(Y2+X2)
-    fe_add(&t1, &p.Y, &p.X)
-    fe_add(&t2, &q.Y, &q.X)
-    fe_mul(&B, &t1, &t2)
+    fe_add(@t1, @p.Y, @p.X)
+    fe_add(@t2, @q.Y, @q.X)
+    fe_mul(@B, @t1, @t2)
 
     # C = T1*2d*T2
-    fe_mul(&t1, &p.T, &d_const)
-    fe_mul(&C, &t1, &q.T)
+    fe_mul(@t1, @p.T, @d_const)
+    fe_mul(@C, @t1, @q.T)
 
     # D = Z1*2*Z2
-    fe_mul(&t1, &p.Z, &q.Z)
-    fe_add(&D, &t1, &t1)
+    fe_mul(@t1, @p.Z, @q.Z)
+    fe_add(@D, @t1, @t1)
 
     # E = B-A
-    fe_sub(&E, &B, &A)
+    fe_sub(@E, @B, @A)
 
     # F = D-C
-    fe_sub(&F, &D, &C)
+    fe_sub(@F, @D, @C)
 
     # G = D+C
-    fe_add(&G, &D, &C)
+    fe_add(@G, @D, @C)
 
     # H = B+A
-    fe_add(&H, &B, &A)
+    fe_add(@H, @B, @A)
 
     # X3 = E*F
-    fe_mul(&r.X, &E, &F)
+    fe_mul(@r.X, @E, @F)
 
     # Y3 = G*H
-    fe_mul(&r.Y, &G, &H)
+    fe_mul(@r.Y, @G, @H)
 
     # T3 = E*H
-    fe_mul(&r.T, &E, &H)
+    fe_mul(@r.T, @E, @H)
 
     # Z3 = F*G
-    fe_mul(&r.Z, &F, &G)
+    fe_mul(@r.Z, @F, @G)
 
 # Point doubling using extended coordinates
 pub fn ge_double(r: *Ge25519, p: *Ge25519)
@@ -165,47 +165,47 @@ pub fn ge_double(r: *Ge25519, p: *Ge25519)
     var H: Fe25519
 
     # A = X1^2
-    fe_sq(&A, &p.X)
+    fe_sq(@A, @p.X)
 
     # B = Y1^2
-    fe_sq(&B, &p.Y)
+    fe_sq(@B, @p.Y)
 
     # C = 2*Z1^2
-    fe_sq(&C, &p.Z)
-    fe_add(&C, &C, &C)
+    fe_sq(@C, @p.Z)
+    fe_add(@C, @C, @C)
 
     # D = -A (for twisted Edwards with a=-1)
     var zero: Fe25519
-    fe_zero(&zero)
-    fe_sub(&D, &zero, &A)
+    fe_zero(@zero)
+    fe_sub(@D, @zero, @A)
 
     # E = (X1+Y1)^2 - A - B
     var t: Fe25519
-    fe_add(&t, &p.X, &p.Y)
-    fe_sq(&E, &t)
-    fe_sub(&E, &E, &A)
-    fe_sub(&E, &E, &B)
+    fe_add(@t, @p.X, @p.Y)
+    fe_sq(@E, @t)
+    fe_sub(@E, @E, @A)
+    fe_sub(@E, @E, @B)
 
     # G = D+B
-    fe_add(&G, &D, &B)
+    fe_add(@G, @D, @B)
 
     # F = G-C
-    fe_sub(&F, &G, &C)
+    fe_sub(@F, @G, @C)
 
     # H = D-B
-    fe_sub(&H, &D, &B)
+    fe_sub(@H, @D, @B)
 
     # X3 = E*F
-    fe_mul(&r.X, &E, &F)
+    fe_mul(@r.X, @E, @F)
 
     # Y3 = G*H
-    fe_mul(&r.Y, &G, &H)
+    fe_mul(@r.Y, @G, @H)
 
     # T3 = E*H
-    fe_mul(&r.T, &E, &H)
+    fe_mul(@r.T, @E, @H)
 
     # Z3 = F*G
-    fe_mul(&r.Z, &F, &G)
+    fe_mul(@r.Z, @F, @G)
 
 # ============================================================================
 # Scalar multiplication
@@ -227,8 +227,8 @@ pub fn ge_scalarmult(r: *Ge25519, s: *u8, p: *Ge25519)
 
         if bit == 1
             var t: Ge25519
-            ge_add(&t, r, p)
-            ge_copy(r, &t)
+            ge_add(@t, r, p)
+            ge_copy(r, @t)
 
         i -= 1
 
@@ -256,16 +256,16 @@ pub fn ge_basepoint(B: *Ge25519)
     B.Y.l4 = 1801439850948198
 
     # Z = 1
-    fe_one(&B.Z)
+    fe_one(@B.Z)
 
     # T = X*Y
-    fe_mul(&B.T, &B.X, &B.Y)
+    fe_mul(@B.T, @B.X, @B.Y)
 
 # Base point scalar multiplication
 pub fn ge_scalarmult_base(r: *Ge25519, s: *u8)
     var B: Ge25519
-    ge_basepoint(&B)
-    ge_scalarmult(r, s, &B)
+    ge_basepoint(@B)
+    ge_scalarmult(r, s, @B)
 
 # ============================================================================
 # Point encoding/decoding (RFC 8032)
@@ -275,17 +275,17 @@ pub fn ge_scalarmult_base(r: *Ge25519, s: *u8)
 # Encoding: y-coordinate with sign bit of x in MSB
 pub fn ge_tobytes(out: *u8, p: *Ge25519)
     var z_inv: Fe25519
-    fe_invert(&z_inv, &p.Z)
+    fe_invert(@z_inv, @p.Z)
 
     var x: Fe25519
     var y: Fe25519
-    fe_mul(&x, &p.X, &z_inv)
-    fe_mul(&y, &p.Y, &z_inv)
+    fe_mul(@x, @p.X, @z_inv)
+    fe_mul(@y, @p.Y, @z_inv)
 
-    fe_reduce(&x)
-    fe_reduce(&y)
+    fe_reduce(@x)
+    fe_reduce(@y)
 
-    fe_tobytes(out, &y)
+    fe_tobytes(out, @y)
 
     # Set sign bit: out[31] |= (x.l0 & 1) << 7
     let x_sign: u8 = (x.l0 & 1) as u8
@@ -294,7 +294,7 @@ pub fn ge_tobytes(out: *u8, p: *Ge25519)
 # Check if field element is negative (LSB == 1)
 fn fe_isnegative(f: *Fe25519) -> i32
     var bytes: [32]u8
-    fe_tobytes(&bytes[0], f)
+    fe_tobytes(@bytes[0], f)
     return (bytes[0] & 1) as i32
 
 # Square root mod p (if it exists)
@@ -310,75 +310,75 @@ pub fn fe_sqrt(out: *Fe25519, a: *Fe25519) -> i32
     # But stop at 2^252 - 2 instead of p-2 = 2^255 - 21
 
     var t0: Fe25519  # a^1
-    fe_copy(&t0, a)
+    fe_copy(@t0, a)
 
     var t1: Fe25519
-    fe_sq(&t1, &t0)  # a^2
+    fe_sq(@t1, @t0)  # a^2
 
     var t2: Fe25519
-    fe_sq(&t2, &t1)  # a^4
-    fe_sq(&t2, &t2)  # a^8
-    fe_mul(&t2, &t2, &t0)  # a^9
+    fe_sq(@t2, @t1)  # a^4
+    fe_sq(@t2, @t2)  # a^8
+    fe_mul(@t2, @t2, @t0)  # a^9
 
-    fe_mul(&t1, &t1, &t2)  # a^11
+    fe_mul(@t1, @t1, @t2)  # a^11
 
     var t3: Fe25519
-    fe_sq(&t3, &t1)  # a^22
-    fe_mul(&t2, &t2, &t3)  # a^31 = 2^5 - 1
+    fe_sq(@t3, @t1)  # a^22
+    fe_mul(@t2, @t2, @t3)  # a^31 = 2^5 - 1
 
-    fe_sq(&t3, &t2)  # (2^5-1) * 2
+    fe_sq(@t3, @t2)  # (2^5-1) * 2
     var i: i32 = 0
     while i < 4
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
     # Now t3 = a^(31 * 32) = a^(2^10 - 32)
-    fe_mul(&t2, &t3, &t2)  # a^(2^10 - 1)
+    fe_mul(@t2, @t3, @t2)  # a^(2^10 - 1)
 
-    fe_sq(&t3, &t2)
+    fe_sq(@t3, @t2)
     i = 0
     while i < 9
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
     # t3 = a^((2^10-1) * 2^10) = a^(2^20 - 2^10)
-    fe_mul(&t3, &t3, &t2)  # a^(2^20 - 1)
+    fe_mul(@t3, @t3, @t2)  # a^(2^20 - 1)
 
     var t4: Fe25519
-    fe_sq(&t4, &t3)
+    fe_sq(@t4, @t3)
     i = 0
     while i < 19
-        fe_sq(&t4, &t4)
+        fe_sq(@t4, @t4)
         i += 1
     # t4 = a^((2^20-1) * 2^20)
-    fe_mul(&t3, &t4, &t3)  # a^(2^40 - 1)
+    fe_mul(@t3, @t4, @t3)  # a^(2^40 - 1)
 
-    fe_sq(&t3, &t3)
+    fe_sq(@t3, @t3)
     i = 0
     while i < 9
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
     # t3 = a^((2^40-1) * 2^10)
-    fe_mul(&t2, &t3, &t2)  # a^(2^50 - 1)
+    fe_mul(@t2, @t3, @t2)  # a^(2^50 - 1)
 
-    fe_sq(&t3, &t2)
+    fe_sq(@t3, @t2)
     i = 0
     while i < 49
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
-    fe_mul(&t3, &t3, &t2)  # a^(2^100 - 1)
+    fe_mul(@t3, @t3, @t2)  # a^(2^100 - 1)
 
-    fe_sq(&t4, &t3)
+    fe_sq(@t4, @t3)
     i = 0
     while i < 99
-        fe_sq(&t4, &t4)
+        fe_sq(@t4, @t4)
         i += 1
-    fe_mul(&t3, &t4, &t3)  # a^(2^200 - 1)
+    fe_mul(@t3, @t4, @t3)  # a^(2^200 - 1)
 
-    fe_sq(&t3, &t3)
+    fe_sq(@t3, @t3)
     i = 0
     while i < 49
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
-    fe_mul(&t2, &t3, &t2)  # a^(2^250 - 1)
+    fe_mul(@t2, @t3, @t2)  # a^(2^250 - 1)
 
     # t2 = a^(2^250 - 1)
     # t1 = a^2 (since we updated it at line 306)
@@ -388,22 +388,22 @@ pub fn fe_sqrt(out: *Fe25519, a: *Fe25519) -> i32
     # So a^(2^252 - 2) = (a^(2^250-1))^4 * a^2
 
     var t1_save: Fe25519
-    fe_sq(&t1_save, &t0)  # a^2 (recalculate since t1 was clobbered)
+    fe_sq(@t1_save, @t0)  # a^2 (recalculate since t1 was clobbered)
 
-    fe_sq(&t2, &t2)  # a^(2*(2^250-1)) = a^(2^251 - 2)
-    fe_sq(&t2, &t2)  # a^(2^252 - 4)
-    fe_mul(&t2, &t2, &t1_save)  # a^(2^252 - 4 + 2) = a^(2^252 - 2)
+    fe_sq(@t2, @t2)  # a^(2*(2^250-1)) = a^(2^251 - 2)
+    fe_sq(@t2, @t2)  # a^(2^252 - 4)
+    fe_mul(@t2, @t2, @t1_save)  # a^(2^252 - 4 + 2) = a^(2^252 - 2)
 
     # t2 is now the candidate sqrt = a^((p+3)/8)
 
     # Verify: check if t2^2 == a
     var check: Fe25519
-    fe_sq(&check, &t2)
-    fe_reduce(&check)
+    fe_sq(@check, @t2)
+    fe_reduce(@check)
 
     var a_r: Fe25519
-    fe_copy(&a_r, a)
-    fe_reduce(&a_r)
+    fe_copy(@a_r, a)
+    fe_reduce(@a_r)
 
     # Compare
     if check.l0 == a_r.l0
@@ -411,23 +411,23 @@ pub fn fe_sqrt(out: *Fe25519, a: *Fe25519) -> i32
             if check.l2 == a_r.l2
                 if check.l3 == a_r.l3
                     if check.l4 == a_r.l4
-                        fe_copy(out, &t2)
+                        fe_copy(out, @t2)
                         return 0
 
     # Try sqrt(-1) * t2 (for case where -a is a QR)
     var sqrtm1: Fe25519
-    fe_sqrtm1(&sqrtm1)
-    fe_mul(&t2, &t2, &sqrtm1)
+    fe_sqrtm1(@sqrtm1)
+    fe_mul(@t2, @t2, @sqrtm1)
 
-    fe_sq(&check, &t2)
-    fe_reduce(&check)
+    fe_sq(@check, @t2)
+    fe_reduce(@check)
 
     if check.l0 == a_r.l0
         if check.l1 == a_r.l1
             if check.l2 == a_r.l2
                 if check.l3 == a_r.l3
                     if check.l4 == a_r.l4
-                        fe_copy(out, &t2)
+                        fe_copy(out, @t2)
                         return 0
 
     # No square root exists
@@ -437,55 +437,55 @@ pub fn fe_sqrt(out: *Fe25519, a: *Fe25519) -> i32
 pub fn ge_frombytes(p: *Ge25519, bytes: *u8) -> i32
     # Extract y coordinate (clear sign bit)
     var y_bytes: [32]u8
-    mem_copy(&y_bytes[0], bytes, 32)
+    mem_copy(@y_bytes[0], bytes, 32)
     let x_sign: i32 = ((y_bytes[31] >> 7) & 1) as i32
     y_bytes[31] = y_bytes[31] & 0x7f
 
     var y: Fe25519
-    fe_frombytes(&y, &y_bytes[0])
+    fe_frombytes(@y, @y_bytes[0])
 
     # Compute x from curve equation: x^2 = (y^2 - 1) / (d*y^2 + 1)
     var y2: Fe25519
-    fe_sq(&y2, &y)
+    fe_sq(@y2, @y)
 
     # u = y^2 - 1
     var one: Fe25519
-    fe_one(&one)
+    fe_one(@one)
     var u: Fe25519
-    fe_sub(&u, &y2, &one)
+    fe_sub(@u, @y2, @one)
 
     # v = d*y^2 + 1
     var d_const: Fe25519
-    fe_d(&d_const)
+    fe_d(@d_const)
     var v: Fe25519
-    fe_mul(&v, &d_const, &y2)
-    fe_add(&v, &v, &one)
+    fe_mul(@v, @d_const, @y2)
+    fe_add(@v, @v, @one)
 
     # x^2 = u * v^(-1)
     var v_inv: Fe25519
-    fe_invert(&v_inv, &v)
+    fe_invert(@v_inv, @v)
     var x2: Fe25519
-    fe_mul(&x2, &u, &v_inv)
+    fe_mul(@x2, @u, @v_inv)
 
     # x = sqrt(x^2)
     var x: Fe25519
-    let sqrt_ok: i32 = fe_sqrt(&x, &x2)
+    let sqrt_ok: i32 = fe_sqrt(@x, @x2)
     if sqrt_ok != 0
         return -1
 
     # Adjust sign of x
-    fe_reduce(&x)
+    fe_reduce(@x)
     let computed_sign: i32 = (x.l0 & 1) as i32
     if computed_sign != x_sign
         var zero: Fe25519
-        fe_zero(&zero)
-        fe_sub(&x, &zero, &x)
+        fe_zero(@zero)
+        fe_sub(@x, @zero, @x)
 
     # Set point coordinates
-    fe_copy(&p.X, &x)
-    fe_copy(&p.Y, &y)
-    fe_one(&p.Z)
-    fe_mul(&p.T, &x, &y)
+    fe_copy(@p.X, @x)
+    fe_copy(@p.Y, @y)
+    fe_one(@p.Z)
+    fe_mul(@p.T, @x, @y)
 
     return 0
 
@@ -643,7 +643,7 @@ pub fn ed25519_keygen(pubkey: *u8, privkey: *u8, seed: *u8)
 
     # Hash the seed - sha512(data, len, out)
     var hash: [64]u8
-    sha512(seed, 32, &hash[0])
+    sha512(seed, 32, @hash[0])
 
     # Clamp the first 32 bytes (RFC 8032 Section 5.1.5)
     # Clear lowest 3 bits of first byte
@@ -654,14 +654,14 @@ pub fn ed25519_keygen(pubkey: *u8, privkey: *u8, seed: *u8)
 
     # Public key = hash[0:32] * B
     var A: Ge25519
-    ge_scalarmult_base(&A, &hash[0])
-    ge_tobytes(pubkey, &A)
+    ge_scalarmult_base(@A, @hash[0])
+    ge_tobytes(pubkey, @A)
 
 # Sign a message
 pub fn ed25519_sign(sig: *u8, msg: *u8, msg_len: u64, privkey: *u8)
     # Hash the private key - sha512(data, len, out)
     var hash: [64]u8
-    sha512(privkey, 32, &hash[0])
+    sha512(privkey, 32, @hash[0])
 
     # Clamp scalar a (RFC 8032 Section 5.1.5)
     hash[0] = hash[0] & 0xf8
@@ -670,9 +670,9 @@ pub fn ed25519_sign(sig: *u8, msg: *u8, msg_len: u64, privkey: *u8)
 
     # Compute public key A
     var A: Ge25519
-    ge_scalarmult_base(&A, &hash[0])
+    ge_scalarmult_base(@A, @hash[0])
     var pubkey: [32]u8
-    ge_tobytes(&pubkey[0], &A)
+    ge_tobytes(@pubkey[0], @A)
 
     # r = SHA512(prefix || msg) mod l
     # prefix = hash[32:64]
@@ -680,40 +680,40 @@ pub fn ed25519_sign(sig: *u8, msg: *u8, msg_len: u64, privkey: *u8)
 
     # Hash prefix || msg
     var ctx: Sha512
-    sha512_init(&ctx)
-    sha512_update(&ctx, &hash[32], 32)
-    sha512_update(&ctx, msg, msg_len)
-    sha512_final(&ctx, &r_hash[0])
+    sha512_init(@ctx)
+    sha512_update(@ctx, @hash[32], 32)
+    sha512_update(@ctx, msg, msg_len)
+    sha512_final(@ctx, @r_hash[0])
 
-    sc_reduce(&r_hash[0])
+    sc_reduce(@r_hash[0])
 
     # R = r * B
     var R: Ge25519
-    ge_scalarmult_base(&R, &r_hash[0])
-    ge_tobytes(sig, &R)  # sig[0:32] = R
+    ge_scalarmult_base(@R, @r_hash[0])
+    ge_tobytes(sig, @R)  # sig[0:32] = R
 
     # k = SHA512(R || A || msg) mod l
     var k_hash: [64]u8
-    sha512_init(&ctx)
-    sha512_update(&ctx, sig, 32)  # R
-    sha512_update(&ctx, &pubkey[0], 32)  # A
-    sha512_update(&ctx, msg, msg_len)
-    sha512_final(&ctx, &k_hash[0])
-    sc_reduce(&k_hash[0])
+    sha512_init(@ctx)
+    sha512_update(@ctx, sig, 32)  # R
+    sha512_update(@ctx, @pubkey[0], 32)  # A
+    sha512_update(@ctx, msg, msg_len)
+    sha512_final(@ctx, @k_hash[0])
+    sc_reduce(@k_hash[0])
 
     # s = r + k * a mod l
-    sc_muladd(&sig[32], &k_hash[0], &hash[0], &r_hash[0])
+    sc_muladd(@sig[32], @k_hash[0], @hash[0], @r_hash[0])
 
 # Verify a signature
 pub fn ed25519_verify(sig: *u8, msg: *u8, msg_len: u64, pubkey: *u8) -> i32
     # Decode public key A
     var A: Ge25519
-    if ge_frombytes(&A, pubkey) != 0
+    if ge_frombytes(@A, pubkey) != 0
         return -1
 
     # Decode R from signature
     var R: Ge25519
-    if ge_frombytes(&R, sig) != 0
+    if ge_frombytes(@R, sig) != 0
         return -1
 
     # s is in sig[32:64]
@@ -722,34 +722,34 @@ pub fn ed25519_verify(sig: *u8, msg: *u8, msg_len: u64, pubkey: *u8) -> i32
     # k = SHA512(R || A || msg) mod l
     var k_hash: [64]u8
     var ctx: Sha512
-    sha512_init(&ctx)
-    sha512_update(&ctx, sig, 32)  # R
-    sha512_update(&ctx, pubkey, 32)  # A
-    sha512_update(&ctx, msg, msg_len)
-    sha512_final(&ctx, &k_hash[0])
-    sc_reduce(&k_hash[0])
+    sha512_init(@ctx)
+    sha512_update(@ctx, sig, 32)  # R
+    sha512_update(@ctx, pubkey, 32)  # A
+    sha512_update(@ctx, msg, msg_len)
+    sha512_final(@ctx, @k_hash[0])
+    sc_reduce(@k_hash[0])
 
     # Verify: [s]B = R + [k]A
     # Equivalently: [s]B - [k]A = R
 
     # Compute [s]B
     var sB: Ge25519
-    ge_scalarmult_base(&sB, &sig[32])
+    ge_scalarmult_base(@sB, @sig[32])
 
     # Compute [k]A
     var kA: Ge25519
-    ge_scalarmult(&kA, &k_hash[0], &A)
+    ge_scalarmult(@kA, @k_hash[0], @A)
 
     # Negate kA
     var neg_kA: Ge25519
-    ge_neg(&neg_kA, &kA)
+    ge_neg(@neg_kA, @kA)
 
     # sB - kA
     var check: Ge25519
-    ge_add(&check, &sB, &neg_kA)
+    ge_add(@check, @sB, @neg_kA)
 
     # Compare with R
     var check_bytes: [32]u8
-    ge_tobytes(&check_bytes[0], &check)
+    ge_tobytes(@check_bytes[0], @check)
 
-    return mem_eq(&check_bytes[0], sig, 32) - 1
+    return mem_eq(@check_bytes[0], sig, 32) - 1

--- a/projects/cryptosec/lib/hkdf.ritz
+++ b/projects/cryptosec/lib/hkdf.ritz
@@ -33,8 +33,8 @@ pub fn hkdf_extract(salt: *u8, salt_len: u64, ikm: *u8, ikm_len: u64, prk: *u8)
     if salt == null || salt_len == 0
         # Use a string of hash_len zeros as salt
         var zero_salt: [32]u8
-        mem_zero(&zero_salt[0], 32)
-        hmac_sha256(&zero_salt[0], 32, ikm, ikm_len, prk)
+        mem_zero(@zero_salt[0], 32)
+        hmac_sha256(@zero_salt[0], 32, ikm, ikm_len, prk)
     else
         hmac_sha256(salt, salt_len, ikm, ikm_len, prk)
 
@@ -69,12 +69,12 @@ pub fn hkdf_expand(prk: *u8, info: *u8, info_len: u64, okm: *u8, okm_len: u64)
 
         # Copy T(i-1)
         if t_prev_len > 0
-            mem_copy(&input[0], &t_prev[0], t_prev_len)
+            mem_copy(@input[0], @t_prev[0], t_prev_len)
             input_len = t_prev_len
 
         # Copy info
         if info != null && info_len > 0
-            mem_copy(&input[input_len], info, info_len)
+            mem_copy(@input[input_len], info, info_len)
             input_len = input_len + info_len
 
         # Append counter byte
@@ -83,28 +83,28 @@ pub fn hkdf_expand(prk: *u8, info: *u8, info_len: u64, okm: *u8, okm_len: u64)
 
         # T(i) = HMAC-Hash(PRK, input)
         var t_current: [32]u8
-        hmac_sha256(prk, 32, &input[0], input_len, &t_current[0])
+        hmac_sha256(prk, 32, @input[0], input_len, @t_current[0])
 
         # Copy to output (may be partial for last block)
         var to_copy: u64 = hash_len
         if offset + to_copy > okm_len
             to_copy = okm_len - offset
 
-        mem_copy(&okm[offset], &t_current[0], to_copy)
+        mem_copy(@okm[offset], @t_current[0], to_copy)
         offset = offset + to_copy
 
         # T(i-1) = T(i) for next iteration
-        mem_copy(&t_prev[0], &t_current[0], 32)
+        mem_copy(@t_prev[0], @t_current[0], 32)
         t_prev_len = 32
 
         # Zero sensitive data
-        mem_zero(&t_current[0], 32)
-        mem_zero(&input[0], input_len)
+        mem_zero(@t_current[0], 32)
+        mem_zero(@input[0], input_len)
 
         i += 1
 
     # Zero sensitive data
-    mem_zero(&t_prev[0], 32)
+    mem_zero(@t_prev[0], 32)
 
 # ============================================================================
 # Combined HKDF
@@ -122,11 +122,11 @@ pub fn hkdf_expand(prk: *u8, info: *u8, info_len: u64, okm: *u8, okm_len: u64)
 pub fn hkdf_sha256(salt: *u8, salt_len: u64, ikm: *u8, ikm_len: u64, info: *u8, info_len: u64, okm: *u8, okm_len: u64)
     # Extract
     var prk: [32]u8
-    hkdf_extract(salt, salt_len, ikm, ikm_len, &prk[0])
+    hkdf_extract(salt, salt_len, ikm, ikm_len, @prk[0])
 
     # Expand
-    hkdf_expand(&prk[0], info, info_len, okm, okm_len)
+    hkdf_expand(@prk[0], info, info_len, okm, okm_len)
 
     # Zero PRK
-    mem_zero(&prk[0], 32)
+    mem_zero(@prk[0], 32)
 

--- a/projects/cryptosec/lib/hmac.ritz
+++ b/projects/cryptosec/lib/hmac.ritz
@@ -49,7 +49,7 @@ pub fn hmac_sha256(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
 
     # If key is longer than block size, hash it first
     if key_len > 64
-        sha256(key, key_len, &k_prime[0])
+        sha256(key, key_len, @k_prime[0])
         # k_prime[0..31] now contains H(key), rest is zeros
     else
         # Copy key to k_prime, padding with zeros
@@ -60,7 +60,7 @@ pub fn hmac_sha256(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
 
     # Compute inner hash: H((K' XOR ipad) || message)
     var inner_ctx: Sha256
-    sha256_init(&inner_ctx)
+    sha256_init(@inner_ctx)
 
     # XOR K' with ipad (0x36) and feed to hash
     var ipad_block: [64]u8
@@ -68,18 +68,18 @@ pub fn hmac_sha256(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     while i < 64
         ipad_block[i] = k_prime[i] ^ 0x36
         i += 1
-    sha256_update(&inner_ctx, &ipad_block[0], 64)
+    sha256_update(@inner_ctx, @ipad_block[0], 64)
 
     # Feed message
-    sha256_update(&inner_ctx, data, data_len)
+    sha256_update(@inner_ctx, data, data_len)
 
     # Finalize inner hash
     var inner_hash: [32]u8
-    sha256_final(&inner_ctx, &inner_hash[0])
+    sha256_final(@inner_ctx, @inner_hash[0])
 
     # Compute outer hash: H((K' XOR opad) || inner_hash)
     var outer_ctx: Sha256
-    sha256_init(&outer_ctx)
+    sha256_init(@outer_ctx)
 
     # XOR K' with opad (0x5c) and feed to hash
     var opad_block: [64]u8
@@ -87,19 +87,19 @@ pub fn hmac_sha256(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     while i < 64
         opad_block[i] = k_prime[i] ^ 0x5c
         i += 1
-    sha256_update(&outer_ctx, &opad_block[0], 64)
+    sha256_update(@outer_ctx, @opad_block[0], 64)
 
     # Feed inner hash
-    sha256_update(&outer_ctx, &inner_hash[0], 32)
+    sha256_update(@outer_ctx, @inner_hash[0], 32)
 
     # Finalize outer hash -> output
-    sha256_final(&outer_ctx, out)
+    sha256_final(@outer_ctx, out)
 
     # Zero sensitive data
-    mem_zero(&k_prime[0], 64)
-    mem_zero(&ipad_block[0], 64)
-    mem_zero(&opad_block[0], 64)
-    mem_zero(&inner_hash[0], 32)
+    mem_zero(@k_prime[0], 64)
+    mem_zero(@ipad_block[0], 64)
+    mem_zero(@opad_block[0], 64)
+    mem_zero(@inner_hash[0], 32)
 
 # ============================================================================
 # HMAC-SHA-512
@@ -123,7 +123,7 @@ pub fn hmac_sha512(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
 
     # If key is longer than block size, hash it first
     if key_len > 128
-        sha512(key, key_len, &k_prime[0])
+        sha512(key, key_len, @k_prime[0])
         # k_prime[0..63] now contains H(key), rest is zeros
     else
         # Copy key to k_prime, padding with zeros
@@ -134,7 +134,7 @@ pub fn hmac_sha512(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
 
     # Compute inner hash: H((K' XOR ipad) || message)
     var inner_ctx: Sha512
-    sha512_init(&inner_ctx)
+    sha512_init(@inner_ctx)
 
     # XOR K' with ipad (0x36) and feed to hash
     var ipad_block: [128]u8
@@ -142,18 +142,18 @@ pub fn hmac_sha512(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     while i < 128
         ipad_block[i] = k_prime[i] ^ 0x36
         i += 1
-    sha512_update(&inner_ctx, &ipad_block[0], 128)
+    sha512_update(@inner_ctx, @ipad_block[0], 128)
 
     # Feed message
-    sha512_update(&inner_ctx, data, data_len)
+    sha512_update(@inner_ctx, data, data_len)
 
     # Finalize inner hash
     var inner_hash: [64]u8
-    sha512_final(&inner_ctx, &inner_hash[0])
+    sha512_final(@inner_ctx, @inner_hash[0])
 
     # Compute outer hash: H((K' XOR opad) || inner_hash)
     var outer_ctx: Sha512
-    sha512_init(&outer_ctx)
+    sha512_init(@outer_ctx)
 
     # XOR K' with opad (0x5c) and feed to hash
     var opad_block: [128]u8
@@ -161,19 +161,19 @@ pub fn hmac_sha512(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     while i < 128
         opad_block[i] = k_prime[i] ^ 0x5c
         i += 1
-    sha512_update(&outer_ctx, &opad_block[0], 128)
+    sha512_update(@outer_ctx, @opad_block[0], 128)
 
     # Feed inner hash
-    sha512_update(&outer_ctx, &inner_hash[0], 64)
+    sha512_update(@outer_ctx, @inner_hash[0], 64)
 
     # Finalize outer hash -> output
-    sha512_final(&outer_ctx, out)
+    sha512_final(@outer_ctx, out)
 
     # Zero sensitive data
-    mem_zero(&k_prime[0], 128)
-    mem_zero(&ipad_block[0], 128)
-    mem_zero(&opad_block[0], 128)
-    mem_zero(&inner_hash[0], 64)
+    mem_zero(@k_prime[0], 128)
+    mem_zero(@ipad_block[0], 128)
+    mem_zero(@opad_block[0], 128)
+    mem_zero(@inner_hash[0], 64)
 
 # ============================================================================
 # HMAC-SHA-384
@@ -197,7 +197,7 @@ pub fn hmac_sha384(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
 
     # If key is longer than block size, hash it first
     if key_len > 128
-        sha384(key, key_len, &k_prime[0])
+        sha384(key, key_len, @k_prime[0])
         # k_prime[0..47] now contains H(key), rest is zeros
     else
         # Copy key to k_prime, padding with zeros
@@ -208,7 +208,7 @@ pub fn hmac_sha384(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
 
     # Compute inner hash: H((K' XOR ipad) || message)
     var inner_ctx: Sha384
-    sha384_init(&inner_ctx)
+    sha384_init(@inner_ctx)
 
     # XOR K' with ipad (0x36) and feed to hash
     var ipad_block: [128]u8
@@ -216,18 +216,18 @@ pub fn hmac_sha384(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     while i < 128
         ipad_block[i] = k_prime[i] ^ 0x36
         i += 1
-    sha384_update(&inner_ctx, &ipad_block[0], 128)
+    sha384_update(@inner_ctx, @ipad_block[0], 128)
 
     # Feed message
-    sha384_update(&inner_ctx, data, data_len)
+    sha384_update(@inner_ctx, data, data_len)
 
     # Finalize inner hash
     var inner_hash: [48]u8
-    sha384_final(&inner_ctx, &inner_hash[0])
+    sha384_final(@inner_ctx, @inner_hash[0])
 
     # Compute outer hash: H((K' XOR opad) || inner_hash)
     var outer_ctx: Sha384
-    sha384_init(&outer_ctx)
+    sha384_init(@outer_ctx)
 
     # XOR K' with opad (0x5c) and feed to hash
     var opad_block: [128]u8
@@ -235,16 +235,16 @@ pub fn hmac_sha384(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     while i < 128
         opad_block[i] = k_prime[i] ^ 0x5c
         i += 1
-    sha384_update(&outer_ctx, &opad_block[0], 128)
+    sha384_update(@outer_ctx, @opad_block[0], 128)
 
     # Feed inner hash
-    sha384_update(&outer_ctx, &inner_hash[0], 48)
+    sha384_update(@outer_ctx, @inner_hash[0], 48)
 
     # Finalize outer hash -> output
-    sha384_final(&outer_ctx, out)
+    sha384_final(@outer_ctx, out)
 
     # Zero sensitive data
-    mem_zero(&k_prime[0], 128)
-    mem_zero(&ipad_block[0], 128)
-    mem_zero(&opad_block[0], 128)
-    mem_zero(&inner_hash[0], 48)
+    mem_zero(@k_prime[0], 128)
+    mem_zero(@ipad_block[0], 128)
+    mem_zero(@opad_block[0], 128)
+    mem_zero(@inner_hash[0], 48)

--- a/projects/cryptosec/lib/p256.ritz
+++ b/projects/cryptosec/lib/p256.ritz
@@ -112,10 +112,10 @@ pub fn scalar256_cmp(a: *Scalar256, b: *Scalar256) -> i32
 
 # Load scalar from big-endian bytes (32 bytes)
 pub fn scalar256_from_bytes(a: *Scalar256, data: *u8)
-    a.limbs[3] = load_u64_be(&data[0])
-    a.limbs[2] = load_u64_be(&data[8])
-    a.limbs[1] = load_u64_be(&data[16])
-    a.limbs[0] = load_u64_be(&data[24])
+    a.limbs[3] = load_u64_be(@data[0])
+    a.limbs[2] = load_u64_be(@data[8])
+    a.limbs[1] = load_u64_be(@data[16])
+    a.limbs[0] = load_u64_be(@data[24])
 
 # Store scalar to big-endian bytes (32 bytes)
 pub fn scalar256_to_bytes(a: *Scalar256, out: *u8)
@@ -205,25 +205,25 @@ fn scalar256_sub_raw(c: *Scalar256, a: *Scalar256, b: *Scalar256) -> u64
 # Reduce c to canonical form [0, n)
 pub fn scalar256_reduce(c: *Scalar256)
     var n: Scalar256
-    get_p256_order(&n)
-    if scalar256_cmp(c, &n) >= 0
-        scalar256_sub_raw(c, c, &n)
+    get_p256_order(@n)
+    if scalar256_cmp(c, @n) >= 0
+        scalar256_sub_raw(c, c, @n)
 
 # Modular addition: c = (a + b) mod n
 pub fn scalar256_add(c: *Scalar256, a: *Scalar256, b: *Scalar256)
     let carry: u64 = scalar256_add_raw(c, a, b)
     var n: Scalar256
-    get_p256_order(&n)
-    if carry != 0 || scalar256_cmp(c, &n) >= 0
-        scalar256_sub_raw(c, c, &n)
+    get_p256_order(@n)
+    if carry != 0 || scalar256_cmp(c, @n) >= 0
+        scalar256_sub_raw(c, c, @n)
 
 # Modular subtraction: c = (a - b) mod n
 pub fn scalar256_sub(c: *Scalar256, a: *Scalar256, b: *Scalar256)
     let borrow: u64 = scalar256_sub_raw(c, a, b)
     if borrow != 0
         var n: Scalar256
-        get_p256_order(&n)
-        scalar256_add_raw(c, c, &n)
+        get_p256_order(@n)
+        scalar256_add_raw(c, c, @n)
 
 # Modular negation: c = -a mod n
 pub fn scalar256_neg(c: *Scalar256, a: *Scalar256)
@@ -231,8 +231,8 @@ pub fn scalar256_neg(c: *Scalar256, a: *Scalar256)
         scalar256_zero(c)
         return
     var n: Scalar256
-    get_p256_order(&n)
-    scalar256_sub_raw(c, &n, a)
+    get_p256_order(@n)
+    scalar256_sub_raw(c, @n, a)
 
 # Modular multiplication: c = (a * b) mod n
 pub fn scalar256_mul(c: *Scalar256, a: *Scalar256, b: *Scalar256)
@@ -250,19 +250,19 @@ pub fn scalar256_mul(c: *Scalar256, a: *Scalar256, b: *Scalar256)
         while bi < 4
             var lo: u64 = 0
             var hi: u64 = 0
-            mul64(a.limbs[ai], b.limbs[bi], &lo, &hi)
+            mul64(a.limbs[ai], b.limbs[bi], @lo, @hi)
             let idx: i32 = ai + bi
-            carry = add64_carry(prod[idx], lo, carry, &prod[idx])
+            carry = add64_carry(prod[idx], lo, carry, @prod[idx])
             carry = carry + hi
             bi += 1
         var k: i32 = ai + 4
         while carry != 0 && k < 8
-            carry = add64_carry(prod[k], 0, carry, &prod[k])
+            carry = add64_carry(prod[k], 0, carry, @prod[k])
             k += 1
         ai += 1
 
     # Reduce mod n using Barrett reduction or simple repeated subtraction
-    scalar256_reduce_512(&prod[0], c)
+    scalar256_reduce_512(@prod[0], c)
 
 # Reduce 512-bit value mod n
 fn scalar256_reduce_512(prod: *u64, r: *Scalar256)
@@ -281,11 +281,11 @@ fn scalar256_reduce_512(prod: *u64, r: *Scalar256)
     lo.limbs[3] = prod[3]
 
     var n: Scalar256
-    get_p256_order(&n)
+    get_p256_order(@n)
 
     # Reduce lo first
-    while scalar256_cmp(&lo, &n) >= 0
-        scalar256_sub_raw(&lo, &lo, &n)
+    while scalar256_cmp(@lo, @n) >= 0
+        scalar256_sub_raw(@lo, @lo, @n)
 
     # Process hi bits: for each set bit in hi, add 2^(256+bit_pos) mod n
     # 2^256 mod n = n - (2^256 - n) = we need to compute 2^256 mod n
@@ -299,12 +299,12 @@ fn scalar256_reduce_512(prod: *u64, r: *Scalar256)
     pow256_mod_n.limbs[3] = 0x00000000FFFFFFFF
 
     # Multiply hi by 2^256 mod n
-    if scalar256_is_zero(&hi) != 1
+    if scalar256_is_zero(@hi) != 1
         var hi_reduced: Scalar256
-        scalar256_mul_simple(&hi_reduced, &hi, &pow256_mod_n, &n)
-        scalar256_add(r, &lo, &hi_reduced)
+        scalar256_mul_simple(@hi_reduced, @hi, @pow256_mod_n, @n)
+        scalar256_add(r, @lo, @hi_reduced)
     else
-        scalar256_copy(r, &lo)
+        scalar256_copy(r, @lo)
 
 # Simple multiplication for reduction (already reduced inputs)
 fn scalar256_mul_simple(c: *Scalar256, a: *Scalar256, b: *Scalar256, n: *Scalar256)
@@ -322,14 +322,14 @@ fn scalar256_mul_simple(c: *Scalar256, a: *Scalar256, b: *Scalar256, n: *Scalar2
         while bi < 4
             var lo: u64 = 0
             var hi: u64 = 0
-            mul64(a.limbs[ai], b.limbs[bi], &lo, &hi)
+            mul64(a.limbs[ai], b.limbs[bi], @lo, @hi)
             let idx: i32 = ai + bi
-            carry = add64_carry(prod[idx], lo, carry, &prod[idx])
+            carry = add64_carry(prod[idx], lo, carry, @prod[idx])
             carry = carry + hi
             bi += 1
         var k: i32 = ai + 4
         while carry != 0 && k < 8
-            carry = add64_carry(prod[k], 0, carry, &prod[k])
+            carry = add64_carry(prod[k], 0, carry, @prod[k])
             k += 1
         ai += 1
 
@@ -351,7 +351,7 @@ fn scalar256_mul_simple(c: *Scalar256, a: *Scalar256, b: *Scalar256, n: *Scalar2
         scalar256_sub_raw(c, c, n)
 
     # Add overflow * 2^256 mod n recursively
-    if scalar256_is_zero(&overflow) != 1
+    if scalar256_is_zero(@overflow) != 1
         var pow256: Scalar256
         pow256.limbs[0] = 0x0C46353D039CDAAF
         pow256.limbs[1] = 0x4319055258E8617B
@@ -359,8 +359,8 @@ fn scalar256_mul_simple(c: *Scalar256, a: *Scalar256, b: *Scalar256, n: *Scalar2
         pow256.limbs[3] = 0x00000000FFFFFFFF
 
         var contrib: Scalar256
-        scalar256_mul_simple(&contrib, &overflow, &pow256, n)
-        scalar256_add(c, c, &contrib)
+        scalar256_mul_simple(@contrib, @overflow, @pow256, n)
+        scalar256_add(c, c, @contrib)
 
 # Modular inversion: c = a^(-1) mod n using Fermat's Little Theorem
 # a^(-1) = a^(n-2) mod n
@@ -401,10 +401,10 @@ pub fn scalar256_inv(c: *Scalar256, a: *Scalar256)
     exp[31] = 0x4F  # n - 2
 
     var result: Scalar256
-    scalar256_one(&result)
+    scalar256_one(@result)
 
     var base: Scalar256
-    scalar256_copy(&base, a)
+    scalar256_copy(@base, a)
 
     var byte_idx: i32 = 31
     while byte_idx >= 0
@@ -412,12 +412,12 @@ pub fn scalar256_inv(c: *Scalar256, a: *Scalar256)
         while bit < 8
             let b: u8 = (exp[byte_idx] >> bit) & 1
             if b == 1
-                scalar256_mul(&result, &result, &base)
-            scalar256_mul(&base, &base, &base)
+                scalar256_mul(@result, @result, @base)
+            scalar256_mul(@base, @base, @base)
             bit += 1
         byte_idx -= 1
 
-    scalar256_copy(c, &result)
+    scalar256_copy(c, @result)
 
 # ============================================================================
 # Field Element Operations
@@ -496,10 +496,10 @@ fn load_u64_be(data: *u8) -> u64
 # Load from big-endian bytes (32 bytes)
 pub fn fep256_from_bytes(a: *FeP256, data: *u8)
     # Big-endian: data[0] is most significant byte
-    a.limbs[3] = load_u64_be(&data[0])
-    a.limbs[2] = load_u64_be(&data[8])
-    a.limbs[1] = load_u64_be(&data[16])
-    a.limbs[0] = load_u64_be(&data[24])
+    a.limbs[3] = load_u64_be(@data[0])
+    a.limbs[2] = load_u64_be(@data[8])
+    a.limbs[1] = load_u64_be(@data[16])
+    a.limbs[0] = load_u64_be(@data[24])
 
 # Store to big-endian bytes (32 bytes)
 pub fn fep256_to_bytes(a: *FeP256, out: *u8)
@@ -620,11 +620,11 @@ fn fep256_sub_raw(c: *FeP256, a: *FeP256, b: *FeP256) -> u64
 # Uses the special structure of p = 2^256 - 2^224 + 2^192 + 2^96 - 1
 pub fn fep256_reduce(c: *FeP256)
     var p: FeP256
-    get_p256_prime(&p)
+    get_p256_prime(@p)
 
     # If c >= p, subtract p
-    if fep256_cmp(c, &p) >= 0
-        fep256_sub_raw(c, c, &p)
+    if fep256_cmp(c, @p) >= 0
+        fep256_sub_raw(c, c, @p)
 
 # ============================================================================
 # Modular Addition: c = (a + b) mod p
@@ -634,11 +634,11 @@ pub fn fep256_add(c: *FeP256, a: *FeP256, b: *FeP256)
     let carry: u64 = fep256_add_raw(c, a, b)
 
     var p: FeP256
-    get_p256_prime(&p)
+    get_p256_prime(@p)
 
     # If carry or c >= p, subtract p
-    if carry != 0 || fep256_cmp(c, &p) >= 0
-        fep256_sub_raw(c, c, &p)
+    if carry != 0 || fep256_cmp(c, @p) >= 0
+        fep256_sub_raw(c, c, @p)
 
 # ============================================================================
 # Modular Subtraction: c = (a - b) mod p
@@ -650,8 +650,8 @@ pub fn fep256_sub(c: *FeP256, a: *FeP256, b: *FeP256)
     # If borrow, add p
     if borrow != 0
         var p: FeP256
-        get_p256_prime(&p)
-        fep256_add_raw(c, c, &p)
+        get_p256_prime(@p)
+        fep256_add_raw(c, c, @p)
 
 # ============================================================================
 # Modular Negation: c = -a mod p = p - a
@@ -663,8 +663,8 @@ pub fn fep256_neg(c: *FeP256, a: *FeP256)
         return
 
     var p: FeP256
-    get_p256_prime(&p)
-    fep256_sub_raw(c, &p, a)
+    get_p256_prime(@p)
+    fep256_sub_raw(c, @p, a)
 
 # ============================================================================
 # 64-bit Multiplication Helper (produces 128-bit result)
@@ -724,25 +724,25 @@ pub fn fep256_mul(c: *FeP256, a: *FeP256, b: *FeP256)
         while bi < 4
             var lo: u64 = 0
             var hi: u64 = 0
-            mul64(a.limbs[ai], b.limbs[bi], &lo, &hi)
+            mul64(a.limbs[ai], b.limbs[bi], @lo, @hi)
 
             # Add to accumulator
             let idx: i32 = ai + bi
-            carry = add64_carry(prod[idx], lo, carry, &prod[idx])
+            carry = add64_carry(prod[idx], lo, carry, @prod[idx])
             carry = carry + hi
             bi += 1
 
         # Propagate remaining carry
         var k: i32 = ai + 4
         while carry != 0 && k < 8
-            carry = add64_carry(prod[k], 0, carry, &prod[k])
+            carry = add64_carry(prod[k], 0, carry, @prod[k])
             k += 1
         ai += 1
 
     # Reduce modulo p using the P-256 reduction formula
     # p = 2^256 - 2^224 + 2^192 + 2^96 - 1
     # So 2^256 ≡ 2^224 - 2^192 - 2^96 + 1 (mod p)
-    fep256_reduce_512(&prod[0], c)
+    fep256_reduce_512(@prod[0], c)
 
 # ============================================================================
 # P-256 Specific Reduction
@@ -884,13 +884,13 @@ fn fep256_reduce_512(prod: *u64, r: *FeP256)
 
     # Handle final carry/borrow
     var p: FeP256
-    get_p256_prime(&p)
+    get_p256_prime(@p)
 
     while carry > 0
-        fep256_sub_raw(r, r, &p)
+        fep256_sub_raw(r, r, @p)
         carry -= 1
     while carry < 0
-        fep256_add_raw(r, r, &p)
+        fep256_add_raw(r, r, @p)
         carry += 1
 
     # Final reduction to ensure result < p
@@ -922,38 +922,38 @@ pub fn fep256_inv(c: *FeP256, a: *FeP256)
     # This uses the standard binary exponentiation with some optimizations
 
     # t1 = a^2
-    fep256_sqr(&t1, a)
+    fep256_sqr(@t1, a)
     # t2 = a^3 = t1 * a
-    fep256_mul(&t2, &t1, a)
+    fep256_mul(@t2, @t1, a)
     # t1 = a^6 = (a^3)^2
-    fep256_sqr(&t1, &t2)
+    fep256_sqr(@t1, @t2)
     # t3 = a^7 = a^6 * a
-    fep256_mul(&t3, &t1, a)
+    fep256_mul(@t3, @t1, a)
     # t1 = a^14
-    fep256_sqr(&t1, &t3)
+    fep256_sqr(@t1, @t3)
     # t2 = a^15 = a^14 * a
-    fep256_mul(&t2, &t1, a)
+    fep256_mul(@t2, @t1, a)
 
     # Continue building up the exponent
     # Square 4 times to get a^(15 * 16) = a^240
     var i: i32 = 0
-    fep256_copy(&t1, &t2)
+    fep256_copy(@t1, @t2)
     while i < 4
-        fep256_sqr(&t1, &t1)
+        fep256_sqr(@t1, @t1)
         i += 1
     # Multiply by a^15 to get a^255
-    fep256_mul(&t1, &t1, &t2)
+    fep256_mul(@t1, @t1, @t2)
 
     # Continue with more squarings and multiplications
     # This is an abbreviated version - for production, use optimized addition chain
 
     # a^(2^32 - 1) via repeated squaring and multiplying
-    fep256_copy(&t3, &t1)
+    fep256_copy(@t3, @t1)
     i = 0
     while i < 8
-        fep256_sqr(&t3, &t3)
+        fep256_sqr(@t3, @t3)
         i += 1
-    fep256_mul(&t3, &t3, &t1)  # a^(2^16 - 1) * 2^8 + a^255 = a^(2^16 - 1 - 256 + 255)?
+    fep256_mul(@t3, @t3, @t1)  # a^(2^16 - 1) * 2^8 + a^255 = a^(2^16 - 1 - 256 + 255)?
 
     # This simplified version does full binary exponentiation
     # For better performance, use an optimized addition chain
@@ -998,10 +998,10 @@ fn fep256_pow_p_minus_2(c: *FeP256, a: *FeP256)
     exp[31] = 0xFD  # p - 2
 
     var result: FeP256
-    fep256_one(&result)
+    fep256_one(@result)
 
     var base: FeP256
-    fep256_copy(&base, a)
+    fep256_copy(@base, a)
 
     # Process from least significant bit
     var byte_idx: i32 = 31
@@ -1010,12 +1010,12 @@ fn fep256_pow_p_minus_2(c: *FeP256, a: *FeP256)
         while bit < 8
             let b: u8 = (exp[byte_idx] >> bit) & 1
             if b == 1
-                fep256_mul(&result, &result, &base)
-            fep256_sqr(&base, &base)
+                fep256_mul(@result, @result, @base)
+            fep256_sqr(@base, @base)
             bit += 1
         byte_idx -= 1
 
-    fep256_copy(c, &result)
+    fep256_copy(c, @result)
 
 # ============================================================================
 # Curve Constant b
@@ -1065,31 +1065,31 @@ pub struct P256Point
 
 # Initialize point to the point at infinity (neutral element)
 pub fn p256_point_identity(p: *P256Point)
-    fep256_one(&p.x)
-    fep256_one(&p.y)
-    fep256_zero(&p.z)
+    fep256_one(@p.x)
+    fep256_one(@p.y)
+    fep256_zero(@p.z)
 
 # Check if point is the identity (point at infinity)
 pub fn p256_point_is_identity(p: *P256Point) -> i32
-    return fep256_is_zero(&p.z)
+    return fep256_is_zero(@p.z)
 
 # Copy point
 pub fn p256_point_copy(dst: *P256Point, src: *P256Point)
-    fep256_copy(&dst.x, &src.x)
-    fep256_copy(&dst.y, &src.y)
-    fep256_copy(&dst.z, &src.z)
+    fep256_copy(@dst.x, @src.x)
+    fep256_copy(@dst.y, @src.y)
+    fep256_copy(@dst.z, @src.z)
 
 # Set point to the generator G
 pub fn p256_point_generator(g: *P256Point)
-    fep256_set_gx(&g.x)
-    fep256_set_gy(&g.y)
-    fep256_one(&g.z)
+    fep256_set_gx(@g.x)
+    fep256_set_gy(@g.y)
+    fep256_one(@g.z)
 
 # Set point from affine coordinates (x, y)
 pub fn p256_point_from_affine(p: *P256Point, x: *FeP256, y: *FeP256)
-    fep256_copy(&p.x, x)
-    fep256_copy(&p.y, y)
-    fep256_one(&p.z)
+    fep256_copy(@p.x, x)
+    fep256_copy(@p.y, y)
+    fep256_one(@p.z)
 
 # Convert from Jacobian to affine coordinates
 # Returns 1 on success, 0 if point is at infinity
@@ -1102,19 +1102,19 @@ pub fn p256_point_to_affine(p: *P256Point, x: *FeP256, y: *FeP256) -> i32
     var z3: FeP256
 
     # z_inv = z^(-1)
-    fep256_inv(&z_inv, &p.z)
+    fep256_inv(@z_inv, @p.z)
 
     # z2 = z^(-2)
-    fep256_sqr(&z2, &z_inv)
+    fep256_sqr(@z2, @z_inv)
 
     # z3 = z^(-3)
-    fep256_mul(&z3, &z2, &z_inv)
+    fep256_mul(@z3, @z2, @z_inv)
 
     # x_affine = X * z^(-2)
-    fep256_mul(x, &p.x, &z2)
+    fep256_mul(x, @p.x, @z2)
 
     # y_affine = Y * z^(-3)
-    fep256_mul(y, &p.y, &z3)
+    fep256_mul(y, @p.y, @z3)
 
     return 1
 
@@ -1123,9 +1123,9 @@ pub fn p256_point_to_affine(p: *P256Point, x: *FeP256, y: *FeP256) -> i32
 # ============================================================================
 
 pub fn p256_point_neg(r: *P256Point, p: *P256Point)
-    fep256_copy(&r.x, &p.x)
-    fep256_neg(&r.y, &p.y)
-    fep256_copy(&r.z, &p.z)
+    fep256_copy(@r.x, @p.x)
+    fep256_neg(@r.y, @p.y)
+    fep256_copy(@r.z, @p.z)
 
 # ============================================================================
 # Point Doubling: R = 2*P (Jacobian coordinates)
@@ -1150,48 +1150,48 @@ pub fn p256_point_double(r: *P256Point, p: *P256Point)
     var z2: FeP256
 
     # y2 = Y^2
-    fep256_sqr(&y2, &p.y)
+    fep256_sqr(@y2, @p.y)
 
     # s = 4*X*Y^2
-    fep256_mul(&s, &p.x, &y2)
-    fep256_add(&s, &s, &s)
-    fep256_add(&s, &s, &s)  # s = 4*X*Y^2
+    fep256_mul(@s, @p.x, @y2)
+    fep256_add(@s, @s, @s)
+    fep256_add(@s, @s, @s)  # s = 4*X*Y^2
 
     # For a = -3: M = 3*(X - Z^2)*(X + Z^2)
-    fep256_sqr(&z2, &p.z)
+    fep256_sqr(@z2, @p.z)
 
     # t1 = X - Z^2
-    fep256_sub(&t1, &p.x, &z2)
+    fep256_sub(@t1, @p.x, @z2)
 
     # t2 = X + Z^2
-    fep256_add(&t2, &p.x, &z2)
+    fep256_add(@t2, @p.x, @z2)
 
     # m = t1 * t2
-    fep256_mul(&m, &t1, &t2)
+    fep256_mul(@m, @t1, @t2)
 
     # m = 3 * m
-    fep256_add(&t1, &m, &m)
-    fep256_add(&m, &t1, &m)  # m = 3*(X - Z^2)*(X + Z^2)
+    fep256_add(@t1, @m, @m)
+    fep256_add(@m, @t1, @m)  # m = 3*(X - Z^2)*(X + Z^2)
 
     # X' = M^2 - 2*S
-    fep256_sqr(&t1, &m)
-    fep256_sub(&r.x, &t1, &s)
-    fep256_sub(&r.x, &r.x, &s)
+    fep256_sqr(@t1, @m)
+    fep256_sub(@r.x, @t1, @s)
+    fep256_sub(@r.x, @r.x, @s)
 
     # Y' = M*(S - X') - 8*Y^4
-    fep256_sub(&t1, &s, &r.x)
-    fep256_mul(&t1, &m, &t1)
+    fep256_sub(@t1, @s, @r.x)
+    fep256_mul(@t1, @m, @t1)
 
     # 8*Y^4 = 2 * 4*Y^4 = 2 * (2*Y^2)^2
-    fep256_add(&t2, &y2, &y2)  # 2*Y^2
-    fep256_sqr(&t2, &t2)       # 4*Y^4
-    fep256_add(&t2, &t2, &t2)  # 8*Y^4
+    fep256_add(@t2, @y2, @y2)  # 2*Y^2
+    fep256_sqr(@t2, @t2)       # 4*Y^4
+    fep256_add(@t2, @t2, @t2)  # 8*Y^4
 
-    fep256_sub(&r.y, &t1, &t2)
+    fep256_sub(@r.y, @t1, @t2)
 
     # Z' = 2*Y*Z
-    fep256_mul(&r.z, &p.y, &p.z)
-    fep256_add(&r.z, &r.z, &r.z)
+    fep256_mul(@r.z, @p.y, @p.z)
+    fep256_add(@r.z, @r.z, @r.z)
 
 # ============================================================================
 # Point Addition: R = P + Q (Jacobian coordinates)
@@ -1228,28 +1228,28 @@ pub fn p256_point_add(r: *P256Point, p: *P256Point, q: *P256Point)
     var h3: FeP256
 
     # Z1^2, Z2^2
-    fep256_sqr(&z1z1, &p.z)
-    fep256_sqr(&z2z2, &q.z)
+    fep256_sqr(@z1z1, @p.z)
+    fep256_sqr(@z2z2, @q.z)
 
     # U1 = X1*Z2^2, U2 = X2*Z1^2
-    fep256_mul(&u1, &p.x, &z2z2)
-    fep256_mul(&u2, &q.x, &z1z1)
+    fep256_mul(@u1, @p.x, @z2z2)
+    fep256_mul(@u2, @q.x, @z1z1)
 
     # S1 = Y1*Z2^3, S2 = Y2*Z1^3
-    fep256_mul(&t1, &z2z2, &q.z)  # Z2^3
-    fep256_mul(&s1, &p.y, &t1)
-    fep256_mul(&t1, &z1z1, &p.z)  # Z1^3
-    fep256_mul(&s2, &q.y, &t1)
+    fep256_mul(@t1, @z2z2, @q.z)  # Z2^3
+    fep256_mul(@s1, @p.y, @t1)
+    fep256_mul(@t1, @z1z1, @p.z)  # Z1^3
+    fep256_mul(@s2, @q.y, @t1)
 
     # H = U2 - U1
-    fep256_sub(&h, &u2, &u1)
+    fep256_sub(@h, @u2, @u1)
 
     # R = S2 - S1
-    fep256_sub(&rr, &s2, &s1)
+    fep256_sub(@rr, @s2, @s1)
 
     # Check for special cases
-    if fep256_is_zero(&h) == 1
-        if fep256_is_zero(&rr) == 1
+    if fep256_is_zero(@h) == 1
+        if fep256_is_zero(@rr) == 1
             # P == Q, do doubling
             p256_point_double(r, p)
             return
@@ -1259,27 +1259,27 @@ pub fn p256_point_add(r: *P256Point, p: *P256Point, q: *P256Point)
             return
 
     # H^2, H^3
-    fep256_sqr(&h2, &h)
-    fep256_mul(&h3, &h2, &h)
+    fep256_sqr(@h2, @h)
+    fep256_mul(@h3, @h2, @h)
 
     # U1*H^2
-    fep256_mul(&t1, &u1, &h2)
+    fep256_mul(@t1, @u1, @h2)
 
     # X3 = R^2 - H^3 - 2*U1*H^2
-    fep256_sqr(&r.x, &rr)
-    fep256_sub(&r.x, &r.x, &h3)
-    fep256_sub(&r.x, &r.x, &t1)
-    fep256_sub(&r.x, &r.x, &t1)
+    fep256_sqr(@r.x, @rr)
+    fep256_sub(@r.x, @r.x, @h3)
+    fep256_sub(@r.x, @r.x, @t1)
+    fep256_sub(@r.x, @r.x, @t1)
 
     # Y3 = R*(U1*H^2 - X3) - S1*H^3
-    fep256_sub(&t2, &t1, &r.x)
-    fep256_mul(&t2, &rr, &t2)
-    fep256_mul(&t1, &s1, &h3)
-    fep256_sub(&r.y, &t2, &t1)
+    fep256_sub(@t2, @t1, @r.x)
+    fep256_mul(@t2, @rr, @t2)
+    fep256_mul(@t1, @s1, @h3)
+    fep256_sub(@r.y, @t2, @t1)
 
     # Z3 = H*Z1*Z2
-    fep256_mul(&r.z, &h, &p.z)
-    fep256_mul(&r.z, &r.z, &q.z)
+    fep256_mul(@r.z, @h, @p.z)
+    fep256_mul(@r.z, @r.z, @q.z)
 
 # ============================================================================
 # Scalar Multiplication: R = k * P
@@ -1296,15 +1296,15 @@ pub fn p256_scalar_mult(r: *P256Point, k: *u8, k_len: i32, p: *P256Point)
         while bit >= 0
             # Double
             var doubled: P256Point
-            p256_point_double(&doubled, r)
-            p256_point_copy(r, &doubled)
+            p256_point_double(@doubled, r)
+            p256_point_copy(r, @doubled)
 
             # Add if bit is set
             let b: u8 = (k[byte_idx] >> bit) & 1
             if b == 1
                 var sum: P256Point
-                p256_point_add(&sum, r, p)
-                p256_point_copy(r, &sum)
+                p256_point_add(@sum, r, p)
+                p256_point_copy(r, @sum)
             bit -= 1
         byte_idx += 1
 
@@ -1316,7 +1316,7 @@ pub fn p256_scalar_mult(r: *P256Point, k: *u8, k_len: i32, p: *P256Point)
 pub fn p256_affine_on_curve(x: *FeP256, y: *FeP256) -> i32
     # Compute y^2
     var y2: FeP256
-    fep256_sqr(&y2, y)
+    fep256_sqr(@y2, y)
 
     # Compute x^3 + ax + b where a = -3
     var x2: FeP256
@@ -1325,24 +1325,24 @@ pub fn p256_affine_on_curve(x: *FeP256, y: *FeP256) -> i32
     var rhs: FeP256
 
     # x^2, x^3
-    fep256_sqr(&x2, x)
-    fep256_mul(&x3, &x2, x)
+    fep256_sqr(@x2, x)
+    fep256_mul(@x3, @x2, x)
 
     # -3x (since a = -3)
-    fep256_add(&t, x, x)
-    fep256_add(&t, &t, x)  # 3x
-    fep256_neg(&t, &t)      # -3x
+    fep256_add(@t, x, x)
+    fep256_add(@t, @t, x)  # 3x
+    fep256_neg(@t, @t)      # -3x
 
     # x^3 - 3x
-    fep256_add(&rhs, &x3, &t)
+    fep256_add(@rhs, @x3, @t)
 
     # x^3 - 3x + b
     var b: FeP256
-    fep256_set_b(&b)
-    fep256_add(&rhs, &rhs, &b)
+    fep256_set_b(@b)
+    fep256_add(@rhs, @rhs, @b)
 
     # Check y^2 == x^3 - 3x + b
-    return fep256_cmp(&y2, &rhs) == 0
+    return fep256_cmp(@y2, @rhs) == 0
 
 # Check if Jacobian point is on the curve
 # For Z=1 points (affine), this is efficient
@@ -1353,9 +1353,9 @@ pub fn p256_point_on_curve(p: *P256Point) -> i32
 
     # For Z=1 (affine), do direct check
     var one: FeP256
-    fep256_one(&one)
-    if fep256_cmp(&p.z, &one) == 0
-        return p256_affine_on_curve(&p.x, &p.y)
+    fep256_one(@one)
+    if fep256_cmp(@p.z, @one) == 0
+        return p256_affine_on_curve(@p.x, @p.y)
 
     # For Z!=1, check: Y^2 = X^3 + a*X*Z^4 + b*Z^6
     var z2: FeP256
@@ -1369,32 +1369,32 @@ pub fn p256_point_on_curve(p: *P256Point) -> i32
     var b: FeP256
 
     # Z^2, Z^4, Z^6
-    fep256_sqr(&z2, &p.z)
-    fep256_sqr(&z4, &z2)
-    fep256_mul(&z6, &z4, &z2)
+    fep256_sqr(@z2, @p.z)
+    fep256_sqr(@z4, @z2)
+    fep256_mul(@z6, @z4, @z2)
 
     # Y^2
-    fep256_sqr(&y2, &p.y)
+    fep256_sqr(@y2, @p.y)
 
     # X^3
-    fep256_sqr(&t1, &p.x)
-    fep256_mul(&x3, &t1, &p.x)
+    fep256_sqr(@t1, @p.x)
+    fep256_mul(@x3, @t1, @p.x)
 
     # a*X*Z^4 where a = -3
-    fep256_mul(&t1, &p.x, &z4)
-    fep256_add(&t2, &t1, &t1)
-    fep256_add(&t2, &t2, &t1)  # 3*X*Z^4
-    fep256_neg(&t2, &t2)        # -3*X*Z^4
+    fep256_mul(@t1, @p.x, @z4)
+    fep256_add(@t2, @t1, @t1)
+    fep256_add(@t2, @t2, @t1)  # 3*X*Z^4
+    fep256_neg(@t2, @t2)        # -3*X*Z^4
 
     # b*Z^6
-    fep256_set_b(&b)
-    fep256_mul(&t1, &b, &z6)
+    fep256_set_b(@b)
+    fep256_mul(@t1, @b, @z6)
 
     # RHS = X^3 + (-3*X*Z^4) + b*Z^6
-    fep256_add(&rhs, &x3, &t2)
-    fep256_add(&rhs, &rhs, &t1)
+    fep256_add(@rhs, @x3, @t2)
+    fep256_add(@rhs, @rhs, @t1)
 
-    return fep256_cmp(&y2, &rhs) == 0
+    return fep256_cmp(@y2, @rhs) == 0
 
 # ============================================================================
 # ECDSA Signature Structure
@@ -1436,7 +1436,7 @@ fn rfc6979_generate_k(k: *Scalar256, priv_key: *Scalar256, hash: *u8)
 
     # Convert private key to bytes
     var x_bytes: [32]u8
-    scalar256_to_bytes(priv_key, &x_bytes[0])
+    scalar256_to_bytes(priv_key, @x_bytes[0])
 
     # Build message: V || 0x00 || x || h1
     var msg1: [97]u8  # 32 + 1 + 32 + 32
@@ -1455,10 +1455,10 @@ fn rfc6979_generate_k(k: *Scalar256, priv_key: *Scalar256, hash: *u8)
         i += 1
 
     # K = HMAC_K(V || 0x00 || x || h1)
-    hmac_sha256(&key[0], 32, &msg1[0], 97, &key[0])
+    hmac_sha256(@key[0], 32, @msg1[0], 97, @key[0])
 
     # V = HMAC_K(V)
-    hmac_sha256(&key[0], 32, &v[0], 32, &v[0])
+    hmac_sha256(@key[0], 32, @v[0], 32, @v[0])
 
     # Build message: V || 0x01 || x || h1
     i = 0
@@ -1468,25 +1468,25 @@ fn rfc6979_generate_k(k: *Scalar256, priv_key: *Scalar256, hash: *u8)
     msg1[32] = 0x01
 
     # K = HMAC_K(V || 0x01 || x || h1)
-    hmac_sha256(&key[0], 32, &msg1[0], 97, &key[0])
+    hmac_sha256(@key[0], 32, @msg1[0], 97, @key[0])
 
     # V = HMAC_K(V)
-    hmac_sha256(&key[0], 32, &v[0], 32, &v[0])
+    hmac_sha256(@key[0], 32, @v[0], 32, @v[0])
 
     # Generate k
     var n: Scalar256
-    get_p256_order(&n)
+    get_p256_order(@n)
 
     var tries: i32 = 0
     while tries < 100  # Safety limit
         # V = HMAC_K(V)
-        hmac_sha256(&key[0], 32, &v[0], 32, &v[0])
+        hmac_sha256(@key[0], 32, @v[0], 32, @v[0])
 
         # T = V as scalar
-        scalar256_from_bytes(k, &v[0])
+        scalar256_from_bytes(k, @v[0])
 
         # Check if k is valid: 1 <= k < n
-        if scalar256_is_zero(k) == 0 && scalar256_cmp(k, &n) < 0
+        if scalar256_is_zero(k) == 0 && scalar256_cmp(k, @n) < 0
             return
 
         # Invalid k, update K and V
@@ -1497,8 +1497,8 @@ fn rfc6979_generate_k(k: *Scalar256, priv_key: *Scalar256, hash: *u8)
             msg2[i] = v[i]
             i += 1
         msg2[32] = 0x00
-        hmac_sha256(&key[0], 32, &msg2[0], 33, &key[0])
-        hmac_sha256(&key[0], 32, &v[0], 32, &v[0])
+        hmac_sha256(@key[0], 32, @msg2[0], 33, @key[0])
+        hmac_sha256(@key[0], 32, @v[0], 32, @v[0])
 
         tries += 1
 
@@ -1521,68 +1521,68 @@ fn rfc6979_generate_k(k: *Scalar256, priv_key: *Scalar256, hash: *u8)
 
 pub fn ecdsa_p256_sign(sig: *EcdsaSignature, hash: *u8, priv_key: *Scalar256) -> i32
     var n: Scalar256
-    get_p256_order(&n)
+    get_p256_order(@n)
 
     # Convert hash to scalar z (may need truncation for larger hashes)
     var z: Scalar256
-    scalar256_from_bytes(&z, hash)
+    scalar256_from_bytes(@z, hash)
     # Reduce z mod n if necessary
-    if scalar256_cmp(&z, &n) >= 0
-        scalar256_sub(&z, &z, &n)
+    if scalar256_cmp(@z, @n) >= 0
+        scalar256_sub(@z, @z, @n)
 
     # Generate deterministic k using RFC 6979
     var k: Scalar256
-    rfc6979_generate_k(&k, priv_key, hash)
+    rfc6979_generate_k(@k, priv_key, hash)
 
-    if scalar256_is_zero(&k) == 1
+    if scalar256_is_zero(@k) == 1
         return 0  # Failed to generate valid k
 
     # Compute R = k * G
     var k_bytes: [32]u8
-    scalar256_to_bytes(&k, &k_bytes[0])
+    scalar256_to_bytes(@k, @k_bytes[0])
 
     var R: P256Point
     var G: P256Point
-    p256_point_generator(&G)
-    p256_scalar_mult(&R, &k_bytes[0], 32, &G)
+    p256_point_generator(@G)
+    p256_scalar_mult(@R, @k_bytes[0], 32, @G)
 
-    if p256_point_is_identity(&R) == 1
+    if p256_point_is_identity(@R) == 1
         return 0
 
     # Convert R to affine coordinates
     var rx: FeP256
     var ry: FeP256
-    if p256_point_to_affine(&R, &rx, &ry) == 0
+    if p256_point_to_affine(@R, @rx, @ry) == 0
         return 0
 
     # r = rx mod n
     var rx_bytes: [32]u8
-    fep256_to_bytes(&rx, &rx_bytes[0])
-    scalar256_from_bytes(&sig.r, &rx_bytes[0])
-    scalar256_reduce(&sig.r)
+    fep256_to_bytes(@rx, @rx_bytes[0])
+    scalar256_from_bytes(@sig.r, @rx_bytes[0])
+    scalar256_reduce(@sig.r)
 
-    if scalar256_is_zero(&sig.r) == 1
+    if scalar256_is_zero(@sig.r) == 1
         return 0
 
     # s = k^(-1) * (z + r * d) mod n
     var k_inv: Scalar256
-    scalar256_inv(&k_inv, &k)
+    scalar256_inv(@k_inv, @k)
 
     var rd: Scalar256
-    scalar256_mul(&rd, &sig.r, priv_key)
+    scalar256_mul(@rd, @sig.r, priv_key)
 
     var z_rd: Scalar256
-    scalar256_add(&z_rd, &z, &rd)
+    scalar256_add(@z_rd, @z, @rd)
 
-    scalar256_mul(&sig.s, &k_inv, &z_rd)
+    scalar256_mul(@sig.s, @k_inv, @z_rd)
 
-    if scalar256_is_zero(&sig.s) == 1
+    if scalar256_is_zero(@sig.s) == 1
         return 0
 
     # Zero sensitive data
-    mem_zero(&k_bytes[0], 32)
-    scalar256_zero(&k)
-    scalar256_zero(&k_inv)
+    mem_zero(@k_bytes[0], 32)
+    scalar256_zero(@k)
+    scalar256_zero(@k_inv)
 
     return 1
 
@@ -1600,71 +1600,71 @@ pub fn ecdsa_p256_sign(sig: *EcdsaSignature, hash: *u8, priv_key: *Scalar256) ->
 
 pub fn ecdsa_p256_verify(hash: *u8, sig: *EcdsaSignature, pub_key: *P256Point) -> i32
     var n: Scalar256
-    get_p256_order(&n)
+    get_p256_order(@n)
 
     # Check r, s are in [1, n-1]
-    if scalar256_is_zero(&sig.r) == 1
+    if scalar256_is_zero(@sig.r) == 1
         return 0
-    if scalar256_cmp(&sig.r, &n) >= 0
+    if scalar256_cmp(@sig.r, @n) >= 0
         return 0
-    if scalar256_is_zero(&sig.s) == 1
+    if scalar256_is_zero(@sig.s) == 1
         return 0
-    if scalar256_cmp(&sig.s, &n) >= 0
+    if scalar256_cmp(@sig.s, @n) >= 0
         return 0
 
     # Convert hash to scalar z
     var z: Scalar256
-    scalar256_from_bytes(&z, hash)
-    if scalar256_cmp(&z, &n) >= 0
-        scalar256_sub(&z, &z, &n)
+    scalar256_from_bytes(@z, hash)
+    if scalar256_cmp(@z, @n) >= 0
+        scalar256_sub(@z, @z, @n)
 
     # w = s^(-1) mod n
     var w: Scalar256
-    scalar256_inv(&w, &sig.s)
+    scalar256_inv(@w, @sig.s)
 
     # u1 = z * w mod n
     var u1: Scalar256
-    scalar256_mul(&u1, &z, &w)
+    scalar256_mul(@u1, @z, @w)
 
     # u2 = r * w mod n
     var u2: Scalar256
-    scalar256_mul(&u2, &sig.r, &w)
+    scalar256_mul(@u2, @sig.r, @w)
 
     # Compute R' = u1*G + u2*Q
     var u1_bytes: [32]u8
     var u2_bytes: [32]u8
-    scalar256_to_bytes(&u1, &u1_bytes[0])
-    scalar256_to_bytes(&u2, &u2_bytes[0])
+    scalar256_to_bytes(@u1, @u1_bytes[0])
+    scalar256_to_bytes(@u2, @u2_bytes[0])
 
     var G: P256Point
-    p256_point_generator(&G)
+    p256_point_generator(@G)
 
     var u1G: P256Point
     var u2Q: P256Point
-    p256_scalar_mult(&u1G, &u1_bytes[0], 32, &G)
-    p256_scalar_mult(&u2Q, &u2_bytes[0], 32, pub_key)
+    p256_scalar_mult(@u1G, @u1_bytes[0], 32, @G)
+    p256_scalar_mult(@u2Q, @u2_bytes[0], 32, pub_key)
 
     var R_prime: P256Point
-    p256_point_add(&R_prime, &u1G, &u2Q)
+    p256_point_add(@R_prime, @u1G, @u2Q)
 
-    if p256_point_is_identity(&R_prime) == 1
+    if p256_point_is_identity(@R_prime) == 1
         return 0
 
     # Convert R' to affine
     var rx: FeP256
     var ry: FeP256
-    if p256_point_to_affine(&R_prime, &rx, &ry) == 0
+    if p256_point_to_affine(@R_prime, @rx, @ry) == 0
         return 0
 
     # v = rx mod n
     var rx_bytes: [32]u8
-    fep256_to_bytes(&rx, &rx_bytes[0])
+    fep256_to_bytes(@rx, @rx_bytes[0])
     var v: Scalar256
-    scalar256_from_bytes(&v, &rx_bytes[0])
-    scalar256_reduce(&v)
+    scalar256_from_bytes(@v, @rx_bytes[0])
+    scalar256_reduce(@v)
 
     # Check v == r
-    if scalar256_cmp(&v, &sig.r) == 0
+    if scalar256_cmp(@v, @sig.r) == 0
         return 1
     return 0
 
@@ -1676,14 +1676,14 @@ pub fn ecdsa_p256_verify(hash: *u8, sig: *EcdsaSignature, pub_key: *P256Point) -
 # Q = d * G
 pub fn ecdsa_p256_pubkey_from_privkey(pub_key: *P256Point, priv_key: *Scalar256)
     var priv_bytes: [32]u8
-    scalar256_to_bytes(priv_key, &priv_bytes[0])
+    scalar256_to_bytes(priv_key, @priv_bytes[0])
 
     var G: P256Point
-    p256_point_generator(&G)
+    p256_point_generator(@G)
 
-    p256_scalar_mult(pub_key, &priv_bytes[0], 32, &G)
+    p256_scalar_mult(pub_key, @priv_bytes[0], 32, @G)
 
-    mem_zero(&priv_bytes[0], 32)
+    mem_zero(@priv_bytes[0], 32)
 
 # ============================================================================
 # Signature Serialization
@@ -1691,10 +1691,10 @@ pub fn ecdsa_p256_pubkey_from_privkey(pub_key: *P256Point, priv_key: *Scalar256)
 
 # Serialize signature to bytes (r || s, 64 bytes total)
 pub fn ecdsa_sig_to_bytes(sig: *EcdsaSignature, out: *u8)
-    scalar256_to_bytes(&sig.r, &out[0])
-    scalar256_to_bytes(&sig.s, &out[32])
+    scalar256_to_bytes(@sig.r, @out[0])
+    scalar256_to_bytes(@sig.s, @out[32])
 
 # Deserialize signature from bytes
 pub fn ecdsa_sig_from_bytes(sig: *EcdsaSignature, data: *u8)
-    scalar256_from_bytes(&sig.r, &data[0])
-    scalar256_from_bytes(&sig.s, &data[32])
+    scalar256_from_bytes(@sig.r, @data[0])
+    scalar256_from_bytes(@sig.s, @data[32])

--- a/projects/cryptosec/lib/pem.ritz
+++ b/projects/cryptosec/lib/pem.ritz
@@ -46,7 +46,7 @@ pub struct PemEntry
 
 # Initialize a PEM entry
 pub fn pem_entry_init(entry: *PemEntry)
-    mem_zero(&entry.type_label[0], 64)
+    mem_zero(@entry.type_label[0], 64)
     entry.type_len = 0
     entry.der_data = null
     entry.der_len = 0
@@ -162,9 +162,9 @@ pub fn pem_parse_entry(data: *u8, data_len: i64, entry: *PemEntry, der_buf: *u8,
             actual_line_len -= 1
 
         if begin_found == 0
-            if is_begin_line(&data[pos], actual_line_len) == 1
+            if is_begin_line(@data[pos], actual_line_len) == 1
                 # Extract type
-                let type_len: i32 = extract_type(&data[pos], actual_line_len, &entry.type_label[0], PEM_MAX_TYPE_LEN)
+                let type_len: i32 = extract_type(@data[pos], actual_line_len, @entry.type_label[0], PEM_MAX_TYPE_LEN)
                 if type_len <= 0
                     return -1  # Invalid type
                 entry.type_len = type_len
@@ -176,13 +176,13 @@ pub fn pem_parse_entry(data: *u8, data_len: i64, entry: *PemEntry, der_buf: *u8,
                     base64_start = data_len
         else
             # Look for END line
-            if is_end_line(&data[pos], actual_line_len) == 1
+            if is_end_line(@data[pos], actual_line_len) == 1
                 # Found END, decode base64
                 base64_end = pos
 
                 # Decode base64 content
                 let base64_len: i64 = base64_end - base64_start
-                let decoded_len: i64 = base64_decode(&data[base64_start], base64_len, der_buf, der_cap)
+                let decoded_len: i64 = base64_decode(@data[base64_start], base64_len, der_buf, der_cap)
 
                 if decoded_len < 0
                     return -1  # Decode error
@@ -211,7 +211,7 @@ pub fn pem_parse_entry(data: *u8, data_len: i64, entry: *PemEntry, der_buf: *u8,
 pub fn pem_type_is(entry: *PemEntry, expected: *u8, expected_len: i32) -> i32
     if entry.type_len != expected_len
         return 0
-    return mem_cmp(&entry.type_label[0], expected, expected_len) == 0
+    return mem_cmp(@entry.type_label[0], expected, expected_len) == 0
 
 # ============================================================================
 # PEM Bundle Iterator
@@ -238,7 +238,7 @@ pub fn pem_iterator_next(iter: *PemIterator, entry: *PemEntry, der_buf: *u8, der
         return 0
 
     let remaining: i64 = iter.data_len - iter.pos
-    let result: i64 = pem_parse_entry(&iter.data[iter.pos], remaining, entry, der_buf, der_cap)
+    let result: i64 = pem_parse_entry(@iter.data[iter.pos], remaining, entry, der_buf, der_cap)
 
     if result > 0
         iter.pos = iter.pos + result
@@ -264,10 +264,10 @@ pub fn pem_count_certificates(data: *u8, data_len: i64) -> i32
             line_len = line_end - pos
 
         # Check for BEGIN CERTIFICATE
-        if is_begin_line(&data[pos], line_len) == 1
+        if is_begin_line(@data[pos], line_len) == 1
             # Check if it's a CERTIFICATE type
             var type_buf: [64]u8
-            let type_len: i32 = extract_type(&data[pos], line_len, &type_buf[0], 64)
+            let type_len: i32 = extract_type(@data[pos], line_len, @type_buf[0], 64)
             if type_len == 11
                 # "CERTIFICATE" is 11 chars
                 if type_buf[0] == 'C' && type_buf[1] == 'E' && type_buf[2] == 'R'
@@ -291,7 +291,7 @@ pub fn pem_count_certificates(data: *u8, data_len: i64) -> i32
 # Returns: 1 on success, 0 on error
 pub fn pem_parse_certificate(pem_data: *u8, pem_len: i64, der_out: *u8, der_cap: i64, der_len_out: *i64) -> i32
     var entry: PemEntry
-    let result: i64 = pem_parse_entry(pem_data, pem_len, &entry, der_out, der_cap)
+    let result: i64 = pem_parse_entry(pem_data, pem_len, @entry, der_out, der_cap)
 
     if result <= 0
         return 0

--- a/projects/cryptosec/lib/poly1305.ritz
+++ b/projects/cryptosec/lib/poly1305.ritz
@@ -49,10 +49,10 @@ fn poly_store32_le(dst: *u8, val: u32) -> void
 
 pub fn poly1305_init(ctx: *Poly1305, key: *u8) -> void
     # Load r and clamp
-    var t0: u32 = poly_load32_le(&key[0])
-    var t1: u32 = poly_load32_le(&key[4])
-    var t2: u32 = poly_load32_le(&key[8])
-    var t3: u32 = poly_load32_le(&key[12])
+    var t0: u32 = poly_load32_le(@key[0])
+    var t1: u32 = poly_load32_le(@key[4])
+    var t2: u32 = poly_load32_le(@key[8])
+    var t3: u32 = poly_load32_le(@key[12])
 
     # Clamp r according to RFC 8439
     # r[3], r[7], r[11], r[15] are ANDed with 0x0f
@@ -77,7 +77,7 @@ pub fn poly1305_init(ctx: *Poly1305, key: *u8) -> void
     ctx.h4 = 0
 
     # Store s (second half of key)
-    mem_copy(&ctx.s[0], &key[16], 16)
+    mem_copy(@ctx.s[0], @key[16], 16)
 
     # Initialize buffer
     ctx.buf_len = 0
@@ -85,10 +85,10 @@ pub fn poly1305_init(ctx: *Poly1305, key: *u8) -> void
 # Helper function to process a single 17-byte block (16 data bytes + terminator)
 fn poly_process_block(ctx: *Poly1305, block: *u8) -> void
     # Load into 32-bit words
-    let t0: u32 = poly_load32_le(&block[0])
-    let t1: u32 = poly_load32_le(&block[4])
-    let t2: u32 = poly_load32_le(&block[8])
-    let t3: u32 = poly_load32_le(&block[12])
+    let t0: u32 = poly_load32_le(@block[0])
+    let t1: u32 = poly_load32_le(@block[4])
+    let t2: u32 = poly_load32_le(@block[8])
+    let t3: u32 = poly_load32_le(@block[12])
     let t4: u32 = block[16] as u32  # Terminator byte (0x01 for full blocks)
 
     # Convert to radix-2^26 and add to h
@@ -147,16 +147,16 @@ pub fn poly1305_update(ctx: *Poly1305, data: *u8, len: i64) -> void
         if to_copy > space
             to_copy = space
 
-        mem_copy(&ctx.buf[ctx.buf_len], data, to_copy)
+        mem_copy(@ctx.buf[ctx.buf_len], data, to_copy)
         ctx.buf_len = ctx.buf_len + to_copy
         offset = to_copy
 
         # Process block if buffer is full
         if ctx.buf_len == 16
             var block: [17]u8
-            mem_copy(&block[0], &ctx.buf[0], 16)
+            mem_copy(@block[0], @ctx.buf[0], 16)
             block[16] = 1  # Add 0x01 byte after the 16 bytes
-            poly_process_block(ctx, &block[0])
+            poly_process_block(ctx, @block[0])
             ctx.buf_len = 0
 
     # Process remaining data
@@ -165,13 +165,13 @@ pub fn poly1305_update(ctx: *Poly1305, data: *u8, len: i64) -> void
         if remaining >= 16
             # Process full block
             var block: [17]u8
-            mem_copy(&block[0], &data[offset], 16)
+            mem_copy(@block[0], @data[offset], 16)
             block[16] = 1  # Add 0x01 byte
-            poly_process_block(ctx, &block[0])
+            poly_process_block(ctx, @block[0])
             offset = offset + 16
         else
             # Buffer partial block
-            mem_copy(&ctx.buf[0], &data[offset], remaining)
+            mem_copy(@ctx.buf[0], @data[offset], remaining)
             ctx.buf_len = remaining
             offset = len
 
@@ -180,10 +180,10 @@ pub fn poly1305_final(ctx: *Poly1305, out: *u8) -> void
     if ctx.buf_len > 0
         # Create a block with the buffered data and add the 0x01 terminator
         var block: [17]u8
-        mem_zero(&block[0], 17)
-        mem_copy(&block[0], &ctx.buf[0], ctx.buf_len)
+        mem_zero(@block[0], 17)
+        mem_copy(@block[0], @ctx.buf[0], ctx.buf_len)
         block[ctx.buf_len] = 1  # Add 0x01 after the partial block
-        poly_process_block(ctx, &block[0])
+        poly_process_block(ctx, @block[0])
 
     # Full reduction - propagate carries through all limbs
     var h0: u32 = ctx.h0
@@ -267,20 +267,20 @@ pub fn poly1305_final(ctx: *Poly1305, out: *u8) -> void
     var f3: u64 = (((h3 >> 18) & 0xff) as u64) | (((h4 & 0xffffff) as u64) << 8)
 
     # Add s (the final one-time-pad addition)
-    f0 = f0 + (poly_load32_le(&ctx.s[0]) as u64)
-    f1 = f1 + (poly_load32_le(&ctx.s[4]) as u64)
-    f2 = f2 + (poly_load32_le(&ctx.s[8]) as u64)
-    f3 = f3 + (poly_load32_le(&ctx.s[12]) as u64)
+    f0 = f0 + (poly_load32_le(@ctx.s[0]) as u64)
+    f1 = f1 + (poly_load32_le(@ctx.s[4]) as u64)
+    f2 = f2 + (poly_load32_le(@ctx.s[8]) as u64)
+    f3 = f3 + (poly_load32_le(@ctx.s[12]) as u64)
 
     # Propagate carries from addition
     f1 = f1 + (f0 >> 32)
     f2 = f2 + (f1 >> 32)
     f3 = f3 + (f2 >> 32)
 
-    poly_store32_le(&out[0], (f0 & 0xffffffff) as u32)
-    poly_store32_le(&out[4], (f1 & 0xffffffff) as u32)
-    poly_store32_le(&out[8], (f2 & 0xffffffff) as u32)
-    poly_store32_le(&out[12], (f3 & 0xffffffff) as u32)
+    poly_store32_le(@out[0], (f0 & 0xffffffff) as u32)
+    poly_store32_le(@out[4], (f1 & 0xffffffff) as u32)
+    poly_store32_le(@out[8], (f2 & 0xffffffff) as u32)
+    poly_store32_le(@out[12], (f3 & 0xffffffff) as u32)
 
 # =============================================================================
 # One-shot API
@@ -288,7 +288,7 @@ pub fn poly1305_final(ctx: *Poly1305, out: *u8) -> void
 
 pub fn poly1305_mac(key: *u8, data: *u8, len: i64, out: *u8) -> void
     var ctx: Poly1305
-    poly1305_init(&ctx, key)
+    poly1305_init(@ctx, key)
     if len > 0
-        poly1305_update(&ctx, data, len)
-    poly1305_final(&ctx, out)
+        poly1305_update(@ctx, data, len)
+    poly1305_final(@ctx, out)

--- a/projects/cryptosec/lib/random.ritz
+++ b/projects/cryptosec/lib/random.ritz
@@ -56,7 +56,7 @@ pub fn random_bytes(buf: *u8, len: u64) -> i32
 # Get a single random u64
 pub fn random_u64() -> u64
     var buf: [8]u8
-    let result: i32 = random_bytes(&buf[0], 8)
+    let result: i32 = random_bytes(@buf[0], 8)
     if result < 0
         # Fallback: return 0 on error (should never happen on healthy system)
         return 0
@@ -78,7 +78,7 @@ pub fn random_u64() -> u64
 # Get a single random u32
 pub fn random_u32() -> u32
     var buf: [4]u8
-    let result: i32 = random_bytes(&buf[0], 4)
+    let result: i32 = random_bytes(@buf[0], 4)
     if result < 0
         return 0
 

--- a/projects/cryptosec/lib/rsa.ritz
+++ b/projects/cryptosec/lib/rsa.ritz
@@ -38,7 +38,7 @@ pub struct RsaPublicKey
     e: u32              # Public exponent (usually 65537)
 
 pub fn rsa_pubkey_init(key: *RsaPublicKey)
-    mem_zero(&key.n[0], 512)
+    mem_zero(@key.n[0], 512)
     key.n_len = 0
     key.e = 0
 
@@ -59,32 +59,32 @@ pub fn rsa_parse_public_key(der: *u8, der_len: i32, key: *RsaPublicKey) -> i32
     rsa_pubkey_init(key)
 
     var parser: DerParser
-    der_parser_init(&parser, der, der_len as u64)
+    der_parser_init(@parser, der, der_len as u64)
 
     var outer: DerElement
-    if der_parse_element(&parser, &outer) != 0
+    if der_parse_element(@parser, @outer) != 0
         return -1
 
-    if der_is_sequence(&outer) != 1
+    if der_is_sequence(@outer) != 1
         return -1
 
     # Parse inside the sequence
     var inner_parser: DerParser
-    der_parser_init(&inner_parser, outer.content, outer.content_len)
+    der_parser_init(@inner_parser, outer.content, outer.content_len)
 
     var first: DerElement
-    if der_parse_element(&inner_parser, &first) != 0
+    if der_parse_element(@inner_parser, @first) != 0
         return -1
 
     # Check if this is SubjectPublicKeyInfo (first elem is SEQUENCE for algorithm)
     # or raw RSAPublicKey (first elem is INTEGER for modulus)
-    if der_is_sequence(&first) == 1
+    if der_is_sequence(@first) == 1
         # SubjectPublicKeyInfo format - skip AlgorithmIdentifier, get BIT STRING
         var bit_string: DerElement
-        if der_parse_element(&inner_parser, &bit_string) != 0
+        if der_parse_element(@inner_parser, @bit_string) != 0
             return -2
 
-        if der_is_bit_string(&bit_string) != 1
+        if der_is_bit_string(@bit_string) != 1
             return -3
 
         # BIT STRING content: first byte is unused bits count
@@ -97,18 +97,18 @@ pub fn rsa_parse_public_key(der: *u8, der_len: i32, key: *RsaPublicKey) -> i32
 
         # Parse the RSAPublicKey inside the BIT STRING
         var rsa_parser: DerParser
-        der_parser_init(&rsa_parser, &bit_string.content[1], bit_string.content_len - 1)
+        der_parser_init(@rsa_parser, @bit_string.content[1], bit_string.content_len - 1)
 
         var rsa_seq: DerElement
-        if der_parse_element(&rsa_parser, &rsa_seq) != 0
+        if der_parse_element(@rsa_parser, @rsa_seq) != 0
             return -6
 
-        if der_is_sequence(&rsa_seq) != 1
+        if der_is_sequence(@rsa_seq) != 1
             return -7
 
         return rsa_parse_pubkey_sequence(rsa_seq.content, rsa_seq.content_len as i32, key)
 
-    else if der_is_integer(&first) == 1
+    else if der_is_integer(@first) == 1
         # Raw RSAPublicKey format - first is already the modulus
         # Parse modulus from first element
         if first.content_len > RSA_MAX_MODULUS_BYTES as u64
@@ -123,19 +123,19 @@ pub fn rsa_parse_public_key(der: *u8, der_len: i32, key: *RsaPublicKey) -> i32
         if mod_len > RSA_MAX_MODULUS_BYTES as u64
             return -11
 
-        mem_copy(&key.n[0], &first.content[start], mod_len)
+        mem_copy(@key.n[0], @first.content[start], mod_len)
         key.n_len = mod_len as i32
 
         # Parse exponent
         var exp_elem: DerElement
-        if der_parse_element(&inner_parser, &exp_elem) != 0
+        if der_parse_element(@inner_parser, @exp_elem) != 0
             return -12
 
-        if der_is_integer(&exp_elem) != 1
+        if der_is_integer(@exp_elem) != 1
             return -13
 
         var exp_val: u64 = 0
-        if der_integer_to_u64(&exp_elem, &exp_val) != 0
+        if der_integer_to_u64(@exp_elem, @exp_val) != 0
             return -14
 
         if exp_val > 0xffffffff
@@ -149,14 +149,14 @@ pub fn rsa_parse_public_key(der: *u8, der_len: i32, key: *RsaPublicKey) -> i32
 # Parse RSAPublicKey SEQUENCE content
 fn rsa_parse_pubkey_sequence(data: *u8, len: i32, key: *RsaPublicKey) -> i32
     var parser: DerParser
-    der_parser_init(&parser, data, len as u64)
+    der_parser_init(@parser, data, len as u64)
 
     # Parse modulus
     var mod_elem: DerElement
-    if der_parse_element(&parser, &mod_elem) != 0
+    if der_parse_element(@parser, @mod_elem) != 0
         return -30
 
-    if der_is_integer(&mod_elem) != 1
+    if der_is_integer(@mod_elem) != 1
         return -31
 
     if mod_elem.content_len > RSA_MAX_MODULUS_BYTES as u64
@@ -171,19 +171,19 @@ fn rsa_parse_pubkey_sequence(data: *u8, len: i32, key: *RsaPublicKey) -> i32
     if mod_len > RSA_MAX_MODULUS_BYTES as u64
         return -33
 
-    mem_copy(&key.n[0], &mod_elem.content[start], mod_len)
+    mem_copy(@key.n[0], @mod_elem.content[start], mod_len)
     key.n_len = mod_len as i32
 
     # Parse exponent
     var exp_elem: DerElement
-    if der_parse_element(&parser, &exp_elem) != 0
+    if der_parse_element(@parser, @exp_elem) != 0
         return -34
 
-    if der_is_integer(&exp_elem) != 1
+    if der_is_integer(@exp_elem) != 1
         return -35
 
     var exp_val: u64 = 0
-    if der_integer_to_u64(&exp_elem, &exp_val) != 0
+    if der_integer_to_u64(@exp_elem, @exp_val) != 0
         return -36
 
     if exp_val > 0xffffffff
@@ -211,23 +211,23 @@ fn rsa_verify_pkcs1(key: *RsaPublicKey, hash: *u8, hash_len: i32, hash_oid_prefi
 
     # Convert signature to BigInt
     var s: BigInt
-    bigint_from_bytes(&s, sig, sig_len)
+    bigint_from_bytes(@s, sig, sig_len)
 
     # Convert modulus to BigInt
     var n: BigInt
-    bigint_from_bytes(&n, &key.n[0], key.n_len)
+    bigint_from_bytes(@n, @key.n[0], key.n_len)
 
     # Check s < n
-    if bigint_ge(&s, &n) == 1
+    if bigint_ge(@s, @n) == 1
         return 0
 
     # Compute m = s^e mod n
     var m: BigInt
-    bigint_mod_exp_u32(&m, &s, key.e, &n)
+    bigint_mod_exp_u32(@m, @s, key.e, @n)
 
     # Convert result to bytes (same length as modulus)
     var em: [512]u8
-    bigint_to_bytes_fixed(&m, &em[0], key.n_len)
+    bigint_to_bytes_fixed(@m, @em[0], key.n_len)
 
     # Verify PKCS#1 v1.5 padding: 0x00 || 0x01 || PS || 0x00 || DigestInfo
     # DigestInfo length = prefix_len + hash_len
@@ -324,19 +324,19 @@ pub fn get_sha256_digest_info_prefix(out: *u8) -> i32
 pub fn rsa_verify_pkcs1_sha256(key: *RsaPublicKey, msg: *u8, msg_len: i64, sig: *u8, sig_len: i32) -> i32
     # Hash the message
     var hash: [32]u8
-    sha256(msg, msg_len, &hash[0])
+    sha256(msg, msg_len, @hash[0])
 
     # Get DigestInfo prefix
     var prefix: [19]u8
-    let prefix_len: i32 = get_sha256_digest_info_prefix(&prefix[0])
+    let prefix_len: i32 = get_sha256_digest_info_prefix(@prefix[0])
 
-    return rsa_verify_pkcs1(key, &hash[0], 32, &prefix[0], prefix_len, sig, sig_len)
+    return rsa_verify_pkcs1(key, @hash[0], 32, @prefix[0], prefix_len, sig, sig_len)
 
 # Verify RSA-SHA256 signature with pre-computed hash
 pub fn rsa_verify_pkcs1_sha256_hash(key: *RsaPublicKey, hash: *u8, sig: *u8, sig_len: i32) -> i32
     var prefix: [19]u8
-    let prefix_len: i32 = get_sha256_digest_info_prefix(&prefix[0])
-    return rsa_verify_pkcs1(key, hash, 32, &prefix[0], prefix_len, sig, sig_len)
+    let prefix_len: i32 = get_sha256_digest_info_prefix(@prefix[0])
+    return rsa_verify_pkcs1(key, hash, 32, @prefix[0], prefix_len, sig, sig_len)
 
 # ============================================================================
 # SHA-384 Signature Verification
@@ -369,17 +369,17 @@ pub fn get_sha384_digest_info_prefix(out: *u8) -> i32
 
 pub fn rsa_verify_pkcs1_sha384(key: *RsaPublicKey, msg: *u8, msg_len: i64, sig: *u8, sig_len: i32) -> i32
     var hash: [48]u8
-    sha384(msg, msg_len, &hash[0])
+    sha384(msg, msg_len, @hash[0])
 
     var prefix: [19]u8
-    let prefix_len: i32 = get_sha384_digest_info_prefix(&prefix[0])
+    let prefix_len: i32 = get_sha384_digest_info_prefix(@prefix[0])
 
-    return rsa_verify_pkcs1(key, &hash[0], 48, &prefix[0], prefix_len, sig, sig_len)
+    return rsa_verify_pkcs1(key, @hash[0], 48, @prefix[0], prefix_len, sig, sig_len)
 
 pub fn rsa_verify_pkcs1_sha384_hash(key: *RsaPublicKey, hash: *u8, sig: *u8, sig_len: i32) -> i32
     var prefix: [19]u8
-    let prefix_len: i32 = get_sha384_digest_info_prefix(&prefix[0])
-    return rsa_verify_pkcs1(key, hash, 48, &prefix[0], prefix_len, sig, sig_len)
+    let prefix_len: i32 = get_sha384_digest_info_prefix(@prefix[0])
+    return rsa_verify_pkcs1(key, hash, 48, @prefix[0], prefix_len, sig, sig_len)
 
 # ============================================================================
 # SHA-512 Signature Verification
@@ -412,14 +412,14 @@ pub fn get_sha512_digest_info_prefix(out: *u8) -> i32
 
 pub fn rsa_verify_pkcs1_sha512(key: *RsaPublicKey, msg: *u8, msg_len: i64, sig: *u8, sig_len: i32) -> i32
     var hash: [64]u8
-    sha512(msg, msg_len, &hash[0])
+    sha512(msg, msg_len, @hash[0])
 
     var prefix: [19]u8
-    let prefix_len: i32 = get_sha512_digest_info_prefix(&prefix[0])
+    let prefix_len: i32 = get_sha512_digest_info_prefix(@prefix[0])
 
-    return rsa_verify_pkcs1(key, &hash[0], 64, &prefix[0], prefix_len, sig, sig_len)
+    return rsa_verify_pkcs1(key, @hash[0], 64, @prefix[0], prefix_len, sig, sig_len)
 
 pub fn rsa_verify_pkcs1_sha512_hash(key: *RsaPublicKey, hash: *u8, sig: *u8, sig_len: i32) -> i32
     var prefix: [19]u8
-    let prefix_len: i32 = get_sha512_digest_info_prefix(&prefix[0])
-    return rsa_verify_pkcs1(key, hash, 64, &prefix[0], prefix_len, sig, sig_len)
+    let prefix_len: i32 = get_sha512_digest_info_prefix(@prefix[0])
+    return rsa_verify_pkcs1(key, hash, 64, @prefix[0], prefix_len, sig, sig_len)

--- a/projects/cryptosec/lib/sha256.ritz
+++ b/projects/cryptosec/lib/sha256.ritz
@@ -257,8 +257,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     cdgh_arr[2] = ctx.h6 as i32
     cdgh_arr[3] = ctx.h7 as i32
 
-    var abef: v4i32 = simd_loadu(&abef_arr[0])
-    var cdgh: v4i32 = simd_loadu(&cdgh_arr[0])
+    var abef: v4i32 = simd_loadu(@abef_arr[0])
+    var cdgh: v4i32 = simd_loadu(@cdgh_arr[0])
 
     # Save original state for final addition
     var abef_save: v4i32 = abef
@@ -292,10 +292,10 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
         msg3[i] = ((block[off] as i32) << 24) | ((block[off + 1] as i32) << 16) | ((block[off + 2] as i32) << 8) | (block[off + 3] as i32)
         i += 1
 
-    var vmsg0: v4i32 = simd_loadu(&msg0[0])
-    var vmsg1: v4i32 = simd_loadu(&msg1[0])
-    var vmsg2: v4i32 = simd_loadu(&msg2[0])
-    var vmsg3: v4i32 = simd_loadu(&msg3[0])
+    var vmsg0: v4i32 = simd_loadu(@msg0[0])
+    var vmsg1: v4i32 = simd_loadu(@msg1[0])
+    var vmsg2: v4i32 = simd_loadu(@msg2[0])
+    var vmsg3: v4i32 = simd_loadu(@msg3[0])
 
     # Perform 64 rounds (16 iterations, 4 rounds each via 2x sha256rnds2)
     # Each iteration:
@@ -308,8 +308,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     var tmp: v4i32
 
     # Rounds 0-3
-    get_k_pair(0, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(0, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg0, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)  # Move upper 64 bits to lower
@@ -317,8 +317,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg0 = sha256msg1(vmsg0, vmsg1)
 
     # Rounds 4-7
-    get_k_pair(4, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(4, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg1, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -327,8 +327,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg0 = sha256msg2(vmsg0, vmsg3)
 
     # Rounds 8-11
-    get_k_pair(8, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(8, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg2, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -337,8 +337,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg1 = sha256msg2(vmsg1, vmsg0)
 
     # Rounds 12-15
-    get_k_pair(12, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(12, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg3, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -347,8 +347,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg2 = sha256msg2(vmsg2, vmsg1)
 
     # Rounds 16-19
-    get_k_pair(16, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(16, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg0, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -357,8 +357,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg3 = sha256msg2(vmsg3, vmsg2)
 
     # Rounds 20-23
-    get_k_pair(20, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(20, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg1, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -367,8 +367,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg0 = sha256msg2(vmsg0, vmsg3)
 
     # Rounds 24-27
-    get_k_pair(24, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(24, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg2, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -377,8 +377,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg1 = sha256msg2(vmsg1, vmsg0)
 
     # Rounds 28-31
-    get_k_pair(28, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(28, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg3, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -387,8 +387,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg2 = sha256msg2(vmsg2, vmsg1)
 
     # Rounds 32-35
-    get_k_pair(32, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(32, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg0, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -397,8 +397,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg3 = sha256msg2(vmsg3, vmsg2)
 
     # Rounds 36-39
-    get_k_pair(36, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(36, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg1, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -407,8 +407,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg0 = sha256msg2(vmsg0, vmsg3)
 
     # Rounds 40-43
-    get_k_pair(40, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(40, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg2, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -417,8 +417,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg1 = sha256msg2(vmsg1, vmsg0)
 
     # Rounds 44-47
-    get_k_pair(44, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(44, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg3, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -427,8 +427,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg2 = sha256msg2(vmsg2, vmsg1)
 
     # Rounds 48-51
-    get_k_pair(48, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(48, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg0, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -437,8 +437,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg3 = sha256msg2(vmsg3, vmsg2)
 
     # Rounds 52-55
-    get_k_pair(52, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(52, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg1, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -447,8 +447,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg0 = sha256msg2(vmsg0, vmsg3)
 
     # Rounds 56-59
-    get_k_pair(56, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(56, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg2, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -456,8 +456,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
     vmsg1 = sha256msg2(vmsg1, vmsg0)
 
     # Rounds 60-63 (final, no message schedule update needed)
-    get_k_pair(60, &k[0])
-    wk = simd_loadu(&k[0])
+    get_k_pair(60, @k[0])
+    wk = simd_loadu(@k[0])
     wk = simd_add(vmsg3, wk)
     cdgh = sha256rnds2(cdgh, abef, wk)
     tmp = simd_shuffle(wk, wk, 2, 3, 0, 1)
@@ -469,8 +469,8 @@ fn sha256_transform_ni(ctx: *Sha256, block: *u8)
 
     # Store back to context
     # abef = [a, b, e, f], cdgh = [c, d, g, h]
-    simd_storeu(&abef_arr[0], abef)
-    simd_storeu(&cdgh_arr[0], cdgh)
+    simd_storeu(@abef_arr[0], abef)
+    simd_storeu(@cdgh_arr[0], cdgh)
 
     ctx.h0 = abef_arr[0] as u32
     ctx.h1 = abef_arr[1] as u32
@@ -604,7 +604,7 @@ pub fn sha256_update(ctx: *Sha256, data: *u8, len: u64)
 
         # If buffer is full, process it
         if ctx.buflen == 64
-            sha256_transform(ctx, &ctx.buffer[0])
+            sha256_transform(ctx, @ctx.buffer[0])
             ctx.buflen = 0
 
     # Process full blocks directly from input
@@ -633,7 +633,7 @@ pub fn sha256_final(ctx: *Sha256, out: *u8)
         while ctx.buflen < 64
             ctx.buffer[ctx.buflen] = 0
             ctx.buflen = ctx.buflen + 1
-        sha256_transform(ctx, &ctx.buffer[0])
+        sha256_transform(ctx, @ctx.buffer[0])
         ctx.buflen = 0
 
     # Pad with zeros up to length field
@@ -652,7 +652,7 @@ pub fn sha256_final(ctx: *Sha256, out: *u8)
     ctx.buffer[63] = total_bits as u8
 
     # Process final block
-    sha256_transform(ctx, &ctx.buffer[0])
+    sha256_transform(ctx, @ctx.buffer[0])
 
     # Output hash (big-endian)
     out[0] = (ctx.h0 >> 24) as u8
@@ -691,6 +691,6 @@ pub fn sha256_final(ctx: *Sha256, out: *u8)
 # One-shot hash function
 pub fn sha256(data: *u8, len: u64, out: *u8)
     var ctx: Sha256
-    sha256_init(&ctx)
-    sha256_update(&ctx, data, len)
-    sha256_final(&ctx, out)
+    sha256_init(@ctx)
+    sha256_update(@ctx, data, len)
+    sha256_final(@ctx, out)

--- a/projects/cryptosec/lib/sha512.ritz
+++ b/projects/cryptosec/lib/sha512.ritz
@@ -356,11 +356,11 @@ fn sha512_transform_internal(h0: *u64, h1: *u64, h2: *u64, h3: *u64, h4: *u64, h
 
 # Transform wrapper for Sha512
 fn sha512_transform(ctx: *Sha512, block: *u8)
-    sha512_transform_internal(&ctx.h0, &ctx.h1, &ctx.h2, &ctx.h3, &ctx.h4, &ctx.h5, &ctx.h6, &ctx.h7, block)
+    sha512_transform_internal(@ctx.h0, @ctx.h1, @ctx.h2, @ctx.h3, @ctx.h4, @ctx.h5, @ctx.h6, @ctx.h7, block)
 
 # Transform wrapper for Sha384
 fn sha384_transform(ctx: *Sha384, block: *u8)
-    sha512_transform_internal(&ctx.h0, &ctx.h1, &ctx.h2, &ctx.h3, &ctx.h4, &ctx.h5, &ctx.h6, &ctx.h7, block)
+    sha512_transform_internal(@ctx.h0, @ctx.h1, @ctx.h2, @ctx.h3, @ctx.h4, @ctx.h5, @ctx.h6, @ctx.h7, block)
 
 # ============================================================================
 # Public API - SHA-512
@@ -426,7 +426,7 @@ pub fn sha512_update(ctx: *Sha512, data: *u8, len: u64)
 
         # If buffer is full, process it
         if ctx.buflen == 128
-            sha512_transform(ctx, &ctx.buffer[0])
+            sha512_transform(ctx, @ctx.buffer[0])
             ctx.buflen = 0
 
     # Process full blocks directly from input
@@ -454,7 +454,7 @@ pub fn sha512_final(ctx: *Sha512, out: *u8)
         while ctx.buflen < 128
             ctx.buffer[ctx.buflen] = 0
             ctx.buflen = ctx.buflen + 1
-        sha512_transform(ctx, &ctx.buffer[0])
+        sha512_transform(ctx, @ctx.buffer[0])
         ctx.buflen = 0
 
     # Pad with zeros up to length field
@@ -481,7 +481,7 @@ pub fn sha512_final(ctx: *Sha512, out: *u8)
     ctx.buffer[127] = total_bits as u8
 
     # Process final block
-    sha512_transform(ctx, &ctx.buffer[0])
+    sha512_transform(ctx, @ctx.buffer[0])
 
     # Output hash (big-endian)
     out[0] = (ctx.h0 >> 56) as u8
@@ -552,9 +552,9 @@ pub fn sha512_final(ctx: *Sha512, out: *u8)
 # One-shot SHA-512 hash function
 pub fn sha512(data: *u8, len: u64, out: *u8)
     var ctx: Sha512
-    sha512_init(&ctx)
-    sha512_update(&ctx, data, len)
-    sha512_final(&ctx, out)
+    sha512_init(@ctx)
+    sha512_update(@ctx, data, len)
+    sha512_final(@ctx, out)
 
 # ============================================================================
 # Public API - SHA-384
@@ -617,7 +617,7 @@ pub fn sha384_update(ctx: *Sha384, data: *u8, len: u64)
         offset = to_copy
 
         if ctx.buflen == 128
-            sha384_transform(ctx, &ctx.buffer[0])
+            sha384_transform(ctx, @ctx.buffer[0])
             ctx.buflen = 0
 
     while offset + 128 <= len
@@ -640,7 +640,7 @@ pub fn sha384_final(ctx: *Sha384, out: *u8)
         while ctx.buflen < 128
             ctx.buffer[ctx.buflen] = 0
             ctx.buflen = ctx.buflen + 1
-        sha384_transform(ctx, &ctx.buffer[0])
+        sha384_transform(ctx, @ctx.buffer[0])
         ctx.buflen = 0
 
     while ctx.buflen < 112
@@ -664,7 +664,7 @@ pub fn sha384_final(ctx: *Sha384, out: *u8)
     ctx.buffer[126] = (total_bits >> 8) as u8
     ctx.buffer[127] = total_bits as u8
 
-    sha384_transform(ctx, &ctx.buffer[0])
+    sha384_transform(ctx, @ctx.buffer[0])
 
     # Output first 6 words (48 bytes) - truncate h6 and h7
     out[0] = (ctx.h0 >> 56) as u8
@@ -719,6 +719,6 @@ pub fn sha384_final(ctx: *Sha384, out: *u8)
 # One-shot SHA-384 hash function
 pub fn sha384(data: *u8, len: u64, out: *u8)
     var ctx: Sha384
-    sha384_init(&ctx)
-    sha384_update(&ctx, data, len)
-    sha384_final(&ctx, out)
+    sha384_init(@ctx)
+    sha384_update(@ctx, data, len)
+    sha384_final(@ctx, out)

--- a/projects/cryptosec/lib/tls13_client.ritz
+++ b/projects/cryptosec/lib/tls13_client.ritz
@@ -164,20 +164,20 @@ pub fn tls_client_init(client: *TlsClient, config: *TlsConfig)
     mem_zero(client as *u8, 8192 as u64)  # Approximate size
 
     # Copy config
-    mem_copy(&client.config as *u8, config as *u8, 280 as u64)
+    mem_copy(@client.config as *u8, config as *u8, 280 as u64)
 
     # Initialize transcript
-    transcript_init(&client.transcript)
+    transcript_init(@client.transcript)
 
     # Initialize key schedule
-    tls13_key_schedule_init(&client.key_schedule)
+    tls13_key_schedule_init(@client.key_schedule)
 
     # Initialize ClientHello
-    client_hello_init(&client.client_hello)
+    client_hello_init(@client.client_hello)
 
     # Set hostname from config
     if config.hostname_len > 0
-        client_hello_set_hostname(&client.client_hello, &config.hostname[0], config.hostname_len)
+        client_hello_set_hostname(@client.client_hello, @config.hostname[0], config.hostname_len)
 
     # Set cipher suites from config
     var i: i32 = 0
@@ -191,9 +191,9 @@ pub fn tls_client_init(client: *TlsClient, config: *TlsConfig)
 # Free client resources
 pub fn tls_client_free(client: *TlsClient)
     # Zero sensitive data
-    mem_zero(&client.shared_secret[0], 32)
-    mem_zero(&client.key_schedule as *u8, 296 as u64)  # Approximate
-    mem_zero(&client.client_hello.x25519_private[0], 32)
+    mem_zero(@client.shared_secret[0], 32)
+    mem_zero(@client.key_schedule as *u8, 296 as u64)  # Approximate
+    mem_zero(@client.client_hello.x25519_private[0], 32)
 
 # ============================================================================
 # Start Handshake - Generate ClientHello
@@ -207,13 +207,13 @@ pub fn tls_client_start(client: *TlsClient, out: *u8, out_cap: i64) -> i64
         return -1
 
     # Serialize ClientHello
-    let ch_len: i64 = client_hello_serialize(&client.client_hello, &client.send_buf[0], 4096)
+    let ch_len: i64 = client_hello_serialize(@client.client_hello, @client.send_buf[0], 4096)
     if ch_len < 0
         client.last_error = TLS_ERR_PARSE_ERROR
         return -1
 
     # Update transcript with ClientHello
-    transcript_update(&client.transcript, &client.send_buf[0], ch_len)
+    transcript_update(@client.transcript, @client.send_buf[0], ch_len)
 
     # Wrap in TLS record header
     # ContentType (1) + Version (2) + Length (2) + data
@@ -226,7 +226,7 @@ pub fn tls_client_start(client: *TlsClient, out: *u8, out_cap: i64) -> i64
     out[2] = 0x01  # Legacy version TLS 1.0
     out[3] = ((ch_len >> 8) & 0xff) as u8
     out[4] = (ch_len & 0xff) as u8
-    mem_copy(out + 5, &client.send_buf[0], ch_len as u64)
+    mem_copy(out + 5, @client.send_buf[0], ch_len as u64)
 
     client.state = TLS_STATE_CLIENT_HELLO_SENT
     return ch_len + 5
@@ -256,7 +256,7 @@ pub fn tls_client_process(client: *TlsClient, data: *u8, data_len: i64, out: *u8
             client.last_error = TLS_ERR_BUFFER_TOO_SMALL
             client.state = TLS_STATE_ERROR
             return TLS_RESULT_ERROR
-        mem_copy(&client.recv_buf[client.recv_len], data, data_len as u64)
+        mem_copy(@client.recv_buf[client.recv_len], data, data_len as u64)
         client.recv_len = client.recv_len + data_len
 
     # Process based on current state
@@ -307,7 +307,7 @@ fn process_server_hello(client: *TlsClient, out: *u8, out_cap: i64, out_len: *i6
 
     # Parse handshake header
     var hdr: HandshakeHeader
-    if handshake_header_parse(&client.recv_buf[5], record_len, &hdr) != 0
+    if handshake_header_parse(@client.recv_buf[5], record_len, @hdr) != 0
         client.last_error = TLS_ERR_PARSE_ERROR
         client.state = TLS_STATE_ERROR
         return TLS_RESULT_ERROR
@@ -318,7 +318,7 @@ fn process_server_hello(client: *TlsClient, out: *u8, out_cap: i64, out_len: *i6
         return TLS_RESULT_ERROR
 
     # Parse ServerHello
-    let sh_result: i32 = server_hello_parse(&client.recv_buf[9], hdr.length, &client.server_hello)
+    let sh_result: i32 = server_hello_parse(@client.recv_buf[9], hdr.length, @client.server_hello)
     if sh_result != 0
         client.last_error = TLS_ERR_PARSE_ERROR
         client.state = TLS_STATE_ERROR
@@ -340,25 +340,25 @@ fn process_server_hello(client: *TlsClient, out: *u8, out_cap: i64, out_len: *i6
     client.cipher_suite = client.server_hello.cipher_suite
 
     # Compute shared secret
-    x25519(&client.shared_secret[0], &client.client_hello.x25519_private[0], &client.server_hello.x25519_public[0])
+    x25519(@client.shared_secret[0], @client.client_hello.x25519_private[0], @client.server_hello.x25519_public[0])
 
     # Update transcript with full ServerHello (including handshake header)
     let sh_total: i64 = 4 + hdr.length
-    transcript_update(&client.transcript, &client.recv_buf[5], sh_total)
+    transcript_update(@client.transcript, @client.recv_buf[5], sh_total)
 
     # Derive handshake keys
     var th_out: [32]u8
-    transcript_hash(&client.transcript, &th_out[0])
+    transcript_hash(@client.transcript, @th_out[0])
 
-    tls13_key_schedule_derive_handshake(&client.key_schedule, &client.shared_secret[0], 32, &th_out[0])
-    tls13_key_schedule_derive_handshake_keys(&client.key_schedule, 16, 12)  # AES-128-GCM
+    tls13_key_schedule_derive_handshake(@client.key_schedule, @client.shared_secret[0], 32, @th_out[0])
+    tls13_key_schedule_derive_handshake_keys(@client.key_schedule, 16, 12)  # AES-128-GCM
 
     # Set up record layer for encrypted handshake
-    tls_record_state_init(&client.read_state)
-    tls_record_state_set_keys(&client.read_state, &client.key_schedule.client_write_key[0], &client.key_schedule.client_write_iv[0], &client.key_schedule.server_write_key[0], &client.key_schedule.server_write_iv[0], 16)
+    tls_record_state_init(@client.read_state)
+    tls_record_state_set_keys(@client.read_state, @client.key_schedule.client_write_key[0], @client.key_schedule.client_write_iv[0], @client.key_schedule.server_write_key[0], @client.key_schedule.server_write_iv[0], 16)
 
-    tls_record_state_init(&client.write_state)
-    tls_record_state_set_keys(&client.write_state, &client.key_schedule.client_write_key[0], &client.key_schedule.client_write_iv[0], &client.key_schedule.server_write_key[0], &client.key_schedule.server_write_iv[0], 16)
+    tls_record_state_init(@client.write_state)
+    tls_record_state_set_keys(@client.write_state, @client.key_schedule.client_write_key[0], @client.key_schedule.client_write_iv[0], @client.key_schedule.server_write_key[0], @client.key_schedule.server_write_iv[0], 16)
 
     # Consume processed record
     let consumed: i64 = 5 + record_len
@@ -401,7 +401,7 @@ fn process_encrypted_handshake(client: *TlsClient, out: *u8, out_cap: i64, out_l
     var plaintext_len: i64 = 0
     var inner_type: u8 = 0
 
-    let decrypt_result: i32 = tls_record_state_server_decrypt(&client.read_state, &client.recv_buf[5], record_len as i32, &plaintext[0], 4096, &inner_type)
+    let decrypt_result: i32 = tls_record_state_server_decrypt(@client.read_state, @client.recv_buf[5], record_len as i32, @plaintext[0], 4096, @inner_type)
     plaintext_len = decrypt_result as i64
 
     if decrypt_result < 0
@@ -419,7 +419,7 @@ fn process_encrypted_handshake(client: *TlsClient, out: *u8, out_cap: i64, out_l
     var pos: i64 = 0
     while pos + 4 <= plaintext_len
         var hdr: HandshakeHeader
-        if handshake_header_parse(&plaintext[pos], plaintext_len - pos, &hdr) != 0
+        if handshake_header_parse(@plaintext[pos], plaintext_len - pos, @hdr) != 0
             client.last_error = TLS_ERR_PARSE_ERROR
             client.state = TLS_STATE_ERROR
             return TLS_RESULT_ERROR
@@ -434,12 +434,12 @@ fn process_encrypted_handshake(client: *TlsClient, out: *u8, out_cap: i64, out_l
             return TLS_RESULT_ERROR
 
         # Process based on message type
-        let result: i32 = process_handshake_message(client, hdr.msg_type, &plaintext[pos + 4], hdr.length)
+        let result: i32 = process_handshake_message(client, hdr.msg_type, @plaintext[pos + 4], hdr.length)
         if result != 0
             return TLS_RESULT_ERROR
 
         # Update transcript with handshake message
-        transcript_update(&client.transcript, &plaintext[pos], msg_len)
+        transcript_update(@client.transcript, @plaintext[pos], msg_len)
 
         pos = pos + msg_len
 
@@ -460,7 +460,7 @@ fn process_encrypted_handshake(client: *TlsClient, out: *u8, out_cap: i64, out_l
 fn process_handshake_message(client: *TlsClient, msg_type: u8, data: *u8, len: i64) -> i32
     if msg_type == HS_ENCRYPTED_EXTENSIONS
         var ee: EncryptedExtensions
-        if encrypted_extensions_parse(data, len, &ee) != 0
+        if encrypted_extensions_parse(data, len, @ee) != 0
             client.last_error = TLS_ERR_PARSE_ERROR
             client.state = TLS_STATE_ERROR
             return -1
@@ -468,7 +468,7 @@ fn process_handshake_message(client: *TlsClient, msg_type: u8, data: *u8, len: i
         return 0
 
     if msg_type == HS_CERTIFICATE
-        if certificate_parse(data, len, &client.server_certs) != 0
+        if certificate_parse(data, len, @client.server_certs) != 0
             client.last_error = TLS_ERR_PARSE_ERROR
             client.state = TLS_STATE_ERROR
             return -1
@@ -476,16 +476,16 @@ fn process_handshake_message(client: *TlsClient, msg_type: u8, data: *u8, len: i
         # Parse first certificate to get public key
         if client.server_certs.num_certs > 0
             var cert: X509Certificate
-            if x509_parse_certificate(client.server_certs.cert_data[0], client.server_certs.cert_lens[0], &cert) == 0
+            if x509_parse_certificate(client.server_certs.cert_data[0], client.server_certs.cert_lens[0], @cert) == 0
                 # Copy public key
-                mem_copy(&client.server_pubkey as *u8, &cert.public_key as *u8, 600 as u64)  # Approximate size
+                mem_copy(@client.server_pubkey as *u8, @cert.public_key as *u8, 600 as u64)  # Approximate size
 
         client.state = TLS_STATE_CERTIFICATE_RECEIVED
         return 0
 
     if msg_type == HS_CERTIFICATE_VERIFY
         var cv: CertificateVerify
-        if certificate_verify_parse(data, len, &cv) != 0
+        if certificate_verify_parse(data, len, @cv) != 0
             client.last_error = TLS_ERR_PARSE_ERROR
             client.state = TLS_STATE_ERROR
             return -1
@@ -499,12 +499,12 @@ fn process_handshake_message(client: *TlsClient, msg_type: u8, data: *u8, len: i
     if msg_type == HS_FINISHED
         # Verify server's Finished message
         var expected_transcript: [32]u8
-        transcript_hash(&client.transcript, &expected_transcript[0])
+        transcript_hash(@client.transcript, @expected_transcript[0])
 
         # Note: We need transcript BEFORE the Finished message for verification
         # The transcript_update for Finished happens after this function returns
 
-        let verify_result: i32 = finished_verify(&client.key_schedule.server_handshake_traffic_secret[0], &expected_transcript[0], data)
+        let verify_result: i32 = finished_verify(@client.key_schedule.server_handshake_traffic_secret[0], @expected_transcript[0], data)
 
         if verify_result != 1
             client.last_error = TLS_ERR_FINISHED_MISMATCH
@@ -524,19 +524,19 @@ fn process_handshake_message(client: *TlsClient, msg_type: u8, data: *u8, len: i
 fn finish_handshake(client: *TlsClient, out: *u8, out_cap: i64, out_len: *i64) -> i32
     # Compute client Finished
     var th_out: [32]u8
-    transcript_hash(&client.transcript, &th_out[0])
+    transcript_hash(@client.transcript, @th_out[0])
 
     var verify_data: [32]u8
-    finished_compute(&client.key_schedule.client_handshake_traffic_secret[0], &th_out[0], &verify_data[0])
+    finished_compute(@client.key_schedule.client_handshake_traffic_secret[0], @th_out[0], @verify_data[0])
 
     # Serialize Finished message
     var finished_msg: [64]u8
-    let finished_len: i64 = finished_serialize(&verify_data[0], &finished_msg[0])
+    let finished_len: i64 = finished_serialize(@verify_data[0], @finished_msg[0])
 
     # Encrypt with handshake keys
     var encrypted: [128]u8
 
-    let encrypt_result: i32 = tls_record_state_client_encrypt(&client.write_state, &finished_msg[0], finished_len as i32, 22, &encrypted[0], 128)
+    let encrypt_result: i32 = tls_record_state_client_encrypt(@client.write_state, @finished_msg[0], finished_len as i32, 22, @encrypted[0], 128)
     var encrypted_len: i64 = encrypt_result as i64
 
     if encrypt_result < 0
@@ -555,24 +555,24 @@ fn finish_handshake(client: *TlsClient, out: *u8, out_cap: i64, out_len: *i64) -
     out[2] = 0x03  # TLS 1.2
     out[3] = ((encrypted_len >> 8) & 0xff) as u8
     out[4] = (encrypted_len & 0xff) as u8
-    mem_copy(out + 5, &encrypted[0], encrypted_len as u64)
+    mem_copy(out + 5, @encrypted[0], encrypted_len as u64)
     *out_len = 5 + encrypted_len
 
     # Update transcript with client Finished
-    transcript_update(&client.transcript, &finished_msg[0], finished_len)
+    transcript_update(@client.transcript, @finished_msg[0], finished_len)
 
     # Derive application keys
     var final_transcript: [32]u8
-    transcript_hash(&client.transcript, &final_transcript[0])
-    tls13_key_schedule_derive_application(&client.key_schedule, &final_transcript[0])
-    tls13_key_schedule_derive_application_keys(&client.key_schedule, 16, 12)
+    transcript_hash(@client.transcript, @final_transcript[0])
+    tls13_key_schedule_derive_application(@client.key_schedule, @final_transcript[0])
+    tls13_key_schedule_derive_application_keys(@client.key_schedule, 16, 12)
 
     # Update record layer with application keys
-    tls_record_state_set_keys(&client.read_state, &client.key_schedule.client_write_key[0], &client.key_schedule.client_write_iv[0], &client.key_schedule.server_write_key[0], &client.key_schedule.server_write_iv[0], 16)
+    tls_record_state_set_keys(@client.read_state, @client.key_schedule.client_write_key[0], @client.key_schedule.client_write_iv[0], @client.key_schedule.server_write_key[0], @client.key_schedule.server_write_iv[0], 16)
     client.read_state.client_seq = 0
     client.read_state.server_seq = 0
 
-    tls_record_state_set_keys(&client.write_state, &client.key_schedule.client_write_key[0], &client.key_schedule.client_write_iv[0], &client.key_schedule.server_write_key[0], &client.key_schedule.server_write_iv[0], 16)
+    tls_record_state_set_keys(@client.write_state, @client.key_schedule.client_write_key[0], @client.key_schedule.client_write_iv[0], @client.key_schedule.server_write_key[0], @client.key_schedule.server_write_iv[0], 16)
     client.write_state.client_seq = 0
     client.write_state.server_seq = 0
 
@@ -594,7 +594,7 @@ pub fn tls_client_write(client: *TlsClient, data: *u8, data_len: i64, out: *u8, 
     # Encrypt data
     var encrypted: [16500]u8  # Max record + overhead
 
-    let result: i32 = tls_record_state_client_encrypt(&client.write_state, data, data_len as i32, 23, &encrypted[0], 16500)
+    let result: i32 = tls_record_state_client_encrypt(@client.write_state, data, data_len as i32, 23, @encrypted[0], 16500)
     var encrypted_len: i64 = result as i64
 
     if result < 0
@@ -609,7 +609,7 @@ pub fn tls_client_write(client: *TlsClient, data: *u8, data_len: i64, out: *u8, 
     out[2] = 0x03
     out[3] = ((encrypted_len >> 8) & 0xff) as u8
     out[4] = (encrypted_len & 0xff) as u8
-    mem_copy(out + 5, &encrypted[0], encrypted_len as u64)
+    mem_copy(out + 5, @encrypted[0], encrypted_len as u64)
 
     return 5 + encrypted_len
 
@@ -638,7 +638,7 @@ pub fn tls_client_read(client: *TlsClient, data: *u8, data_len: i64, out: *u8, o
     var plaintext_len: i64 = 0
     var inner_type: u8 = 0
 
-    let result: i32 = tls_record_state_server_decrypt(&client.read_state, data + 5, record_len as i32, &plaintext[0], 16500, &inner_type)
+    let result: i32 = tls_record_state_server_decrypt(@client.read_state, data + 5, record_len as i32, @plaintext[0], 16500, @inner_type)
     plaintext_len = result as i64
 
     if result < 0
@@ -652,7 +652,7 @@ pub fn tls_client_read(client: *TlsClient, data: *u8, data_len: i64, out: *u8, o
     if plaintext_len > out_cap
         return -1
 
-    mem_copy(out, &plaintext[0], plaintext_len as u64)
+    mem_copy(out, @plaintext[0], plaintext_len as u64)
     return plaintext_len
 
 # ============================================================================
@@ -669,7 +669,7 @@ pub fn tls_client_close(client: *TlsClient, out: *u8, out_cap: i64) -> i64
     alert[1] = 0  # close_notify
 
     var encrypted: [64]u8
-    let result: i32 = tls_record_state_client_encrypt(&client.write_state, &alert[0], 2, 21, &encrypted[0], 64)
+    let result: i32 = tls_record_state_client_encrypt(@client.write_state, @alert[0], 2, 21, @encrypted[0], 64)
     var encrypted_len: i64 = result as i64
 
     if result < 0
@@ -683,7 +683,7 @@ pub fn tls_client_close(client: *TlsClient, out: *u8, out_cap: i64) -> i64
     out[2] = 0x03
     out[3] = ((encrypted_len >> 8) & 0xff) as u8
     out[4] = (encrypted_len & 0xff) as u8
-    mem_copy(out + 5, &encrypted[0], encrypted_len as u64)
+    mem_copy(out + 5, @encrypted[0], encrypted_len as u64)
 
     client.state = TLS_STATE_CLOSING
     return 5 + encrypted_len

--- a/projects/cryptosec/lib/tls13_handshake.ritz
+++ b/projects/cryptosec/lib/tls13_handshake.ritz
@@ -86,7 +86,7 @@ pub struct Transcript
 
 # Initialize transcript hash (defaults to SHA-256)
 pub fn transcript_init(t: *Transcript)
-    sha256_init(&t.sha_ctx)
+    sha256_init(@t.sha_ctx)
     t.hash_alg = 0
     t.bytes_hashed = 0
 
@@ -96,16 +96,16 @@ pub fn transcript_init_for_suite(t: *Transcript, cipher_suite: u16)
     if cipher_suite == TLS_AES_256_GCM_SHA384
         # For SHA-384, we'd need a different context
         # For now, we only support SHA-256 based suites
-        sha256_init(&t.sha_ctx)
+        sha256_init(@t.sha_ctx)
         t.hash_alg = 0
     else
-        sha256_init(&t.sha_ctx)
+        sha256_init(@t.sha_ctx)
         t.hash_alg = 0
     t.bytes_hashed = 0
 
 # Update transcript with handshake message data
 pub fn transcript_update(t: *Transcript, data: *u8, len: i64)
-    sha256_update(&t.sha_ctx, data, len as u64)
+    sha256_update(@t.sha_ctx, data, len as u64)
     t.bytes_hashed = t.bytes_hashed + len
 
 # Get current transcript hash without finalizing
@@ -114,8 +114,8 @@ pub fn transcript_hash(t: *Transcript, out: *u8)
     # Copy the context so we can finalize without affecting original
     # sizeof(Sha256) = 8*4 + 64 + 8 + 8 = 112 bytes
     var ctx_copy: Sha256
-    mem_copy(&ctx_copy as *u8, &t.sha_ctx as *u8, 112 as u64)
-    sha256_final(&ctx_copy, out)
+    mem_copy(@ctx_copy as *u8, @t.sha_ctx as *u8, 112 as u64)
+    sha256_final(@ctx_copy, out)
 
 # Get hash length for this transcript
 pub fn transcript_hash_len(t: *Transcript) -> i32
@@ -150,16 +150,16 @@ pub struct ClientHello
 # Initialize ClientHello with random values and key share
 pub fn client_hello_init(ch: *ClientHello)
     # Generate random
-    random_bytes(&ch.random[0], 32)
+    random_bytes(@ch.random[0], 32)
 
     # Generate fake session ID (32 bytes for compatibility)
-    random_bytes(&ch.session_id[0], 32)
+    random_bytes(@ch.session_id[0], 32)
     ch.session_id_len = 32
 
     # Generate X25519 key pair
-    random_bytes(&ch.x25519_private[0], 32)
-    x25519_clamp(&ch.x25519_private[0])
-    x25519_pubkey(&ch.x25519_public[0], &ch.x25519_private[0])
+    random_bytes(@ch.x25519_private[0], 32)
+    x25519_clamp(@ch.x25519_private[0])
+    x25519_pubkey(@ch.x25519_public[0], @ch.x25519_private[0])
 
     # Default cipher suites
     ch.cipher_suites[0] = TLS_AES_128_GCM_SHA256
@@ -195,14 +195,14 @@ pub fn client_hello_serialize(ch: *ClientHello, out: *u8, cap: i64) -> i64
     pos = pos + 2
 
     # Random (32 bytes)
-    mem_copy(out + pos, &ch.random[0], 32)
+    mem_copy(out + pos, @ch.random[0], 32)
     pos = pos + 32
 
     # Legacy session ID
     out[pos] = ch.session_id_len
     pos += 1
     if ch.session_id_len > 0
-        mem_copy(out + pos, &ch.session_id[0], ch.session_id_len as u64)
+        mem_copy(out + pos, @ch.session_id[0], ch.session_id_len as u64)
         pos = pos + ch.session_id_len as i64
 
     # Cipher suites
@@ -238,11 +238,11 @@ pub fn client_hello_serialize(ch: *ClientHello, out: *u8, cap: i64) -> i64
     ext_pos = write_ext_signature_algorithms(out, ext_pos)
 
     # Extension: key_share (X25519 public key)
-    ext_pos = write_ext_key_share(out, ext_pos, &ch.x25519_public[0])
+    ext_pos = write_ext_key_share(out, ext_pos, @ch.x25519_public[0])
 
     # Extension: server_name (SNI)
     if ch.hostname_len > 0
-        ext_pos = write_ext_server_name(out, ext_pos, &ch.hostname[0], ch.hostname_len)
+        ext_pos = write_ext_server_name(out, ext_pos, @ch.hostname[0], ch.hostname_len)
 
     # Write extension length
     let ext_len: i64 = ext_pos - ext_start
@@ -465,7 +465,7 @@ pub fn server_hello_parse(data: *u8, len: i64, sh: *ServerHello) -> i32
     pos = pos + 2
 
     # Random (32 bytes)
-    mem_copy(&sh.random[0], data + pos, 32)
+    mem_copy(@sh.random[0], data + pos, 32)
     pos = pos + 32
 
     # Session ID
@@ -478,7 +478,7 @@ pub fn server_hello_parse(data: *u8, len: i64, sh: *ServerHello) -> i32
 
     sh.session_id_len = sid_len
     if sid_len > 0
-        mem_copy(&sh.session_id[0], data + pos, sid_len as u64)
+        mem_copy(@sh.session_id[0], data + pos, sid_len as u64)
         pos = pos + sid_len as i64
 
     # Cipher suite (2 bytes)
@@ -526,7 +526,7 @@ pub fn server_hello_parse(data: *u8, len: i64, sh: *ServerHello) -> i32
                 let group: u16 = ((data[pos] as u16) << 8) | (data[pos + 1] as u16)
                 let key_len: i64 = ((data[pos + 2] as i64) << 8) | (data[pos + 3] as i64)
                 if group == GROUP_X25519 && key_len == 32 && ext_data_len >= 4 + key_len
-                    mem_copy(&sh.x25519_public[0], data + pos + 4, 32)
+                    mem_copy(@sh.x25519_public[0], data + pos + 4, 32)
                     sh.has_key_share = 1
 
         pos = pos + ext_data_len
@@ -707,7 +707,7 @@ pub fn certificate_verify_parse(data: *u8, len: i64, cv: *CertificateVerify) -> 
         return -3
 
     cv.signature_len = sig_len
-    mem_copy(&cv.signature[0], data + pos, sig_len as u64)
+    mem_copy(@cv.signature[0], data + pos, sig_len as u64)
 
     return 0
 
@@ -740,7 +740,7 @@ pub fn certificate_verify_verify(cv: *CertificateVerify, transcript_hash: *u8, p
     pos += 1
 
     # Transcript hash (32 bytes for SHA-256)
-    mem_copy(&content[pos as i64], transcript_hash, 32)
+    mem_copy(@content[pos as i64], transcript_hash, 32)
     pos = pos + 32
 
     # Verify based on algorithm
@@ -748,7 +748,7 @@ pub fn certificate_verify_verify(cv: *CertificateVerify, transcript_hash: *u8, p
     if cv.algorithm == SIG_RSA_PKCS1_SHA256
         # Hash the content with SHA-256
         var hash: [32]u8
-        sha256(&content[0], pos as i64, &hash[0])
+        sha256(@content[0], pos as i64, @hash[0])
 
         # TODO: Call RSA verification
         # For now, return success placeholder
@@ -768,21 +768,21 @@ pub fn finished_compute(base_key: *u8, transcript_hash: *u8, out: *u8)
     var finished_key: [32]u8
 
     # Derive finished key
-    hkdf_expand_label(base_key, c"finished", 8, null, 0, &finished_key[0], 32)
+    hkdf_expand_label(base_key, c"finished", 8, null, 0, @finished_key[0], 32)
 
     # Compute HMAC
-    hmac_sha256(&finished_key[0], 32, transcript_hash, 32, out)
+    hmac_sha256(@finished_key[0], 32, transcript_hash, 32, out)
 
     # Zero sensitive data
-    mem_zero(&finished_key[0], 32)
+    mem_zero(@finished_key[0], 32)
 
 # Verify received Finished message
 pub fn finished_verify(base_key: *u8, transcript_hash: *u8, received: *u8) -> i32
     var expected: [32]u8
-    finished_compute(base_key, transcript_hash, &expected[0])
+    finished_compute(base_key, transcript_hash, @expected[0])
 
-    let result: i32 = mem_eq(&expected[0], received, 32)
-    mem_zero(&expected[0], 32)
+    let result: i32 = mem_eq(@expected[0], received, 32)
+    mem_zero(@expected[0], 32)
 
     return result
 

--- a/projects/cryptosec/lib/tls13_kdf.ritz
+++ b/projects/cryptosec/lib/tls13_kdf.ritz
@@ -118,10 +118,10 @@ pub fn hkdf_expand_label(secret: *u8, label: *u8, label_len: i32, context: *u8, 
             i += 1
 
     # Call HKDF-Expand with the constructed label
-    hkdf_expand(secret, &hkdf_label[0], pos as u64, out, out_len as u64)
+    hkdf_expand(secret, @hkdf_label[0], pos as u64, out, out_len as u64)
 
     # Zero sensitive data
-    mem_zero(&hkdf_label[0], pos as u64)
+    mem_zero(@hkdf_label[0], pos as u64)
 
 # ============================================================================
 # Derive-Secret (RFC 8446 Section 7.1)
@@ -137,14 +137,14 @@ pub fn derive_secret(secret: *u8, label: *u8, label_len: i32, messages: *u8, mes
 
     if messages == null || messages_len == 0
         # Hash of empty string
-        sha256(null, 0, &transcript_hash[0])
+        sha256(null, 0, @transcript_hash[0])
     else
-        sha256(messages, messages_len, &transcript_hash[0])
+        sha256(messages, messages_len, @transcript_hash[0])
 
-    hkdf_expand_label(secret, label, label_len, &transcript_hash[0], 32, out, 32)
+    hkdf_expand_label(secret, label, label_len, @transcript_hash[0], 32, out, 32)
 
     # Zero sensitive data
-    mem_zero(&transcript_hash[0], 32)
+    mem_zero(@transcript_hash[0], 32)
 
 # ============================================================================
 # TLS 1.3 Key Schedule Functions
@@ -154,15 +154,15 @@ pub fn derive_secret(secret: *u8, label: *u8, label_len: i32, messages: *u8, mes
 # Without PSK: Early Secret = HKDF-Extract(0, 0)
 pub fn tls13_early_secret(psk: *u8, psk_len: i32, out: *u8)
     var zero_ikm: [32]u8
-    mem_zero(&zero_ikm[0], 32)
+    mem_zero(@zero_ikm[0], 32)
 
     if psk == null || psk_len == 0
         # No PSK: use zeros as IKM
-        hkdf_extract(null, 0, &zero_ikm[0], 32, out)
+        hkdf_extract(null, 0, @zero_ikm[0], 32, out)
     else
         hkdf_extract(null, 0, psk, psk_len as u64, out)
 
-    mem_zero(&zero_ikm[0], 32)
+    mem_zero(@zero_ikm[0], 32)
 
 # Handshake Secret = HKDF-Extract(Derive-Secret(early, "derived", ""), shared_secret)
 pub fn tls13_handshake_secret(derived: *u8, shared_secret: *u8, shared_len: i32, out: *u8)
@@ -172,11 +172,11 @@ pub fn tls13_handshake_secret(derived: *u8, shared_secret: *u8, shared_len: i32,
 # Master Secret = HKDF-Extract(Derive-Secret(hs, "derived", ""), 0)
 pub fn tls13_master_secret(derived: *u8, out: *u8)
     var zero_ikm: [32]u8
-    mem_zero(&zero_ikm[0], 32)
+    mem_zero(@zero_ikm[0], 32)
 
-    hkdf_extract(derived, 32, &zero_ikm[0], 32, out)
+    hkdf_extract(derived, 32, @zero_ikm[0], 32, out)
 
-    mem_zero(&zero_ikm[0], 32)
+    mem_zero(@zero_ikm[0], 32)
 
 # ============================================================================
 # Traffic Key Derivation
@@ -221,7 +221,7 @@ pub fn tls13_key_schedule_init(ks: *TLS13KeySchedule)
     mem_zero(ks as *u8, 296 as u64)  # sizeof(TLS13KeySchedule) approx
 
     # Compute early secret (no PSK)
-    tls13_early_secret(null, 0, &ks.early_secret[0])
+    tls13_early_secret(null, 0, @ks.early_secret[0])
     ks.state = 1
 
 # Advance to handshake keys
@@ -230,16 +230,16 @@ pub fn tls13_key_schedule_init(ks: *TLS13KeySchedule)
 pub fn tls13_key_schedule_derive_handshake(ks: *TLS13KeySchedule, shared_secret: *u8, shared_len: i32, transcript_hash: *u8)
     # Derive intermediate secret
     var derived: [32]u8
-    derive_secret(&ks.early_secret[0], c"derived", 7, null, 0, &derived[0])
+    derive_secret(@ks.early_secret[0], c"derived", 7, null, 0, @derived[0])
 
     # Compute handshake secret
-    tls13_handshake_secret(&derived[0], shared_secret, shared_len, &ks.handshake_secret[0])
+    tls13_handshake_secret(@derived[0], shared_secret, shared_len, @ks.handshake_secret[0])
 
     # Derive client/server handshake traffic secrets
-    hkdf_expand_label(&ks.handshake_secret[0], c"c hs traffic", 12, transcript_hash, 32, &ks.client_handshake_traffic_secret[0], 32)
-    hkdf_expand_label(&ks.handshake_secret[0], c"s hs traffic", 12, transcript_hash, 32, &ks.server_handshake_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.handshake_secret[0], c"c hs traffic", 12, transcript_hash, 32, @ks.client_handshake_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.handshake_secret[0], c"s hs traffic", 12, transcript_hash, 32, @ks.server_handshake_traffic_secret[0], 32)
 
-    mem_zero(&derived[0], 32)
+    mem_zero(@derived[0], 32)
     ks.state = 2
 
 # Advance to application keys
@@ -247,24 +247,24 @@ pub fn tls13_key_schedule_derive_handshake(ks: *TLS13KeySchedule, shared_secret:
 pub fn tls13_key_schedule_derive_application(ks: *TLS13KeySchedule, transcript_hash: *u8)
     # Derive intermediate secret from handshake
     var derived: [32]u8
-    derive_secret(&ks.handshake_secret[0], c"derived", 7, null, 0, &derived[0])
+    derive_secret(@ks.handshake_secret[0], c"derived", 7, null, 0, @derived[0])
 
     # Compute master secret
-    tls13_master_secret(&derived[0], &ks.master_secret[0])
+    tls13_master_secret(@derived[0], @ks.master_secret[0])
 
     # Derive application traffic secrets
-    hkdf_expand_label(&ks.master_secret[0], c"c ap traffic", 12, transcript_hash, 32, &ks.client_application_traffic_secret[0], 32)
-    hkdf_expand_label(&ks.master_secret[0], c"s ap traffic", 12, transcript_hash, 32, &ks.server_application_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.master_secret[0], c"c ap traffic", 12, transcript_hash, 32, @ks.client_application_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.master_secret[0], c"s ap traffic", 12, transcript_hash, 32, @ks.server_application_traffic_secret[0], 32)
 
-    mem_zero(&derived[0], 32)
+    mem_zero(@derived[0], 32)
     ks.state = 3
 
 # Derive current keys from handshake traffic secrets (for AES-128-GCM)
 pub fn tls13_key_schedule_derive_handshake_keys(ks: *TLS13KeySchedule, key_len: i32, iv_len: i32)
-    tls13_derive_traffic_keys(&ks.client_handshake_traffic_secret[0], &ks.client_write_key[0], key_len, &ks.client_write_iv[0], iv_len)
-    tls13_derive_traffic_keys(&ks.server_handshake_traffic_secret[0], &ks.server_write_key[0], key_len, &ks.server_write_iv[0], iv_len)
+    tls13_derive_traffic_keys(@ks.client_handshake_traffic_secret[0], @ks.client_write_key[0], key_len, @ks.client_write_iv[0], iv_len)
+    tls13_derive_traffic_keys(@ks.server_handshake_traffic_secret[0], @ks.server_write_key[0], key_len, @ks.server_write_iv[0], iv_len)
 
 # Derive current keys from application traffic secrets
 pub fn tls13_key_schedule_derive_application_keys(ks: *TLS13KeySchedule, key_len: i32, iv_len: i32)
-    tls13_derive_traffic_keys(&ks.client_application_traffic_secret[0], &ks.client_write_key[0], key_len, &ks.client_write_iv[0], iv_len)
-    tls13_derive_traffic_keys(&ks.server_application_traffic_secret[0], &ks.server_write_key[0], key_len, &ks.server_write_iv[0], iv_len)
+    tls13_derive_traffic_keys(@ks.client_application_traffic_secret[0], @ks.client_write_key[0], key_len, @ks.client_write_iv[0], iv_len)
+    tls13_derive_traffic_keys(@ks.server_application_traffic_secret[0], @ks.server_write_key[0], key_len, @ks.server_write_iv[0], iv_len)

--- a/projects/cryptosec/lib/tls13_record.ritz
+++ b/projects/cryptosec/lib/tls13_record.ritz
@@ -80,7 +80,7 @@ pub fn tls13_parse_inner_plaintext(inner: *u8, inner_len: i32, content_type: *u8
 
 pub fn tls13_record_encrypt(key: *u8, key_len: i32, iv: *u8, seq: u64, plaintext: *u8, plaintext_len: i32, content_type: u8, out: *u8, out_cap: i32) -> i32
     var inner: [1024]u8
-    let inner_len: i32 = tls13_build_inner_plaintext(plaintext, plaintext_len, content_type, &inner[0], 1024)
+    let inner_len: i32 = tls13_build_inner_plaintext(plaintext, plaintext_len, content_type, @inner[0], 1024)
     if inner_len < 0
         return -1
 
@@ -103,20 +103,20 @@ pub fn tls13_record_encrypt(key: *u8, key_len: i32, iv: *u8, seq: u64, plaintext
     aad[4] = out[4]
 
     var nonce: [12]u8
-    tls13_compute_nonce(iv, seq, &nonce[0])
+    tls13_compute_nonce(iv, seq, @nonce[0])
 
     var ctx: AesGcm128
     if key_len == 16
-        aes128_gcm_init(&ctx, key)
+        aes128_gcm_init(@ctx, key)
     else
         return -3
 
     var tag: [16]u8
-    aes128_gcm_encrypt(&ctx, &nonce[0], 12, &aad[0], 5, &inner[0], inner_len as u64, &out[TLS_RECORD_HEADER_LEN], &tag[0])
-    mem_copy(&out[TLS_RECORD_HEADER_LEN + inner_len], &tag[0], 16)
+    aes128_gcm_encrypt(@ctx, @nonce[0], 12, @aad[0], 5, @inner[0], inner_len as u64, @out[TLS_RECORD_HEADER_LEN], @tag[0])
+    mem_copy(@out[TLS_RECORD_HEADER_LEN + inner_len], @tag[0], 16)
 
-    mem_zero(&inner[0], inner_len as u64)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@inner[0], inner_len as u64)
+    mem_zero(@nonce[0], 12)
 
     return record_len
 
@@ -156,36 +156,36 @@ pub fn tls13_record_decrypt(key: *u8, key_len: i32, iv: *u8, seq: u64, record: *
     aad[4] = record[4]
 
     var nonce: [12]u8
-    tls13_compute_nonce(iv, seq, &nonce[0])
+    tls13_compute_nonce(iv, seq, @nonce[0])
 
     var ctx: AesGcm128
     if key_len == 16
-        aes128_gcm_init(&ctx, key)
+        aes128_gcm_init(@ctx, key)
     else
         return -6
 
     var inner: [1024]u8
-    let ct_ptr: *u8 = &record[TLS_RECORD_HEADER_LEN]
-    let tag_ptr: *u8 = &record[TLS_RECORD_HEADER_LEN + inner_len]
+    let ct_ptr: *u8 = @record[TLS_RECORD_HEADER_LEN]
+    let tag_ptr: *u8 = @record[TLS_RECORD_HEADER_LEN + inner_len]
 
-    let result: i32 = aes128_gcm_decrypt(&ctx, &nonce[0], 12, &aad[0], 5, ct_ptr, inner_len as u64, tag_ptr, &inner[0])
+    let result: i32 = aes128_gcm_decrypt(@ctx, @nonce[0], 12, @aad[0], 5, ct_ptr, inner_len as u64, tag_ptr, @inner[0])
     if result != 1
-        mem_zero(&inner[0], inner_len as u64)
-        mem_zero(&nonce[0], 12)
+        mem_zero(@inner[0], inner_len as u64)
+        mem_zero(@nonce[0], 12)
         return -7
 
-    let plaintext_len: i32 = tls13_parse_inner_plaintext(&inner[0], inner_len, content_type)
+    let plaintext_len: i32 = tls13_parse_inner_plaintext(@inner[0], inner_len, content_type)
     if plaintext_len < 0
-        mem_zero(&inner[0], inner_len as u64)
+        mem_zero(@inner[0], inner_len as u64)
         return -8
 
     if plaintext_len > out_cap
-        mem_zero(&inner[0], inner_len as u64)
+        mem_zero(@inner[0], inner_len as u64)
         return -9
 
-    mem_copy(out, &inner[0], plaintext_len as u64)
-    mem_zero(&inner[0], inner_len as u64)
-    mem_zero(&nonce[0], 12)
+    mem_copy(out, @inner[0], plaintext_len as u64)
+    mem_zero(@inner[0], inner_len as u64)
+    mem_zero(@nonce[0], 12)
 
     return plaintext_len
 
@@ -206,34 +206,34 @@ pub fn tls_record_state_init(state: *TlsRecordState)
     mem_zero(state as *u8, 120 as u64)
 
 pub fn tls_record_state_set_keys(state: *TlsRecordState, client_key: *u8, client_iv: *u8, server_key: *u8, server_iv: *u8, key_len: i32)
-    mem_copy(&state.client_key[0], client_key, key_len as u64)
-    mem_copy(&state.client_iv[0], client_iv, 12)
-    mem_copy(&state.server_key[0], server_key, key_len as u64)
-    mem_copy(&state.server_iv[0], server_iv, 12)
+    mem_copy(@state.client_key[0], client_key, key_len as u64)
+    mem_copy(@state.client_iv[0], client_iv, 12)
+    mem_copy(@state.server_key[0], server_key, key_len as u64)
+    mem_copy(@state.server_iv[0], server_iv, 12)
     state.key_len = key_len
     state.client_seq = 0
     state.server_seq = 0
 
 pub fn tls_record_state_client_encrypt(state: *TlsRecordState, plaintext: *u8, plaintext_len: i32, content_type: u8, out: *u8, out_cap: i32) -> i32
-    let result: i32 = tls13_record_encrypt(&state.client_key[0], state.key_len, &state.client_iv[0], state.client_seq, plaintext, plaintext_len, content_type, out, out_cap)
+    let result: i32 = tls13_record_encrypt(@state.client_key[0], state.key_len, @state.client_iv[0], state.client_seq, plaintext, plaintext_len, content_type, out, out_cap)
     if result > 0
         state.client_seq = state.client_seq + 1
     return result
 
 pub fn tls_record_state_server_decrypt(state: *TlsRecordState, record: *u8, record_len: i32, out: *u8, out_cap: i32, content_type: *u8) -> i32
-    let result: i32 = tls13_record_decrypt(&state.server_key[0], state.key_len, &state.server_iv[0], state.server_seq, record, record_len, out, out_cap, content_type)
+    let result: i32 = tls13_record_decrypt(@state.server_key[0], state.key_len, @state.server_iv[0], state.server_seq, record, record_len, out, out_cap, content_type)
     if result >= 0
         state.server_seq = state.server_seq + 1
     return result
 
 pub fn tls_record_state_server_encrypt(state: *TlsRecordState, plaintext: *u8, plaintext_len: i32, content_type: u8, out: *u8, out_cap: i32) -> i32
-    let result: i32 = tls13_record_encrypt(&state.server_key[0], state.key_len, &state.server_iv[0], state.server_seq, plaintext, plaintext_len, content_type, out, out_cap)
+    let result: i32 = tls13_record_encrypt(@state.server_key[0], state.key_len, @state.server_iv[0], state.server_seq, plaintext, plaintext_len, content_type, out, out_cap)
     if result > 0
         state.server_seq = state.server_seq + 1
     return result
 
 pub fn tls_record_state_client_decrypt(state: *TlsRecordState, record: *u8, record_len: i32, out: *u8, out_cap: i32, content_type: *u8) -> i32
-    let result: i32 = tls13_record_decrypt(&state.client_key[0], state.key_len, &state.client_iv[0], state.client_seq, record, record_len, out, out_cap, content_type)
+    let result: i32 = tls13_record_decrypt(@state.client_key[0], state.key_len, @state.client_iv[0], state.client_seq, record, record_len, out, out_cap, content_type)
     if result >= 0
         state.client_seq = state.client_seq + 1
     return result

--- a/projects/cryptosec/lib/x25519.ritz
+++ b/projects/cryptosec/lib/x25519.ritz
@@ -99,8 +99,8 @@ pub fn fe_frombytes(out: *Fe25519, bytes: *u8)
 pub fn fe_tobytes(bytes: *u8, a: *Fe25519)
     # First fully reduce
     var t: Fe25519
-    fe_copy(&t, a)
-    fe_reduce(&t)
+    fe_copy(@t, a)
+    fe_reduce(@t)
 
     # Convert from 5 x 51-bit limbs to 32 bytes
     # Limb layout: bits 0-50 in l0, 51-101 in l1, 102-152 in l2, 153-203 in l3, 204-254 in l4
@@ -390,8 +390,8 @@ fn fe_mul_a24(out: *Fe25519, a: *Fe25519)
 
     # Reduce input to ensure limbs are < 2^51
     var a_r: Fe25519
-    fe_copy(&a_r, a)
-    fe_reduce(&a_r)
+    fe_copy(@a_r, a)
+    fe_reduce(@a_r)
 
     # Use 128-bit arithmetic for the multiplications
     var acc0: U128 = u128_mul_u64(a_r.l0, c)
@@ -467,84 +467,84 @@ pub fn fe_invert(out: *Fe25519, z: *Fe25519)
     var t3: Fe25519
 
     # z^2
-    fe_sq(&t0, z)
+    fe_sq(@t0, z)
     # z^4
-    fe_sq(&t1, &t0)
+    fe_sq(@t1, @t0)
     # z^8
-    fe_sq(&t1, &t1)
+    fe_sq(@t1, @t1)
     # z^9 = z^8 * z
-    fe_mul(&t1, &t1, z)
+    fe_mul(@t1, @t1, z)
     # z^11 = z^9 * z^2
-    fe_mul(&t0, &t1, &t0)
+    fe_mul(@t0, @t1, @t0)
     # z^22
-    fe_sq(&t2, &t0)
+    fe_sq(@t2, @t0)
     # z^31 = z^22 * z^9
-    fe_mul(&t1, &t2, &t1)
+    fe_mul(@t1, @t2, @t1)
     # z^2^5
-    fe_sq(&t2, &t1)
+    fe_sq(@t2, @t1)
     # z^2^10
     var i: i32 = 1
     while i < 5
-        fe_sq(&t2, &t2)
+        fe_sq(@t2, @t2)
         i += 1
     # z^(2^10 - 1) = z^(2^10 - 2^5) * z^(2^5 - 1)
-    fe_mul(&t1, &t2, &t1)
+    fe_mul(@t1, @t2, @t1)
     # z^2^20
-    fe_sq(&t2, &t1)
+    fe_sq(@t2, @t1)
     i = 1
     while i < 10
-        fe_sq(&t2, &t2)
+        fe_sq(@t2, @t2)
         i += 1
     # z^(2^20 - 1)
-    fe_mul(&t2, &t2, &t1)
+    fe_mul(@t2, @t2, @t1)
     # z^2^40
-    fe_sq(&t3, &t2)
+    fe_sq(@t3, @t2)
     i = 1
     while i < 20
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
     # z^(2^40 - 1)
-    fe_mul(&t2, &t3, &t2)
+    fe_mul(@t2, @t3, @t2)
     # z^2^50
-    fe_sq(&t2, &t2)
+    fe_sq(@t2, @t2)
     i = 1
     while i < 10
-        fe_sq(&t2, &t2)
+        fe_sq(@t2, @t2)
         i += 1
     # z^(2^50 - 1)
-    fe_mul(&t1, &t2, &t1)
+    fe_mul(@t1, @t2, @t1)
     # z^2^100
-    fe_sq(&t2, &t1)
+    fe_sq(@t2, @t1)
     i = 1
     while i < 50
-        fe_sq(&t2, &t2)
+        fe_sq(@t2, @t2)
         i += 1
     # z^(2^100 - 1)
-    fe_mul(&t2, &t2, &t1)
+    fe_mul(@t2, @t2, @t1)
     # z^2^200
-    fe_sq(&t3, &t2)
+    fe_sq(@t3, @t2)
     i = 1
     while i < 100
-        fe_sq(&t3, &t3)
+        fe_sq(@t3, @t3)
         i += 1
     # z^(2^200 - 1)
-    fe_mul(&t2, &t3, &t2)
+    fe_mul(@t2, @t3, @t2)
     # z^2^250
-    fe_sq(&t2, &t2)
+    fe_sq(@t2, @t2)
     i = 1
     while i < 50
-        fe_sq(&t2, &t2)
+        fe_sq(@t2, @t2)
         i += 1
     # z^(2^250 - 1)
-    fe_mul(&t1, &t2, &t1)
+    fe_mul(@t1, @t2, @t1)
     # z^2^255
-    fe_sq(&t1, &t1)
-    fe_sq(&t1, &t1)
-    fe_sq(&t1, &t1)
-    fe_sq(&t1, &t1)
-    fe_sq(&t1, &t1)
+    fe_sq(@t1, @t1)
+    fe_sq(@t1, @t1)
+    fe_sq(@t1, @t1)
+    fe_sq(@t1, @t1)
+    fe_sq(@t1, @t1)
     # z^(2^255 - 32) * z^11 = z^(2^255 - 21)
-    fe_mul(out, &t1, &t0)
+    fe_mul(out, @t1, @t0)
 
 # ============================================================================
 # Conditional swap (constant-time)
@@ -583,30 +583,30 @@ fn fe_cswap(a: *Fe25519, b: *Fe25519, swap: u64)
 fn x25519_scalarmult(out: *u8, scalar: *u8, point: *u8)
     # Clamp scalar per RFC 7748
     var k: [32]u8
-    mem_copy(&k[0], scalar, 32)
+    mem_copy(@k[0], scalar, 32)
     k[0] = k[0] & 0xf8
     k[31] = k[31] & 0x7f
     k[31] = k[31] | 0x40
 
     # Load point u-coordinate
     var u: Fe25519
-    fe_frombytes(&u, point)
+    fe_frombytes(@u, point)
 
     # Montgomery ladder
     var x1: Fe25519
-    fe_copy(&x1, &u)
+    fe_copy(@x1, @u)
 
     var x2: Fe25519
-    fe_one(&x2)
+    fe_one(@x2)
 
     var z2: Fe25519
-    fe_zero(&z2)
+    fe_zero(@z2)
 
     var x3: Fe25519
-    fe_copy(&x3, &u)
+    fe_copy(@x3, @u)
 
     var z3: Fe25519
-    fe_one(&z3)
+    fe_one(@z3)
 
     var swap: u64 = 0
 
@@ -618,8 +618,8 @@ fn x25519_scalarmult(out: *u8, scalar: *u8, point: *u8)
         let ki: u64 = ((k[byte_idx] >> (bit_idx as u8)) & 1) as u64
 
         swap = swap ^ ki
-        fe_cswap(&x2, &x3, swap)
-        fe_cswap(&z2, &z3, swap)
+        fe_cswap(@x2, @x3, swap)
+        fe_cswap(@z2, @z3, swap)
         swap = ki
 
         # Montgomery ladder step
@@ -633,42 +633,42 @@ fn x25519_scalarmult(out: *u8, scalar: *u8, point: *u8)
         var DA: Fe25519
         var CB: Fe25519
 
-        fe_add(&A, &x2, &z2)
-        fe_sq(&AA, &A)
-        fe_sub(&B, &x2, &z2)
-        fe_sq(&BB, &B)
-        fe_sub(&E, &AA, &BB)
-        fe_add(&C, &x3, &z3)
-        fe_sub(&D, &x3, &z3)
-        fe_mul(&DA, &D, &A)
-        fe_mul(&CB, &C, &B)
+        fe_add(@A, @x2, @z2)
+        fe_sq(@AA, @A)
+        fe_sub(@B, @x2, @z2)
+        fe_sq(@BB, @B)
+        fe_sub(@E, @AA, @BB)
+        fe_add(@C, @x3, @z3)
+        fe_sub(@D, @x3, @z3)
+        fe_mul(@DA, @D, @A)
+        fe_mul(@CB, @C, @B)
 
         var t1: Fe25519
         var t2: Fe25519
-        fe_add(&t1, &DA, &CB)
-        fe_sq(&x3, &t1)
-        fe_sub(&t2, &DA, &CB)
-        fe_sq(&t1, &t2)
-        fe_mul(&z3, &t1, &x1)
+        fe_add(@t1, @DA, @CB)
+        fe_sq(@x3, @t1)
+        fe_sub(@t2, @DA, @CB)
+        fe_sq(@t1, @t2)
+        fe_mul(@z3, @t1, @x1)
 
-        fe_mul(&x2, &AA, &BB)
-        fe_mul_a24(&t1, &E)
-        fe_add(&t1, &AA, &t1)
-        fe_mul(&z2, &E, &t1)
+        fe_mul(@x2, @AA, @BB)
+        fe_mul_a24(@t1, @E)
+        fe_add(@t1, @AA, @t1)
+        fe_mul(@z2, @E, @t1)
 
         pos -= 1
 
-    fe_cswap(&x2, &x3, swap)
-    fe_cswap(&z2, &z3, swap)
+    fe_cswap(@x2, @x3, swap)
+    fe_cswap(@z2, @z3, swap)
 
     # Compute result: x2 * z2^(-1)
     var z2_inv: Fe25519
-    fe_invert(&z2_inv, &z2)
+    fe_invert(@z2_inv, @z2)
 
     var result: Fe25519
-    fe_mul(&result, &x2, &z2_inv)
+    fe_mul(@result, @x2, @z2_inv)
 
-    fe_tobytes(out, &result)
+    fe_tobytes(out, @result)
 
 # ============================================================================
 # Public API
@@ -694,4 +694,4 @@ pub fn x25519_pubkey(pubkey: *u8, privkey: *u8)
         basepoint[i] = 0
         i += 1
 
-    x25519_scalarmult(pubkey, privkey, &basepoint[0])
+    x25519_scalarmult(pubkey, privkey, @basepoint[0])

--- a/projects/cryptosec/lib/x509.ritz
+++ b/projects/cryptosec/lib/x509.ritz
@@ -115,37 +115,37 @@ struct X509Certificate
 # Returns: algorithm type constant, or 0 on error/unknown
 pub fn x509_parse_sig_algorithm(parser: *DerParser) -> u8
     var seq: DerElement
-    if der_parse_element(parser, &seq) != 0
+    if der_parse_element(parser, @seq) != 0
         return SIG_ALG_UNKNOWN
 
-    if der_is_sequence(&seq) != 1
+    if der_is_sequence(@seq) != 1
         return SIG_ALG_UNKNOWN
 
     var seq_parser: DerParser
-    if der_enter_sequence(&seq, &seq_parser) != 0
+    if der_enter_sequence(@seq, @seq_parser) != 0
         return SIG_ALG_UNKNOWN
 
     # Parse OID
     var oid_elem: DerElement
-    if der_parse_element(&seq_parser, &oid_elem) != 0
+    if der_parse_element(@seq_parser, @oid_elem) != 0
         return SIG_ALG_UNKNOWN
 
     var oid: Oid
-    if der_decode_oid(&oid_elem, &oid) != 0
+    if der_decode_oid(@oid_elem, @oid) != 0
         return SIG_ALG_UNKNOWN
 
     # Match against known algorithms
-    if oid_is_sha256_rsa(&oid) == 1
+    if oid_is_sha256_rsa(@oid) == 1
         return SIG_ALG_SHA256_RSA
-    if oid_is_sha384_rsa(&oid) == 1
+    if oid_is_sha384_rsa(@oid) == 1
         return SIG_ALG_SHA384_RSA
-    if oid_is_sha512_rsa(&oid) == 1
+    if oid_is_sha512_rsa(@oid) == 1
         return SIG_ALG_SHA512_RSA
-    if oid_is_ecdsa_sha256(&oid) == 1
+    if oid_is_ecdsa_sha256(@oid) == 1
         return SIG_ALG_ECDSA_SHA256
-    if oid_is_ecdsa_sha384(&oid) == 1
+    if oid_is_ecdsa_sha384(@oid) == 1
         return SIG_ALG_ECDSA_SHA384
-    if oid_is_ed25519(&oid) == 1
+    if oid_is_ed25519(@oid) == 1
         return SIG_ALG_ED25519
 
     return SIG_ALG_UNKNOWN
@@ -157,50 +157,50 @@ pub fn x509_parse_sig_algorithm(parser: *DerParser) -> u8
 # Parse a single RDN attribute value (OID + value)
 fn x509_parse_rdn_attribute(parser: *DerParser, name: *X509Name) -> i32
     var seq: DerElement
-    if der_parse_element(parser, &seq) != 0
+    if der_parse_element(parser, @seq) != 0
         return -1
 
-    if der_is_sequence(&seq) != 1
+    if der_is_sequence(@seq) != 1
         return -1
 
     var attr_parser: DerParser
-    if der_enter_sequence(&seq, &attr_parser) != 0
+    if der_enter_sequence(@seq, @attr_parser) != 0
         return -1
 
     # Parse attribute type OID
     var oid_elem: DerElement
-    if der_parse_element(&attr_parser, &oid_elem) != 0
+    if der_parse_element(@attr_parser, @oid_elem) != 0
         return -1
 
     var oid: Oid
-    if der_decode_oid(&oid_elem, &oid) != 0
+    if der_decode_oid(@oid_elem, @oid) != 0
         return -1
 
     # Parse attribute value (string)
     var value_elem: DerElement
-    if der_parse_element(&attr_parser, &value_elem) != 0
+    if der_parse_element(@attr_parser, @value_elem) != 0
         return -1
 
     # Copy value to appropriate field based on OID
-    if oid_is_common_name(&oid) == 1
+    if oid_is_common_name(@oid) == 1
         var copy_len: u64 = value_elem.content_len
         if copy_len > 63
             copy_len = 63
-        mem_copy(&name.common_name[0], value_elem.content, copy_len)
+        mem_copy(@name.common_name[0], value_elem.content, copy_len)
         name.common_name_len = copy_len as u8
 
-    if oid_is_org_name(&oid) == 1
+    if oid_is_org_name(@oid) == 1
         var copy_len: u64 = value_elem.content_len
         if copy_len > 63
             copy_len = 63
-        mem_copy(&name.organization[0], value_elem.content, copy_len)
+        mem_copy(@name.organization[0], value_elem.content, copy_len)
         name.organization_len = copy_len as u8
 
-    if oid_is_country_name(&oid) == 1
+    if oid_is_country_name(@oid) == 1
         var copy_len: u64 = value_elem.content_len
         if copy_len > 2
             copy_len = 2
-        mem_copy(&name.country[0], value_elem.content, copy_len)
+        mem_copy(@name.country[0], value_elem.content, copy_len)
         name.country_len = copy_len as u8
 
     return 0
@@ -213,10 +213,10 @@ fn x509_parse_name(parser: *DerParser, name: *X509Name) -> i32
     name.country_len = 0
 
     var seq: DerElement
-    if der_parse_element(parser, &seq) != 0
+    if der_parse_element(parser, @seq) != 0
         return -1
 
-    if der_is_sequence(&seq) != 1
+    if der_is_sequence(@seq) != 1
         return -1
 
     # Save raw DER for later comparison
@@ -224,25 +224,25 @@ fn x509_parse_name(parser: *DerParser, name: *X509Name) -> i32
     name.der_len = seq.header_len + seq.content_len
 
     var name_parser: DerParser
-    if der_enter_sequence(&seq, &name_parser) != 0
+    if der_enter_sequence(@seq, @name_parser) != 0
         return -1
 
     # Parse each RDN (SET of AttributeTypeAndValue)
-    while der_parser_eof(&name_parser) != 1
+    while der_parser_eof(@name_parser) != 1
         var rdn_set: DerElement
-        if der_parse_element(&name_parser, &rdn_set) != 0
+        if der_parse_element(@name_parser, @rdn_set) != 0
             return -1
 
-        if der_is_set(&rdn_set) != 1
+        if der_is_set(@rdn_set) != 1
             return -1
 
         var rdn_parser: DerParser
-        if der_enter_set(&rdn_set, &rdn_parser) != 0
+        if der_enter_set(@rdn_set, @rdn_parser) != 0
             return -1
 
         # Parse attributes in this RDN
-        while der_parser_eof(&rdn_parser) != 1
-            if x509_parse_rdn_attribute(&rdn_parser, name) != 0
+        while der_parser_eof(@rdn_parser) != 1
+            if x509_parse_rdn_attribute(@rdn_parser, name) != 0
                 return -1
 
     return 0
@@ -342,12 +342,12 @@ pub fn x509_parse_utc_time(elem: *DerElement, out: *i64) -> i32
     if elem.content_len < 13
         return -1
 
-    let yy: i32 = parse_2digit(&elem.content[0])
-    let mm: i32 = parse_2digit(&elem.content[2])
-    let dd: i32 = parse_2digit(&elem.content[4])
-    let hh: i32 = parse_2digit(&elem.content[6])
-    let mi: i32 = parse_2digit(&elem.content[8])
-    let ss: i32 = parse_2digit(&elem.content[10])
+    let yy: i32 = parse_2digit(@elem.content[0])
+    let mm: i32 = parse_2digit(@elem.content[2])
+    let dd: i32 = parse_2digit(@elem.content[4])
+    let hh: i32 = parse_2digit(@elem.content[6])
+    let mi: i32 = parse_2digit(@elem.content[8])
+    let ss: i32 = parse_2digit(@elem.content[10])
 
     # Y2K handling: 00-49 -> 2000-2049, 50-99 -> 1950-1999
     var year: i32 = 0
@@ -367,12 +367,12 @@ pub fn x509_parse_generalized_time(elem: *DerElement, out: *i64) -> i32
     if elem.content_len < 15
         return -1
 
-    let year: i32 = parse_4digit(&elem.content[0])
-    let mm: i32 = parse_2digit(&elem.content[4])
-    let dd: i32 = parse_2digit(&elem.content[6])
-    let hh: i32 = parse_2digit(&elem.content[8])
-    let mi: i32 = parse_2digit(&elem.content[10])
-    let ss: i32 = parse_2digit(&elem.content[12])
+    let year: i32 = parse_4digit(@elem.content[0])
+    let mm: i32 = parse_2digit(@elem.content[4])
+    let dd: i32 = parse_2digit(@elem.content[6])
+    let hh: i32 = parse_2digit(@elem.content[8])
+    let mi: i32 = parse_2digit(@elem.content[10])
+    let ss: i32 = parse_2digit(@elem.content[12])
 
     *out = calendar_to_unix(year, mm, dd, hh, mi, ss)
     return 0
@@ -388,30 +388,30 @@ fn x509_parse_time(elem: *DerElement, out: *i64) -> i32
 # Parse Validity sequence
 pub fn x509_parse_validity(parser: *DerParser, validity: *X509Validity) -> i32
     var seq: DerElement
-    if der_parse_element(parser, &seq) != 0
+    if der_parse_element(parser, @seq) != 0
         return -1
 
-    if der_is_sequence(&seq) != 1
+    if der_is_sequence(@seq) != 1
         return -1
 
     var val_parser: DerParser
-    if der_enter_sequence(&seq, &val_parser) != 0
+    if der_enter_sequence(@seq, @val_parser) != 0
         return -1
 
     # Parse notBefore
     var not_before: DerElement
-    if der_parse_element(&val_parser, &not_before) != 0
+    if der_parse_element(@val_parser, @not_before) != 0
         return -1
 
-    if x509_parse_time(&not_before, &validity.not_before) != 0
+    if x509_parse_time(@not_before, @validity.not_before) != 0
         return -1
 
     # Parse notAfter
     var not_after: DerElement
-    if der_parse_element(&val_parser, &not_after) != 0
+    if der_parse_element(@val_parser, @not_after) != 0
         return -1
 
-    if x509_parse_time(&not_after, &validity.not_after) != 0
+    if x509_parse_time(@not_after, @validity.not_after) != 0
         return -1
 
     return 0
@@ -422,62 +422,62 @@ pub fn x509_parse_validity(parser: *DerParser, validity: *X509Validity) -> i32
 
 pub fn x509_parse_public_key(parser: *DerParser, pubkey: *X509PublicKey) -> i32
     var seq: DerElement
-    if der_parse_element(parser, &seq) != 0
+    if der_parse_element(parser, @seq) != 0
         return -1
 
-    if der_is_sequence(&seq) != 1
+    if der_is_sequence(@seq) != 1
         return -1
 
     var spki_parser: DerParser
-    if der_enter_sequence(&seq, &spki_parser) != 0
+    if der_enter_sequence(@seq, @spki_parser) != 0
         return -1
 
     # Parse AlgorithmIdentifier
     var alg_seq: DerElement
-    if der_parse_element(&spki_parser, &alg_seq) != 0
+    if der_parse_element(@spki_parser, @alg_seq) != 0
         return -1
 
-    if der_is_sequence(&alg_seq) != 1
+    if der_is_sequence(@alg_seq) != 1
         return -1
 
     var alg_parser: DerParser
-    if der_enter_sequence(&alg_seq, &alg_parser) != 0
+    if der_enter_sequence(@alg_seq, @alg_parser) != 0
         return -1
 
     var oid_elem: DerElement
-    if der_parse_element(&alg_parser, &oid_elem) != 0
+    if der_parse_element(@alg_parser, @oid_elem) != 0
         return -1
 
     var oid: Oid
-    if der_decode_oid(&oid_elem, &oid) != 0
+    if der_decode_oid(@oid_elem, @oid) != 0
         return -1
 
     # Determine key type
-    if oid_is_rsa(&oid) == 1
+    if oid_is_rsa(@oid) == 1
         pubkey.algorithm = PUBKEY_TYPE_RSA
         pubkey.curve = EC_CURVE_UNKNOWN
     else
-        if oid_is_ec_public_key(&oid) == 1
+        if oid_is_ec_public_key(@oid) == 1
             pubkey.algorithm = PUBKEY_TYPE_EC
 
             # Parse curve OID from parameters
             var curve_elem: DerElement
-            if der_parse_element(&alg_parser, &curve_elem) != 0
+            if der_parse_element(@alg_parser, @curve_elem) != 0
                 return -1
 
             var curve_oid: Oid
-            if der_decode_oid(&curve_elem, &curve_oid) != 0
+            if der_decode_oid(@curve_elem, @curve_oid) != 0
                 return -1
 
-            if oid_is_p256(&curve_oid) == 1
+            if oid_is_p256(@curve_oid) == 1
                 pubkey.curve = EC_CURVE_P256
             else
-                if oid_is_p384(&curve_oid) == 1
+                if oid_is_p384(@curve_oid) == 1
                     pubkey.curve = EC_CURVE_P384
                 else
                     pubkey.curve = EC_CURVE_UNKNOWN
         else
-            if oid_is_ed25519(&oid) == 1
+            if oid_is_ed25519(@oid) == 1
                 pubkey.algorithm = PUBKEY_TYPE_ED25519
                 pubkey.curve = EC_CURVE_UNKNOWN
             else
@@ -486,20 +486,20 @@ pub fn x509_parse_public_key(parser: *DerParser, pubkey: *X509PublicKey) -> i32
 
     # Parse subjectPublicKey BIT STRING
     var pk_bits: DerElement
-    if der_parse_element(&spki_parser, &pk_bits) != 0
+    if der_parse_element(@spki_parser, @pk_bits) != 0
         return -1
 
     var pk_data: *u8 = null
     var pk_len: u64 = 0
     var unused: u8 = 0
 
-    if der_bit_string_content(&pk_bits, &pk_data, &pk_len, &unused) != 0
+    if der_bit_string_content(@pk_bits, @pk_data, @pk_len, @unused) != 0
         return -1
 
     if pk_len > 512
         pk_len = 512
 
-    mem_copy(&pubkey.key_data[0], pk_data, pk_len)
+    mem_copy(@pubkey.key_data[0], pk_data, pk_len)
     pubkey.key_len = pk_len
 
     return 0
@@ -511,81 +511,81 @@ pub fn x509_parse_public_key(parser: *DerParser, pubkey: *X509PublicKey) -> i32
 fn x509_parse_extensions(parser: *DerParser, cert: *X509Certificate) -> i32
     # Extensions are wrapped in [3] context tag
     var wrapper: DerElement
-    if der_parse_element(parser, &wrapper) != 0
+    if der_parse_element(parser, @wrapper) != 0
         return -1
 
-    if der_is_context_tag(&wrapper, 3) != 1
+    if der_is_context_tag(@wrapper, 3) != 1
         return -1
 
     var wrapper_parser: DerParser
-    if der_enter_constructed(&wrapper, &wrapper_parser) != 0
+    if der_enter_constructed(@wrapper, @wrapper_parser) != 0
         return -1
 
     # Extensions is a SEQUENCE
     var ext_seq: DerElement
-    if der_parse_element(&wrapper_parser, &ext_seq) != 0
+    if der_parse_element(@wrapper_parser, @ext_seq) != 0
         return -1
 
-    if der_is_sequence(&ext_seq) != 1
+    if der_is_sequence(@ext_seq) != 1
         return -1
 
     var ext_parser: DerParser
-    if der_enter_sequence(&ext_seq, &ext_parser) != 0
+    if der_enter_sequence(@ext_seq, @ext_parser) != 0
         return -1
 
     # Parse each extension
-    while der_parser_eof(&ext_parser) != 1
+    while der_parser_eof(@ext_parser) != 1
         var ext: DerElement
-        if der_parse_element(&ext_parser, &ext) != 0
+        if der_parse_element(@ext_parser, @ext) != 0
             break
 
-        if der_is_sequence(&ext) != 1
+        if der_is_sequence(@ext) != 1
             continue
 
         var ext_inner: DerParser
-        if der_enter_sequence(&ext, &ext_inner) != 0
+        if der_enter_sequence(@ext, @ext_inner) != 0
             continue
 
         # Extension OID
         var ext_oid_elem: DerElement
-        if der_parse_element(&ext_inner, &ext_oid_elem) != 0
+        if der_parse_element(@ext_inner, @ext_oid_elem) != 0
             continue
 
         var ext_oid: Oid
-        if der_decode_oid(&ext_oid_elem, &ext_oid) != 0
+        if der_decode_oid(@ext_oid_elem, @ext_oid) != 0
             continue
 
         # Critical flag (optional BOOLEAN)
         var next_elem: DerElement
-        if der_parse_element(&ext_inner, &next_elem) != 0
+        if der_parse_element(@ext_inner, @next_elem) != 0
             continue
 
-        var ext_value: *DerElement = &next_elem
+        var ext_value: *DerElement = @next_elem
 
         # Check if it's a BOOLEAN (critical flag)
         if next_elem.tag_class == TAG_CLASS_UNIVERSAL
             if next_elem.tag_number == (TAG_BOOLEAN as u32)
                 # Skip critical flag, parse actual value
                 var actual_value: DerElement
-                if der_parse_element(&ext_inner, &actual_value) != 0
+                if der_parse_element(@ext_inner, @actual_value) != 0
                     continue
-                ext_value = &actual_value
+                ext_value = @actual_value
 
         # Process known extensions
-        if oid_is_basic_constraints(&ext_oid) == 1
+        if oid_is_basic_constraints(@ext_oid) == 1
             # Parse basicConstraints
             if der_is_octet_string(ext_value) == 1
                 var bc_parser: DerParser
-                der_parser_init(&bc_parser, ext_value.content, ext_value.content_len)
+                der_parser_init(@bc_parser, ext_value.content, ext_value.content_len)
 
                 var bc_seq: DerElement
-                if der_parse_element(&bc_parser, &bc_seq) == 0
-                    if der_is_sequence(&bc_seq) == 1
+                if der_parse_element(@bc_parser, @bc_seq) == 0
+                    if der_is_sequence(@bc_seq) == 1
                         var bc_inner: DerParser
-                        if der_enter_sequence(&bc_seq, &bc_inner) == 0
-                            if der_parser_eof(&bc_inner) != 1
+                        if der_enter_sequence(@bc_seq, @bc_inner) == 0
+                            if der_parser_eof(@bc_inner) != 1
                                 var ca_elem: DerElement
-                                if der_parse_element(&bc_inner, &ca_elem) == 0
+                                if der_parse_element(@bc_inner, @ca_elem) == 0
                                     if ca_elem.tag_number == (TAG_BOOLEAN as u32)
                                         if ca_elem.content_len > 0
                                             if ca_elem.content[0] != 0
@@ -604,26 +604,26 @@ pub fn x509_parse_certificate(der_data: *u8, der_len: u64, cert: *X509Certificat
     mem_zero(cert as *u8, 1200)  # sizeof(X509Certificate) approximately
 
     var parser: DerParser
-    der_parser_init(&parser, der_data, der_len)
+    der_parser_init(@parser, der_data, der_len)
 
     # Certificate ::= SEQUENCE
     var cert_seq: DerElement
-    if der_parse_element(&parser, &cert_seq) != 0
+    if der_parse_element(@parser, @cert_seq) != 0
         return -1
 
-    if der_is_sequence(&cert_seq) != 1
+    if der_is_sequence(@cert_seq) != 1
         return -2
 
     var cert_parser: DerParser
-    if der_enter_sequence(&cert_seq, &cert_parser) != 0
+    if der_enter_sequence(@cert_seq, @cert_parser) != 0
         return -3
 
     # TBSCertificate
     var tbs: DerElement
-    if der_parse_element(&cert_parser, &tbs) != 0
+    if der_parse_element(@cert_parser, @tbs) != 0
         return -4
 
-    if der_is_sequence(&tbs) != 1
+    if der_is_sequence(@tbs) != 1
         return -5
 
     # Save TBS for signature verification
@@ -631,74 +631,74 @@ pub fn x509_parse_certificate(der_data: *u8, der_len: u64, cert: *X509Certificat
     cert.tbs_len = tbs.header_len + tbs.content_len
 
     var tbs_parser: DerParser
-    if der_enter_sequence(&tbs, &tbs_parser) != 0
+    if der_enter_sequence(@tbs, @tbs_parser) != 0
         return -6
 
     # Version [0] EXPLICIT (optional, default v1)
     var first_elem: DerElement
-    if der_parse_element(&tbs_parser, &first_elem) != 0
+    if der_parse_element(@tbs_parser, @first_elem) != 0
         return -7
 
-    if der_is_context_tag(&first_elem, 0) == 1
+    if der_is_context_tag(@first_elem, 0) == 1
         # Explicit version tag
         var ver_parser: DerParser
-        if der_enter_constructed(&first_elem, &ver_parser) != 0
+        if der_enter_constructed(@first_elem, @ver_parser) != 0
             return -8
 
         var ver_int: DerElement
-        if der_parse_element(&ver_parser, &ver_int) != 0
+        if der_parse_element(@ver_parser, @ver_int) != 0
             return -9
 
         var version: i64 = 0
-        if der_integer_to_i64(&ver_int, &version) != 0
+        if der_integer_to_i64(@ver_int, @version) != 0
             return -10
 
         cert.version = (version + 1) as u8  # 0 = v1, 1 = v2, 2 = v3
 
         # Parse serial number (next element)
-        if der_parse_element(&tbs_parser, &first_elem) != 0
+        if der_parse_element(@tbs_parser, @first_elem) != 0
             return -11
     else
         # No explicit version, default to v1
         cert.version = 1
 
     # Serial number (reusing first_elem)
-    if der_is_integer(&first_elem) != 1
+    if der_is_integer(@first_elem) != 1
         return -12
 
     var serial_len: u64 = first_elem.content_len
     if serial_len > 20
         serial_len = 20
-    mem_copy(&cert.serial[0], first_elem.content, serial_len)
+    mem_copy(@cert.serial[0], first_elem.content, serial_len)
     cert.serial_len = serial_len as u8
 
     # Signature algorithm (in TBS)
-    cert.sig_algorithm = x509_parse_sig_algorithm(&tbs_parser)
+    cert.sig_algorithm = x509_parse_sig_algorithm(@tbs_parser)
 
     # Issuer
-    if x509_parse_name(&tbs_parser, &cert.issuer) != 0
+    if x509_parse_name(@tbs_parser, @cert.issuer) != 0
         return -13
 
     # Validity
-    if x509_parse_validity(&tbs_parser, &cert.validity) != 0
+    if x509_parse_validity(@tbs_parser, @cert.validity) != 0
         return -14
 
     # Subject
-    if x509_parse_name(&tbs_parser, &cert.subject) != 0
+    if x509_parse_name(@tbs_parser, @cert.subject) != 0
         return -15
 
     # Subject Public Key Info
-    if x509_parse_public_key(&tbs_parser, &cert.public_key) != 0
+    if x509_parse_public_key(@tbs_parser, @cert.public_key) != 0
         return -16
 
     # Extensions (v3 only)
     if cert.version == 3
-        if der_parser_eof(&tbs_parser) != 1
+        if der_parser_eof(@tbs_parser) != 1
             # Try to parse extensions, but don't fail if we can't
-            x509_parse_extensions(&tbs_parser, cert)
+            x509_parse_extensions(@tbs_parser, cert)
 
     # Signature Algorithm (outer)
-    var outer_alg: u8 = x509_parse_sig_algorithm(&cert_parser)
+    var outer_alg: u8 = x509_parse_sig_algorithm(@cert_parser)
     # Should match inner algorithm
     if outer_alg != cert.sig_algorithm
         if outer_alg != SIG_ALG_UNKNOWN
@@ -707,19 +707,19 @@ pub fn x509_parse_certificate(der_data: *u8, der_len: u64, cert: *X509Certificat
 
     # Signature Value
     var sig_bits: DerElement
-    if der_parse_element(&cert_parser, &sig_bits) != 0
+    if der_parse_element(@cert_parser, @sig_bits) != 0
         return -18
 
     var sig_data: *u8 = null
     var sig_len: u64 = 0
     var unused: u8 = 0
 
-    if der_bit_string_content(&sig_bits, &sig_data, &sig_len, &unused) != 0
+    if der_bit_string_content(@sig_bits, @sig_data, @sig_len, @unused) != 0
         return -19
 
     if sig_len > 512
         sig_len = 512
-    mem_copy(&cert.signature[0], sig_data, sig_len)
+    mem_copy(@cert.signature[0], sig_data, sig_len)
     cert.signature_len = sig_len
 
     return 0
@@ -738,8 +738,8 @@ pub fn x509_is_valid_time(cert: *X509Certificate, current_time: i64) -> i32
 
 # Check if issuer matches subject (for chain validation)
 pub fn x509_is_issued_by(cert: *X509Certificate, issuer: *X509Certificate) -> i32
-    return x509_name_equals(&cert.issuer, &issuer.subject)
+    return x509_name_equals(@cert.issuer, @issuer.subject)
 
 # Check if certificate is self-signed
 pub fn x509_is_self_signed(cert: *X509Certificate) -> i32
-    return x509_name_equals(&cert.issuer, &cert.subject)
+    return x509_name_equals(@cert.issuer, @cert.subject)

--- a/projects/cryptosec/lib/x509_verify.ritz
+++ b/projects/cryptosec/lib/x509_verify.ritz
@@ -57,16 +57,16 @@ fn x509_verify_rsa_sha256(cert: *X509Certificate, issuer_key: *X509PublicKey) ->
 
     # Parse issuer's RSA public key from SubjectPublicKeyInfo
     var rsa_key: RsaPublicKey
-    let parse_result: i32 = rsa_parse_public_key(&issuer_key.key_data[0], issuer_key.key_len as i32, &rsa_key)
+    let parse_result: i32 = rsa_parse_public_key(@issuer_key.key_data[0], issuer_key.key_len as i32, @rsa_key)
     if parse_result != 0
         return 0
 
     # Hash the TBS data
     var hash: [32]u8
-    sha256(cert.tbs_data, cert.tbs_len as i64, &hash[0])
+    sha256(cert.tbs_data, cert.tbs_len as i64, @hash[0])
 
     # Verify signature
-    return rsa_verify_pkcs1_sha256_hash(&rsa_key, &hash[0], &cert.signature[0], cert.signature_len as i32)
+    return rsa_verify_pkcs1_sha256_hash(@rsa_key, @hash[0], @cert.signature[0], cert.signature_len as i32)
 
 # Verify RSA-SHA384 signature
 fn x509_verify_rsa_sha384(cert: *X509Certificate, issuer_key: *X509PublicKey) -> i32
@@ -77,14 +77,14 @@ fn x509_verify_rsa_sha384(cert: *X509Certificate, issuer_key: *X509PublicKey) ->
         return 0
 
     var rsa_key: RsaPublicKey
-    let parse_result: i32 = rsa_parse_public_key(&issuer_key.key_data[0], issuer_key.key_len as i32, &rsa_key)
+    let parse_result: i32 = rsa_parse_public_key(@issuer_key.key_data[0], issuer_key.key_len as i32, @rsa_key)
     if parse_result != 0
         return 0
 
     var hash: [48]u8
-    sha384(cert.tbs_data, cert.tbs_len as i64, &hash[0])
+    sha384(cert.tbs_data, cert.tbs_len as i64, @hash[0])
 
-    return rsa_verify_pkcs1_sha384_hash(&rsa_key, &hash[0], &cert.signature[0], cert.signature_len as i32)
+    return rsa_verify_pkcs1_sha384_hash(@rsa_key, @hash[0], @cert.signature[0], cert.signature_len as i32)
 
 # Verify RSA-SHA512 signature
 fn x509_verify_rsa_sha512(cert: *X509Certificate, issuer_key: *X509PublicKey) -> i32
@@ -95,14 +95,14 @@ fn x509_verify_rsa_sha512(cert: *X509Certificate, issuer_key: *X509PublicKey) ->
         return 0
 
     var rsa_key: RsaPublicKey
-    let parse_result: i32 = rsa_parse_public_key(&issuer_key.key_data[0], issuer_key.key_len as i32, &rsa_key)
+    let parse_result: i32 = rsa_parse_public_key(@issuer_key.key_data[0], issuer_key.key_len as i32, @rsa_key)
     if parse_result != 0
         return 0
 
     var hash: [64]u8
-    sha512(cert.tbs_data, cert.tbs_len as i64, &hash[0])
+    sha512(cert.tbs_data, cert.tbs_len as i64, @hash[0])
 
-    return rsa_verify_pkcs1_sha512_hash(&rsa_key, &hash[0], &cert.signature[0], cert.signature_len as i32)
+    return rsa_verify_pkcs1_sha512_hash(@rsa_key, @hash[0], @cert.signature[0], cert.signature_len as i32)
 
 # ============================================================================
 # Certificate Chain Validation
@@ -138,7 +138,7 @@ pub fn x509_verify_chain(chain: **X509Certificate, chain_len: i32, trusted_roots
             return 0
 
         # Verify cert's signature with issuer's public key
-        if x509_verify_signature(cert, &issuer.public_key) != 1
+        if x509_verify_signature(cert, @issuer.public_key) != 1
             return 0
 
         # Check that issuer is a CA (can sign certificates)
@@ -167,7 +167,7 @@ pub fn x509_verify_chain(chain: **X509Certificate, chain_len: i32, trusted_roots
             let trusted: *X509Certificate = trusted_roots[j]
             if trusted != null
                 if x509_is_issued_by(root, trusted) == 1
-                    if x509_verify_signature(root, &trusted.public_key) == 1
+                    if x509_verify_signature(root, @trusted.public_key) == 1
                         found = 1
                         break
             j += 1
@@ -176,7 +176,7 @@ pub fn x509_verify_chain(chain: **X509Certificate, chain_len: i32, trusted_roots
             return 0
     else
         # Self-signed root - verify its own signature
-        if x509_verify_signature(root, &root.public_key) != 1
+        if x509_verify_signature(root, @root.public_key) != 1
             return 0
 
         # Check if root is in trusted store (if provided)
@@ -187,7 +187,7 @@ pub fn x509_verify_chain(chain: **X509Certificate, chain_len: i32, trusted_roots
                 let trusted: *X509Certificate = trusted_roots[j]
                 if trusted != null
                     # Compare by subject DN
-                    if x509_name_equals(&root.subject, &trusted.subject) == 1
+                    if x509_name_equals(@root.subject, @trusted.subject) == 1
                         found = 1
                         break
                 j += 1
@@ -262,10 +262,10 @@ pub fn x509_hostname_match(pattern: *u8, pattern_len: i32, hostname: *u8, hostna
             return 0  # No dot or dot at start = no match
 
         # The part after the wildcard must match exactly
-        let pattern_suffix: *u8 = &pattern[1]  # ".domain.com"
+        let pattern_suffix: *u8 = @pattern[1]  # ".domain.com"
         let pattern_suffix_len: i32 = pattern_len - 1
 
-        let hostname_suffix: *u8 = &hostname[hostname_dot]
+        let hostname_suffix: *u8 = @hostname[hostname_dot]
         let hostname_suffix_len: i32 = hostname_len - hostname_dot
 
         return bytes_equal_ci(pattern_suffix, pattern_suffix_len, hostname_suffix, hostname_suffix_len)
@@ -283,7 +283,7 @@ pub fn x509_verify_hostname(cert: *X509Certificate, hostname: *u8, hostname_len:
     if cert.subject.common_name_len == 0
         return 0
 
-    return x509_hostname_match(&cert.subject.common_name[0], cert.subject.common_name_len as i32, hostname, hostname_len)
+    return x509_hostname_match(@cert.subject.common_name[0], cert.subject.common_name_len as i32, hostname, hostname_len)
 
 # ============================================================================
 # Simplified Verification for TLS

--- a/projects/cryptosec/test/test_aes.ritz
+++ b/projects/cryptosec/test/test_aes.ritz
@@ -45,15 +45,15 @@ fn test_aes128_encrypt_fips197() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", &key[0], 16)
-    hex_to_bytes(c"3243f6a8885a308d313198a2e0370734", &pt[0], 16)
-    hex_to_bytes(c"3925841d02dc09fbdc118597196a0b32", &expected[0], 16)
+    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes(c"3243f6a8885a308d313198a2e0370734", @pt[0], 16)
+    hex_to_bytes(c"3925841d02dc09fbdc118597196a0b32", @expected[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes128_init(@ctx, @key[0])
+    aes128_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -65,15 +65,15 @@ fn test_aes128_decrypt_fips197() -> i32
     var pt: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", &key[0], 16)
-    hex_to_bytes(c"3925841d02dc09fbdc118597196a0b32", &ct[0], 16)
-    hex_to_bytes(c"3243f6a8885a308d313198a2e0370734", &expected[0], 16)
+    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes(c"3925841d02dc09fbdc118597196a0b32", @ct[0], 16)
+    hex_to_bytes(c"3243f6a8885a308d313198a2e0370734", @expected[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_decrypt_block(&ctx, &ct[0], &pt[0])
+    aes128_init(@ctx, @key[0])
+    aes128_decrypt_block(@ctx, @ct[0], @pt[0])
 
-    if mem_eq(&pt[0], &expected[0], 16) == 0
+    if mem_eq(@pt[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -84,15 +84,15 @@ fn test_aes128_roundtrip() -> i32
     var ct: [16]u8
     var rt: [16]u8
 
-    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f", &key[0], 16)
-    hex_to_bytes(c"00112233445566778899aabbccddeeff", &pt[0], 16)
+    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f", @key[0], 16)
+    hex_to_bytes(c"00112233445566778899aabbccddeeff", @pt[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_encrypt_block(&ctx, &pt[0], &ct[0])
-    aes128_decrypt_block(&ctx, &ct[0], &rt[0])
+    aes128_init(@ctx, @key[0])
+    aes128_encrypt_block(@ctx, @pt[0], @ct[0])
+    aes128_decrypt_block(@ctx, @ct[0], @rt[0])
 
-    if mem_eq(&pt[0], &rt[0], 16) == 0
+    if mem_eq(@pt[0], @rt[0], 16) == 0
         return 1
     return 0
 
@@ -109,15 +109,15 @@ fn test_aes128_nist_ecb_vector1() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", &key[0], 16)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", &pt[0], 16)
-    hex_to_bytes(c"3ad77bb40d7a3660a89ecaf32466ef97", &expected[0], 16)
+    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
+    hex_to_bytes(c"3ad77bb40d7a3660a89ecaf32466ef97", @expected[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes128_init(@ctx, @key[0])
+    aes128_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -129,15 +129,15 @@ fn test_aes128_nist_ecb_vector2() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", &key[0], 16)
-    hex_to_bytes(c"ae2d8a571e03ac9c9eb76fac45af8e51", &pt[0], 16)
-    hex_to_bytes(c"f5d3d58503b9699de785895a96fdbaaf", &expected[0], 16)
+    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes(c"ae2d8a571e03ac9c9eb76fac45af8e51", @pt[0], 16)
+    hex_to_bytes(c"f5d3d58503b9699de785895a96fdbaaf", @expected[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes128_init(@ctx, @key[0])
+    aes128_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -157,15 +157,15 @@ fn test_aes256_encrypt_fips197() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", &key[0], 32)
-    hex_to_bytes(c"00112233445566778899aabbccddeeff", &pt[0], 16)
-    hex_to_bytes(c"8ea2b7ca516745bfeafc49904b496089", &expected[0], 16)
+    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", @key[0], 32)
+    hex_to_bytes(c"00112233445566778899aabbccddeeff", @pt[0], 16)
+    hex_to_bytes(c"8ea2b7ca516745bfeafc49904b496089", @expected[0], 16)
 
     var ctx: Aes256
-    aes256_init(&ctx, &key[0])
-    aes256_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes256_init(@ctx, @key[0])
+    aes256_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -177,15 +177,15 @@ fn test_aes256_decrypt_fips197() -> i32
     var pt: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", &key[0], 32)
-    hex_to_bytes(c"8ea2b7ca516745bfeafc49904b496089", &ct[0], 16)
-    hex_to_bytes(c"00112233445566778899aabbccddeeff", &expected[0], 16)
+    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", @key[0], 32)
+    hex_to_bytes(c"8ea2b7ca516745bfeafc49904b496089", @ct[0], 16)
+    hex_to_bytes(c"00112233445566778899aabbccddeeff", @expected[0], 16)
 
     var ctx: Aes256
-    aes256_init(&ctx, &key[0])
-    aes256_decrypt_block(&ctx, &ct[0], &pt[0])
+    aes256_init(@ctx, @key[0])
+    aes256_decrypt_block(@ctx, @ct[0], @pt[0])
 
-    if mem_eq(&pt[0], &expected[0], 16) == 0
+    if mem_eq(@pt[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -196,15 +196,15 @@ fn test_aes256_roundtrip() -> i32
     var ct: [16]u8
     var rt: [16]u8
 
-    hex_to_bytes(c"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", &key[0], 32)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", &pt[0], 16)
+    hex_to_bytes(c"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", @key[0], 32)
+    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
 
     var ctx: Aes256
-    aes256_init(&ctx, &key[0])
-    aes256_encrypt_block(&ctx, &pt[0], &ct[0])
-    aes256_decrypt_block(&ctx, &ct[0], &rt[0])
+    aes256_init(@ctx, @key[0])
+    aes256_encrypt_block(@ctx, @pt[0], @ct[0])
+    aes256_decrypt_block(@ctx, @ct[0], @rt[0])
 
-    if mem_eq(&pt[0], &rt[0], 16) == 0
+    if mem_eq(@pt[0], @rt[0], 16) == 0
         return 1
     return 0
 
@@ -220,15 +220,15 @@ fn test_aes256_nist_ecb_vector1() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", &key[0], 32)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", &pt[0], 16)
-    hex_to_bytes(c"f3eed1bdb5d2a03c064b5a7e3db181f8", &expected[0], 16)
+    hex_to_bytes(c"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", @key[0], 32)
+    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
+    hex_to_bytes(c"f3eed1bdb5d2a03c064b5a7e3db181f8", @expected[0], 16)
 
     var ctx: Aes256
-    aes256_init(&ctx, &key[0])
-    aes256_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes256_init(@ctx, @key[0])
+    aes256_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -249,16 +249,16 @@ fn test_aes128_zero_key_zero_pt() -> i32
     var expected: [16]u8
 
     # Zero-initialize key and plaintext
-    mem_zero(&key[0], 16)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 16)
+    mem_zero(@pt[0], 16)
 
-    hex_to_bytes(c"66e94bd4ef8a2c3b884cfa59ca342b2e", &expected[0], 16)
+    hex_to_bytes(c"66e94bd4ef8a2c3b884cfa59ca342b2e", @expected[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes128_init(@ctx, @key[0])
+    aes128_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -275,16 +275,16 @@ fn test_aes256_zero_key_zero_pt() -> i32
     var expected: [16]u8
 
     # Zero-initialize key and plaintext
-    mem_zero(&key[0], 32)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 32)
+    mem_zero(@pt[0], 16)
 
-    hex_to_bytes(c"dc95c078a2408989ad48a21492842087", &expected[0], 16)
+    hex_to_bytes(c"dc95c078a2408989ad48a21492842087", @expected[0], 16)
 
     var ctx: Aes256
-    aes256_init(&ctx, &key[0])
-    aes256_encrypt_block(&ctx, &pt[0], &ct[0])
+    aes256_init(@ctx, @key[0])
+    aes256_encrypt_block(@ctx, @pt[0], @ct[0])
 
-    if mem_eq(&ct[0], &expected[0], 16) == 0
+    if mem_eq(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -303,19 +303,19 @@ fn test_aes128_multiple_blocks() -> i32
     var rt1: [16]u8
     var rt2: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", &key[0], 16)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", &pt1[0], 16)
-    hex_to_bytes(c"ae2d8a571e03ac9c9eb76fac45af8e51", &pt2[0], 16)
+    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt1[0], 16)
+    hex_to_bytes(c"ae2d8a571e03ac9c9eb76fac45af8e51", @pt2[0], 16)
 
     var ctx: Aes128
-    aes128_init(&ctx, &key[0])
-    aes128_encrypt_block(&ctx, &pt1[0], &ct1[0])
-    aes128_encrypt_block(&ctx, &pt2[0], &ct2[0])
-    aes128_decrypt_block(&ctx, &ct1[0], &rt1[0])
-    aes128_decrypt_block(&ctx, &ct2[0], &rt2[0])
+    aes128_init(@ctx, @key[0])
+    aes128_encrypt_block(@ctx, @pt1[0], @ct1[0])
+    aes128_encrypt_block(@ctx, @pt2[0], @ct2[0])
+    aes128_decrypt_block(@ctx, @ct1[0], @rt1[0])
+    aes128_decrypt_block(@ctx, @ct2[0], @rt2[0])
 
-    if mem_eq(&pt1[0], &rt1[0], 16) == 0
+    if mem_eq(@pt1[0], @rt1[0], 16) == 0
         return 1
-    if mem_eq(&pt2[0], &rt2[0], 16) == 0
+    if mem_eq(@pt2[0], @rt2[0], 16) == 0
         return 2
     return 0

--- a/projects/cryptosec/test/test_aes_gcm.ritz
+++ b/projects/cryptosec/test/test_aes_gcm.ritz
@@ -26,13 +26,13 @@ fn test_aes128_gcm_empty_pt_no_aad() -> i32
     var ct: [16]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 16)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 16)
+    mem_zero(@nonce[0], 12)
 
     var ctx: AesGcm128
-    aes128_gcm_init(&ctx, &key[0])
+    aes128_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes128_gcm_encrypt(&ctx, &nonce[0], 12, nil, 0, nil, 0, &ct[0], &tag[0])
+    let ct_len: i64 = aes128_gcm_encrypt(@ctx, @nonce[0], 12, nil, 0, nil, 0, @ct[0], @tag[0])
 
     # Expected tag: 58e2fccefa7e3061367f1d57a4e7455a
     var expected_tag: [16]u8
@@ -55,7 +55,7 @@ fn test_aes128_gcm_empty_pt_no_aad() -> i32
 
     if ct_len != 0
         return 1
-    if bytes_equal(&tag[0], &expected_tag[0], 16) == 0
+    if bytes_equal(@tag[0], @expected_tag[0], 16) == 0
         return 2
     return 0
 
@@ -68,14 +68,14 @@ fn test_aes128_gcm_16byte_pt() -> i32
     var ct: [16]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 16)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 16)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@pt[0], 16)
 
     var ctx: AesGcm128
-    aes128_gcm_init(&ctx, &key[0])
+    aes128_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes128_gcm_encrypt(&ctx, &nonce[0], 12, nil, 0, &pt[0], 16, &ct[0], &tag[0])
+    let ct_len: i64 = aes128_gcm_encrypt(@ctx, @nonce[0], 12, nil, 0, @pt[0], 16, @ct[0], @tag[0])
 
     # Expected ciphertext: 0388dace60b6a392f328c2b971b2fe78
     var expected_ct: [16]u8
@@ -117,9 +117,9 @@ fn test_aes128_gcm_16byte_pt() -> i32
 
     if ct_len != 16
         return 1
-    if bytes_equal(&ct[0], &expected_ct[0], 16) == 0
+    if bytes_equal(@ct[0], @expected_ct[0], 16) == 0
         return 2
-    if bytes_equal(&tag[0], &expected_tag[0], 16) == 0
+    if bytes_equal(@tag[0], @expected_tag[0], 16) == 0
         return 3
     return 0
 
@@ -147,14 +147,14 @@ fn test_aes128_gcm_roundtrip() -> i32
         i += 1
 
     var ctx: AesGcm128
-    aes128_gcm_init(&ctx, &key[0])
+    aes128_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes128_gcm_encrypt(&ctx, &nonce[0], 12, nil, 0, &pt[0], 32, &ct[0], &tag[0])
-    let result: i32 = aes128_gcm_decrypt(&ctx, &nonce[0], 12, nil, 0, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let ct_len: i64 = aes128_gcm_encrypt(@ctx, @nonce[0], 12, nil, 0, @pt[0], 32, @ct[0], @tag[0])
+    let result: i32 = aes128_gcm_decrypt(@ctx, @nonce[0], 12, nil, 0, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 1
         return 1
-    if bytes_equal(&pt[0], &decrypted[0], 32) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 32) == 0
         return 2
     return 0
 
@@ -181,14 +181,14 @@ fn test_aes128_gcm_with_aad() -> i32
         i += 1
 
     var ctx: AesGcm128
-    aes128_gcm_init(&ctx, &key[0])
+    aes128_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes128_gcm_encrypt(&ctx, &nonce[0], 12, &aad[0], 16, &pt[0], 16, &ct[0], &tag[0])
-    let result: i32 = aes128_gcm_decrypt(&ctx, &nonce[0], 12, &aad[0], 16, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let ct_len: i64 = aes128_gcm_encrypt(@ctx, @nonce[0], 12, @aad[0], 16, @pt[0], 16, @ct[0], @tag[0])
+    let result: i32 = aes128_gcm_decrypt(@ctx, @nonce[0], 12, @aad[0], 16, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 1
         return 1
-    if bytes_equal(&pt[0], &decrypted[0], 16) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 16) == 0
         return 2
     return 0
 
@@ -202,19 +202,19 @@ fn test_aes128_gcm_tampered_ct() -> i32
     var decrypted: [16]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 16)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 16)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@pt[0], 16)
 
     var ctx: AesGcm128
-    aes128_gcm_init(&ctx, &key[0])
+    aes128_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes128_gcm_encrypt(&ctx, &nonce[0], 12, nil, 0, &pt[0], 16, &ct[0], &tag[0])
+    let ct_len: i64 = aes128_gcm_encrypt(@ctx, @nonce[0], 12, nil, 0, @pt[0], 16, @ct[0], @tag[0])
 
     # Tamper with ciphertext
     ct[0] = ct[0] ^ 0x01
 
-    let result: i32 = aes128_gcm_decrypt(&ctx, &nonce[0], 12, nil, 0, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let result: i32 = aes128_gcm_decrypt(@ctx, @nonce[0], 12, nil, 0, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 0
         return 1
@@ -230,19 +230,19 @@ fn test_aes128_gcm_tampered_tag() -> i32
     var decrypted: [16]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 16)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 16)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@pt[0], 16)
 
     var ctx: AesGcm128
-    aes128_gcm_init(&ctx, &key[0])
+    aes128_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes128_gcm_encrypt(&ctx, &nonce[0], 12, nil, 0, &pt[0], 16, &ct[0], &tag[0])
+    let ct_len: i64 = aes128_gcm_encrypt(@ctx, @nonce[0], 12, nil, 0, @pt[0], 16, @ct[0], @tag[0])
 
     # Tamper with tag
     tag[0] = tag[0] ^ 0x01
 
-    let result: i32 = aes128_gcm_decrypt(&ctx, &nonce[0], 12, nil, 0, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let result: i32 = aes128_gcm_decrypt(@ctx, @nonce[0], 12, nil, 0, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 0
         return 1
@@ -275,14 +275,14 @@ fn test_aes256_gcm_roundtrip() -> i32
         i += 1
 
     var ctx: AesGcm256
-    aes256_gcm_init(&ctx, &key[0])
+    aes256_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes256_gcm_encrypt(&ctx, &nonce[0], 12, nil, 0, &pt[0], 48, &ct[0], &tag[0])
-    let result: i32 = aes256_gcm_decrypt(&ctx, &nonce[0], 12, nil, 0, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let ct_len: i64 = aes256_gcm_encrypt(@ctx, @nonce[0], 12, nil, 0, @pt[0], 48, @ct[0], @tag[0])
+    let result: i32 = aes256_gcm_decrypt(@ctx, @nonce[0], 12, nil, 0, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 1
         return 1
-    if bytes_equal(&pt[0], &decrypted[0], 48) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 48) == 0
         return 2
     return 0
 
@@ -314,14 +314,14 @@ fn test_aes256_gcm_with_aad() -> i32
         i += 1
 
     var ctx: AesGcm256
-    aes256_gcm_init(&ctx, &key[0])
+    aes256_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes256_gcm_encrypt(&ctx, &nonce[0], 12, &aad[0], 20, &pt[0], 64, &ct[0], &tag[0])
-    let result: i32 = aes256_gcm_decrypt(&ctx, &nonce[0], 12, &aad[0], 20, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let ct_len: i64 = aes256_gcm_encrypt(@ctx, @nonce[0], 12, @aad[0], 20, @pt[0], 64, @ct[0], @tag[0])
+    let result: i32 = aes256_gcm_decrypt(@ctx, @nonce[0], 12, @aad[0], 20, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 1
         return 1
-    if bytes_equal(&pt[0], &decrypted[0], 64) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 64) == 0
         return 2
     return 0
 
@@ -337,18 +337,18 @@ fn test_aes256_gcm_wrong_aad() -> i32
     var decrypted: [16]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&aad[0], 16)
-    mem_zero(&wrong_aad[0], 16)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@aad[0], 16)
+    mem_zero(@wrong_aad[0], 16)
+    mem_zero(@pt[0], 16)
     wrong_aad[0] = 0x01
 
     var ctx: AesGcm256
-    aes256_gcm_init(&ctx, &key[0])
+    aes256_gcm_init(@ctx, @key[0])
 
-    let ct_len: i64 = aes256_gcm_encrypt(&ctx, &nonce[0], 12, &aad[0], 16, &pt[0], 16, &ct[0], &tag[0])
-    let result: i32 = aes256_gcm_decrypt(&ctx, &nonce[0], 12, &wrong_aad[0], 16, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let ct_len: i64 = aes256_gcm_encrypt(@ctx, @nonce[0], 12, @aad[0], 16, @pt[0], 16, @ct[0], @tag[0])
+    let result: i32 = aes256_gcm_decrypt(@ctx, @nonce[0], 12, @wrong_aad[0], 16, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 0
         return 1

--- a/projects/cryptosec/test/test_asn1.ritz
+++ b/projects/cryptosec/test/test_asn1.ritz
@@ -20,13 +20,13 @@ fn test_parse_integer_tag() -> i32
     data[2] = 0x00  # value 0
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 3)
+    der_parser_init(@parser, @data[0], 3)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
-    if der_is_integer(&elem) != 1
+    if der_is_integer(@elem) != 1
         return 2
 
     if elem.content_len != 1
@@ -48,13 +48,13 @@ fn test_parse_sequence_tag() -> i32
     data[4] = 0x01  # value 1
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 5)
+    der_parser_init(@parser, @data[0], 5)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
-    if der_is_sequence(&elem) != 1
+    if der_is_sequence(@elem) != 1
         return 2
 
     if elem.constructed != 1
@@ -74,13 +74,13 @@ fn test_parse_context_tag() -> i32
     data[2] = 0x05  # content
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 3)
+    der_parser_init(@parser, @data[0], 3)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
-    if der_is_context_tag(&elem, 0) != 1
+    if der_is_context_tag(@elem, 0) != 1
         return 2
 
     if elem.constructed != 1
@@ -105,10 +105,10 @@ fn test_short_length() -> i32
     data[6] = 0x05
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 7)
+    der_parser_init(@parser, @data[0], 7)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     if elem.content_len != 5
@@ -132,10 +132,10 @@ fn test_long_length_one_byte() -> i32
         i += 1
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 131)
+    der_parser_init(@parser, @data[0], 131)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     if elem.content_len != 128
@@ -161,10 +161,10 @@ fn test_long_length_two_bytes() -> i32
         i += 1
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 260)
+    der_parser_init(@parser, @data[0], 260)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     if elem.content_len != 256
@@ -187,14 +187,14 @@ fn test_integer_zero() -> i32
     data[2] = 0x00  # value 0
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 3)
+    der_parser_init(@parser, @data[0], 3)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var value: i64 = 0
-    if der_integer_to_i64(&elem, &value) != 0
+    if der_integer_to_i64(@elem, @value) != 0
         return 2
 
     if value != 0
@@ -211,14 +211,14 @@ fn test_integer_positive() -> i32
     data[2] = 0x7f
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 3)
+    der_parser_init(@parser, @data[0], 3)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var value: i64 = 0
-    if der_integer_to_i64(&elem, &value) != 0
+    if der_integer_to_i64(@elem, @value) != 0
         return 2
 
     if value != 127
@@ -235,14 +235,14 @@ fn test_integer_negative() -> i32
     data[2] = 0xff
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 3)
+    der_parser_init(@parser, @data[0], 3)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var value: i64 = 0
-    if der_integer_to_i64(&elem, &value) != 0
+    if der_integer_to_i64(@elem, @value) != 0
         return 2
 
     if value != -1
@@ -260,14 +260,14 @@ fn test_integer_128() -> i32
     data[3] = 0x80  # 128
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 4)
+    der_parser_init(@parser, @data[0], 4)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var value: u64 = 0
-    if der_integer_to_u64(&elem, &value) != 0
+    if der_integer_to_u64(@elem, @value) != 0
         return 2
 
     if value != 128
@@ -286,14 +286,14 @@ fn test_integer_large() -> i32
     data[4] = 0x01
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 5)
+    der_parser_init(@parser, @data[0], 5)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var value: u64 = 0
-    if der_integer_to_u64(&elem, &value) != 0
+    if der_integer_to_u64(@elem, @value) != 0
         return 2
 
     if value != 65537
@@ -323,17 +323,17 @@ fn test_oid_rsa() -> i32
     data[10] = 0x01 # 1
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 11)
+    der_parser_init(@parser, @data[0], 11)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
-    if der_is_oid(&elem) != 1
+    if der_is_oid(@elem) != 1
         return 2
 
     var oid: Oid
-    if der_decode_oid(&elem, &oid) != 0
+    if der_decode_oid(@elem, @oid) != 0
         return 3
 
     if oid.num_components != 7
@@ -354,7 +354,7 @@ fn test_oid_rsa() -> i32
     if oid.components[6] != 1
         return 11
 
-    if oid_is_rsa(&oid) != 1
+    if oid_is_rsa(@oid) != 1
         return 12
 
     return 0
@@ -376,17 +376,17 @@ fn test_oid_sha256_rsa() -> i32
     data[10] = 0x0b # .11
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 11)
+    der_parser_init(@parser, @data[0], 11)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var oid: Oid
-    if der_decode_oid(&elem, &oid) != 0
+    if der_decode_oid(@elem, @oid) != 0
         return 2
 
-    if oid_is_sha256_rsa(&oid) != 1
+    if oid_is_sha256_rsa(@oid) != 1
         return 3
 
     return 0
@@ -403,20 +403,20 @@ fn test_oid_ed25519() -> i32
     data[4] = 0x70  # 112
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 5)
+    der_parser_init(@parser, @data[0], 5)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var oid: Oid
-    if der_decode_oid(&elem, &oid) != 0
+    if der_decode_oid(@elem, @oid) != 0
         return 2
 
     if oid.num_components != 4
         return 3
 
-    if oid_is_ed25519(&oid) != 1
+    if oid_is_ed25519(@oid) != 1
         return 4
 
     return 0
@@ -433,17 +433,17 @@ fn test_oid_common_name() -> i32
     data[4] = 0x03  # 3
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 5)
+    der_parser_init(@parser, @data[0], 5)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var oid: Oid
-    if der_decode_oid(&elem, &oid) != 0
+    if der_decode_oid(@elem, @oid) != 0
         return 2
 
-    if oid_is_common_name(&oid) != 1
+    if oid_is_common_name(@oid) != 1
         return 3
 
     return 0
@@ -467,36 +467,36 @@ fn test_nested_sequence() -> i32
     data[8] = 0x2a  # 42
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 9)
+    der_parser_init(@parser, @data[0], 9)
 
     var outer: DerElement
-    if der_parse_element(&parser, &outer) != 0
+    if der_parse_element(@parser, @outer) != 0
         return 1
 
-    if der_is_sequence(&outer) != 1
+    if der_is_sequence(@outer) != 1
         return 2
 
     var inner_parser: DerParser
-    if der_enter_sequence(&outer, &inner_parser) != 0
+    if der_enter_sequence(@outer, @inner_parser) != 0
         return 3
 
     var inner: DerElement
-    if der_parse_element(&inner_parser, &inner) != 0
+    if der_parse_element(@inner_parser, @inner) != 0
         return 4
 
-    if der_is_sequence(&inner) != 1
+    if der_is_sequence(@inner) != 1
         return 5
 
     var int_parser: DerParser
-    if der_enter_sequence(&inner, &int_parser) != 0
+    if der_enter_sequence(@inner, @int_parser) != 0
         return 6
 
     var int_elem: DerElement
-    if der_parse_element(&int_parser, &int_elem) != 0
+    if der_parse_element(@int_parser, @int_elem) != 0
         return 7
 
     var value: u64 = 0
-    if der_integer_to_u64(&int_elem, &value) != 0
+    if der_integer_to_u64(@int_elem, @value) != 0
         return 8
 
     if value != 42
@@ -519,20 +519,20 @@ fn test_bit_string() -> i32
     data[4] = 0xcd
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 5)
+    der_parser_init(@parser, @data[0], 5)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
-    if der_is_bit_string(&elem) != 1
+    if der_is_bit_string(@elem) != 1
         return 2
 
     var bits: *u8 = null
     var bits_len: u64 = 0
     var unused: u8 = 0
 
-    if der_bit_string_content(&elem, &bits, &bits_len, &unused) != 0
+    if der_bit_string_content(@elem, @bits, @bits_len, @unused) != 0
         return 3
 
     if unused != 0
@@ -560,13 +560,13 @@ fn test_null() -> i32
     data[1] = 0x00  # length 0
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 2)
+    der_parser_init(@parser, @data[0], 2)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
-    if der_is_null(&elem) != 1
+    if der_is_null(@elem) != 1
         return 2
 
     return 0
@@ -585,11 +585,11 @@ fn test_truncated_data() -> i32
     data[3] = 0x02
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 4)
+    der_parser_init(@parser, @data[0], 4)
 
     var elem: DerElement
     # Should fail due to insufficient data
-    if der_parse_element(&parser, &elem) == 0
+    if der_parse_element(@parser, @elem) == 0
         return 1  # Should have failed
 
     return 0
@@ -597,12 +597,12 @@ fn test_truncated_data() -> i32
 [[test]]
 fn test_empty_parser() -> i32
     var parser: DerParser
-    der_parser_init(&parser, null, 0)
+    der_parser_init(@parser, null, 0)
 
-    if der_parser_eof(&parser) != 1
+    if der_parser_eof(@parser) != 1
         return 1
 
-    if der_parser_remaining(&parser) != 0
+    if der_parser_remaining(@parser) != 0
         return 2
 
     return 0
@@ -633,41 +633,41 @@ fn test_algorithm_identifier_rsa() -> i32
     data[14] = 0x00
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 15)
+    der_parser_init(@parser, @data[0], 15)
 
     var seq: DerElement
-    if der_parse_element(&parser, &seq) != 0
+    if der_parse_element(@parser, @seq) != 0
         return 1
 
-    if der_is_sequence(&seq) != 1
+    if der_is_sequence(@seq) != 1
         return 2
 
     var seq_parser: DerParser
-    if der_enter_sequence(&seq, &seq_parser) != 0
+    if der_enter_sequence(@seq, @seq_parser) != 0
         return 3
 
     # Parse OID
     var oid_elem: DerElement
-    if der_parse_element(&seq_parser, &oid_elem) != 0
+    if der_parse_element(@seq_parser, @oid_elem) != 0
         return 4
 
     var oid: Oid
-    if der_decode_oid(&oid_elem, &oid) != 0
+    if der_decode_oid(@oid_elem, @oid) != 0
         return 5
 
-    if oid_is_rsa(&oid) != 1
+    if oid_is_rsa(@oid) != 1
         return 6
 
     # Parse NULL parameters
     var null_elem: DerElement
-    if der_parse_element(&seq_parser, &null_elem) != 0
+    if der_parse_element(@seq_parser, @null_elem) != 0
         return 7
 
-    if der_is_null(&null_elem) != 1
+    if der_is_null(@null_elem) != 1
         return 8
 
     # Should be at end
-    if der_parser_eof(&seq_parser) != 1
+    if der_parser_eof(@seq_parser) != 1
         return 9
 
     return 0
@@ -689,10 +689,10 @@ fn test_multi_byte_tag() -> i32
     data[4] = 0xcd
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 5)
+    der_parser_init(@parser, @data[0], 5)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     if elem.tag_class != TAG_CLASS_CONTEXT

--- a/projects/cryptosec/test/test_bigint.ritz
+++ b/projects/cryptosec/test/test_bigint.ritz
@@ -9,21 +9,21 @@ import lib.bigint
 [[test]]
 fn test_bigint_zero()
     var a: BigInt
-    bigint_zero(&a)
-    assert bigint_is_zero(&a) == 1
+    bigint_zero(@a)
+    assert bigint_is_zero(@a) == 1
 
 [[test]]
 fn test_bigint_one()
     var a: BigInt
-    bigint_one(&a)
-    assert bigint_is_zero(&a) == 0
+    bigint_one(@a)
+    assert bigint_is_zero(@a) == 0
     assert a.limbs[0] == 1
     assert a.limbs[1] == 0
 
 [[test]]
 fn test_bigint_from_u64()
     var a: BigInt
-    bigint_from_u64(&a, 0x123456789abcdef0)
+    bigint_from_u64(@a, 0x123456789abcdef0)
     assert a.limbs[0] == 0x123456789abcdef0
     assert a.limbs[1] == 0
 
@@ -31,10 +31,10 @@ fn test_bigint_from_u64()
 fn test_bigint_copy()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 42)
-    bigint_copy(&b, &a)
+    bigint_from_u64(@a, 42)
+    bigint_copy(@b, @a)
     assert b.limbs[0] == 42
-    assert bigint_eq(&a, &b) == 1
+    assert bigint_eq(@a, @b) == 1
 
 # ============================================================================
 # Byte Conversion Tests
@@ -48,7 +48,7 @@ fn test_bigint_from_bytes_simple()
     bytes[1] = 0x34
     bytes[2] = 0x56
     bytes[3] = 0x78
-    bigint_from_bytes(&a, &bytes[0], 4)
+    bigint_from_bytes(@a, @bytes[0], 4)
     assert a.limbs[0] == 0x12345678
 
 [[test]]
@@ -63,7 +63,7 @@ fn test_bigint_from_bytes_64bit()
     bytes[5] = 0x06
     bytes[6] = 0x07
     bytes[7] = 0x08
-    bigint_from_bytes(&a, &bytes[0], 8)
+    bigint_from_bytes(@a, @bytes[0], 8)
     assert a.limbs[0] == 0x0102030405060708
 
 [[test]]
@@ -88,7 +88,7 @@ fn test_bigint_from_bytes_multi_limb()
     bytes[13] = 0xff
     bytes[14] = 0x00
     bytes[15] = 0x11
-    bigint_from_bytes(&a, &bytes[0], 16)
+    bigint_from_bytes(@a, @bytes[0], 16)
     # Little-endian limb order, so limbs[0] is low
     assert a.limbs[0] == 0xaabbccddeeff0011
     assert a.limbs[1] == 0x1122334455667788
@@ -105,10 +105,10 @@ fn test_bigint_to_bytes_roundtrip()
     bytes_in[5] = 0xfe
     bytes_in[6] = 0xba
     bytes_in[7] = 0xbe
-    bigint_from_bytes(&a, &bytes_in[0], 8)
+    bigint_from_bytes(@a, @bytes_in[0], 8)
 
     var bytes_out: [8]u8
-    bigint_to_bytes_fixed(&a, &bytes_out[0], 8)
+    bigint_to_bytes_fixed(@a, @bytes_out[0], 8)
 
     var i: i32 = 0
     while i < 8
@@ -123,50 +123,50 @@ fn test_bigint_to_bytes_roundtrip()
 fn test_bigint_eq()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 12345)
-    bigint_from_u64(&b, 12345)
-    assert bigint_eq(&a, &b) == 1
+    bigint_from_u64(@a, 12345)
+    bigint_from_u64(@b, 12345)
+    assert bigint_eq(@a, @b) == 1
 
-    bigint_from_u64(&b, 12346)
-    assert bigint_eq(&a, &b) == 0
+    bigint_from_u64(@b, 12346)
+    assert bigint_eq(@a, @b) == 0
 
 [[test]]
 fn test_bigint_lt()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 100)
-    bigint_from_u64(&b, 200)
-    assert bigint_lt(&a, &b) == 1
-    assert bigint_lt(&b, &a) == 0
-    assert bigint_lt(&a, &a) == 0
+    bigint_from_u64(@a, 100)
+    bigint_from_u64(@b, 200)
+    assert bigint_lt(@a, @b) == 1
+    assert bigint_lt(@b, @a) == 0
+    assert bigint_lt(@a, @a) == 0
 
 [[test]]
 fn test_bigint_ge()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 100)
-    bigint_from_u64(&b, 200)
-    assert bigint_ge(&a, &b) == 0
-    assert bigint_ge(&b, &a) == 1
-    assert bigint_ge(&a, &a) == 1
+    bigint_from_u64(@a, 100)
+    bigint_from_u64(@b, 200)
+    assert bigint_ge(@a, @b) == 0
+    assert bigint_ge(@b, @a) == 1
+    assert bigint_ge(@a, @a) == 1
 
 [[test]]
 fn test_bigint_bit_length()
     var a: BigInt
-    bigint_from_u64(&a, 0)
-    assert bigint_bit_length(&a) == 0
+    bigint_from_u64(@a, 0)
+    assert bigint_bit_length(@a) == 0
 
-    bigint_from_u64(&a, 1)
-    assert bigint_bit_length(&a) == 1
+    bigint_from_u64(@a, 1)
+    assert bigint_bit_length(@a) == 1
 
-    bigint_from_u64(&a, 255)
-    assert bigint_bit_length(&a) == 8
+    bigint_from_u64(@a, 255)
+    assert bigint_bit_length(@a) == 8
 
-    bigint_from_u64(&a, 256)
-    assert bigint_bit_length(&a) == 9
+    bigint_from_u64(@a, 256)
+    assert bigint_bit_length(@a) == 9
 
-    bigint_from_u64(&a, 0x8000000000000000)
-    assert bigint_bit_length(&a) == 64
+    bigint_from_u64(@a, 0x8000000000000000)
+    assert bigint_bit_length(@a) == 64
 
 # ============================================================================
 # Arithmetic Tests
@@ -176,18 +176,18 @@ fn test_bigint_bit_length()
 fn test_bigint_add_simple()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 100)
-    bigint_from_u64(&b, 50)
-    bigint_add(&a, &b)
+    bigint_from_u64(@a, 100)
+    bigint_from_u64(@b, 50)
+    bigint_add(@a, @b)
     assert a.limbs[0] == 150
 
 [[test]]
 fn test_bigint_add_overflow()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 0xffffffffffffffff)
-    bigint_from_u64(&b, 1)
-    let carry: u64 = bigint_add(&a, &b)
+    bigint_from_u64(@a, 0xffffffffffffffff)
+    bigint_from_u64(@b, 1)
+    let carry: u64 = bigint_add(@a, @b)
     # a should now be 0x10000000000000000 (in two limbs)
     assert a.limbs[0] == 0
     assert a.limbs[1] == 1
@@ -196,9 +196,9 @@ fn test_bigint_add_overflow()
 fn test_bigint_sub_simple()
     var a: BigInt
     var b: BigInt
-    bigint_from_u64(&a, 100)
-    bigint_from_u64(&b, 30)
-    bigint_sub(&a, &b)
+    bigint_from_u64(@a, 100)
+    bigint_from_u64(@b, 30)
+    bigint_sub(@a, @b)
     assert a.limbs[0] == 70
 
 [[test]]
@@ -206,9 +206,9 @@ fn test_bigint_mul_simple()
     var a: BigInt
     var b: BigInt
     var result: BigInt
-    bigint_from_u64(&a, 12345)
-    bigint_from_u64(&b, 6789)
-    bigint_mul(&result, &a, &b)
+    bigint_from_u64(@a, 12345)
+    bigint_from_u64(@b, 6789)
+    bigint_mul(@result, @a, @b)
     # 12345 * 6789 = 83810205
     assert result.limbs[0] == 83810205
 
@@ -217,9 +217,9 @@ fn test_bigint_mul_large()
     var a: BigInt
     var b: BigInt
     var result: BigInt
-    bigint_from_u64(&a, 0xffffffff)
-    bigint_from_u64(&b, 0xffffffff)
-    bigint_mul(&result, &a, &b)
+    bigint_from_u64(@a, 0xffffffff)
+    bigint_from_u64(@b, 0xffffffff)
+    bigint_mul(@result, @a, @b)
     # (2^32 - 1)^2 = 2^64 - 2^33 + 1 = 0xfffffffe00000001
     assert result.limbs[0] == 0xfffffffe00000001
 
@@ -230,30 +230,30 @@ fn test_bigint_mul_large()
 [[test]]
 fn test_bigint_shl()
     var a: BigInt
-    bigint_from_u64(&a, 1)
-    bigint_shl(&a, 64)
+    bigint_from_u64(@a, 1)
+    bigint_shl(@a, 64)
     assert a.limbs[0] == 0
     assert a.limbs[1] == 1
 
 [[test]]
 fn test_bigint_shr()
     var a: BigInt
-    bigint_zero(&a)
+    bigint_zero(@a)
     a.limbs[1] = 1
-    bigint_shr(&a, 64)
+    bigint_shr(@a, 64)
     assert a.limbs[0] == 1
     assert a.limbs[1] == 0
 
 [[test]]
 fn test_bigint_get_bit()
     var a: BigInt
-    bigint_from_u64(&a, 0b10101010)
-    assert bigint_get_bit(&a, 0) == 0
-    assert bigint_get_bit(&a, 1) == 1
-    assert bigint_get_bit(&a, 2) == 0
-    assert bigint_get_bit(&a, 3) == 1
-    assert bigint_get_bit(&a, 7) == 1
-    assert bigint_get_bit(&a, 8) == 0
+    bigint_from_u64(@a, 0b10101010)
+    assert bigint_get_bit(@a, 0) == 0
+    assert bigint_get_bit(@a, 1) == 1
+    assert bigint_get_bit(@a, 2) == 0
+    assert bigint_get_bit(@a, 3) == 1
+    assert bigint_get_bit(@a, 7) == 1
+    assert bigint_get_bit(@a, 8) == 0
 
 # ============================================================================
 # Modular Arithmetic Tests
@@ -264,9 +264,9 @@ fn test_bigint_mod_simple()
     var a: BigInt
     var n: BigInt
     var result: BigInt
-    bigint_from_u64(&a, 17)
-    bigint_from_u64(&n, 5)
-    bigint_mod_fast(&result, &a, &n)
+    bigint_from_u64(@a, 17)
+    bigint_from_u64(@n, 5)
+    bigint_mod_fast(@result, @a, @n)
     # 17 mod 5 = 2
     assert result.limbs[0] == 2
 
@@ -275,9 +275,9 @@ fn test_bigint_mod_larger()
     var a: BigInt
     var n: BigInt
     var result: BigInt
-    bigint_from_u64(&a, 1000000)
-    bigint_from_u64(&n, 97)
-    bigint_mod_fast(&result, &a, &n)
+    bigint_from_u64(@a, 1000000)
+    bigint_from_u64(@n, 97)
+    bigint_mod_fast(@result, @a, @n)
     # 1000000 mod 97 = 9 (since 1000000 = 10309 * 97 + 27)
     # Actually: 1000000 / 97 = 10309.27..., 10309 * 97 = 999973, 1000000 - 999973 = 27
     assert result.limbs[0] == 27
@@ -290,10 +290,10 @@ fn test_bigint_mod_exp_small()
     var result: BigInt
 
     # 2^10 mod 1000 = 1024 mod 1000 = 24
-    bigint_from_u64(&base, 2)
-    bigint_from_u64(&exp, 10)
-    bigint_from_u64(&n, 1000)
-    bigint_mod_exp(&result, &base, &exp, &n)
+    bigint_from_u64(@base, 2)
+    bigint_from_u64(@exp, 10)
+    bigint_from_u64(@n, 1000)
+    bigint_mod_exp(@result, @base, @exp, @n)
     assert result.limbs[0] == 24
 
 [[test]]
@@ -305,10 +305,10 @@ fn test_bigint_mod_exp_fermat()
 
     # Fermat's little theorem: a^(p-1) = 1 mod p for prime p
     # 3^6 mod 7 = 729 mod 7 = 1
-    bigint_from_u64(&base, 3)
-    bigint_from_u64(&exp, 6)
-    bigint_from_u64(&n, 7)
-    bigint_mod_exp(&result, &base, &exp, &n)
+    bigint_from_u64(@base, 3)
+    bigint_from_u64(@exp, 6)
+    bigint_from_u64(@n, 7)
+    bigint_mod_exp(@result, @base, @exp, @n)
     assert result.limbs[0] == 1
 
 [[test]]
@@ -322,14 +322,14 @@ fn test_bigint_mod_exp_rsa_small()
     var n: BigInt
     var result: BigInt
 
-    bigint_from_u64(&base, 5)
-    bigint_from_u64(&exp, 3)
-    bigint_from_u64(&n, 33)
-    bigint_mod_exp(&result, &base, &exp, &n)
+    bigint_from_u64(@base, 5)
+    bigint_from_u64(@exp, 3)
+    bigint_from_u64(@n, 33)
+    bigint_mod_exp(@result, @base, @exp, @n)
     assert result.limbs[0] == 26
 
     # Decrypt
-    bigint_from_u64(&base, 26)
-    bigint_from_u64(&exp, 7)
-    bigint_mod_exp(&result, &base, &exp, &n)
+    bigint_from_u64(@base, 26)
+    bigint_from_u64(@exp, 7)
+    bigint_mod_exp(@result, @base, @exp, @n)
     assert result.limbs[0] == 5

--- a/projects/cryptosec/test/test_ca_store.ritz
+++ b/projects/cryptosec/test/test_ca_store.ritz
@@ -32,30 +32,30 @@ fn get_test_pem_len() -> i64
 [[test]]
 fn test_ca_store_init() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
-    if ca_store_valid(&store) != 1
-        ca_store_destroy(&store)
+    if ca_store_valid(@store) != 1
+        ca_store_destroy(@store)
         return 1
 
-    if ca_store_count(&store) != 0
-        ca_store_destroy(&store)
+    if ca_store_count(@store) != 0
+        ca_store_destroy(@store)
         return 2
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 [[test]]
 fn test_ca_store_destroy() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
-    if ca_store_valid(&store) != 1
+    if ca_store_valid(@store) != 1
         return 1
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
 
-    if ca_store_valid(&store) != 0
+    if ca_store_valid(@store) != 0
         return 2
 
     return 0
@@ -63,20 +63,20 @@ fn test_ca_store_destroy() -> i32
 [[test]]
 fn test_ca_store_get_empty() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # Getting from empty store should return null
-    let cert: *X509Certificate = ca_store_get(&store, 0)
+    let cert: *X509Certificate = ca_store_get(@store, 0)
     if cert != null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    let cert2: *X509Certificate = ca_store_get(&store, -1)
+    let cert2: *X509Certificate = ca_store_get(@store, -1)
     if cert2 != null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 2
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 # ============================================================================
@@ -110,36 +110,36 @@ fn test_ca_store_count_pem() -> i32
 [[test]]
 fn test_ca_store_find_by_subject_not_found() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # Create a fake X509Name to search for
     var fake_name: X509Name
-    mem_zero(&fake_name as *u8, 200)
+    mem_zero(@fake_name as *u8, 200)
     fake_name.common_name[0] = 'X'
     fake_name.common_name_len = 1
 
-    let found: *X509Certificate = ca_store_find_by_subject(&store, &fake_name)
+    let found: *X509Certificate = ca_store_find_by_subject(@store, @fake_name)
     if found != null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 [[test]]
 fn test_ca_store_contains_empty() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     var dummy_cert: X509Certificate
-    mem_zero(&dummy_cert as *u8, 1200)
+    mem_zero(@dummy_cert as *u8, 1200)
 
-    let contains: i32 = ca_store_contains(&store, &dummy_cert)
+    let contains: i32 = ca_store_contains(@store, @dummy_cert)
     if contains != 0
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 # ============================================================================
@@ -149,19 +149,19 @@ fn test_ca_store_contains_empty() -> i32
 [[test]]
 fn test_ca_store_as_array() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
-    let arr: **X509Certificate = ca_store_as_array(&store)
+    let arr: **X509Certificate = ca_store_as_array(@store)
     if arr == null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
     # Empty store, first element should be null
     if arr[0] != null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 2
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 # ============================================================================
@@ -171,93 +171,93 @@ fn test_ca_store_as_array() -> i32
 [[test]]
 fn test_ca_store_get_out_of_bounds() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
-    let cert: *X509Certificate = ca_store_get(&store, 1000)
+    let cert: *X509Certificate = ca_store_get(@store, 1000)
     if cert != null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    let cert2: *X509Certificate = ca_store_get(&store, -5)
+    let cert2: *X509Certificate = ca_store_get(@store, -5)
     if cert2 != null
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 2
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 [[test]]
 fn test_ca_store_load_empty_bundle() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # Empty data should load 0 certs
     let empty: *u8 = c""
-    let loaded: i32 = ca_store_load_pem_bundle(&store, empty, 0)
+    let loaded: i32 = ca_store_load_pem_bundle(@store, empty, 0)
 
     if loaded != 0
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    if ca_store_count(&store) != 0
-        ca_store_destroy(&store)
+    if ca_store_count(@store) != 0
+        ca_store_destroy(@store)
         return 2
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 [[test]]
 fn test_ca_store_load_garbage() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # Non-PEM data should load 0 certs
     let garbage: *u8 = c"This is not PEM data at all.\nJust random text.\n"
-    let loaded: i32 = ca_store_load_pem_bundle(&store, garbage, 48)
+    let loaded: i32 = ca_store_load_pem_bundle(@store, garbage, 48)
 
     if loaded != 0
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    if ca_store_count(&store) != 0
-        ca_store_destroy(&store)
+    if ca_store_count(@store) != 0
+        ca_store_destroy(@store)
         return 2
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 [[test]]
 fn test_ca_store_load_partial_pem() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # PEM with BEGIN but no END
     let partial: *u8 = c"-----BEGIN CERTIFICATE-----\nSomeBase64Data\n"
-    let loaded: i32 = ca_store_load_pem_bundle(&store, partial, 45)
+    let loaded: i32 = ca_store_load_pem_bundle(@store, partial, 45)
 
     # Should fail gracefully (load 0)
     if loaded != 0
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 [[test]]
 fn test_ca_store_load_non_cert_pem() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # PEM with different type (RSA PRIVATE KEY)
     let key_pem: *u8 = c"-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBAK==\n-----END RSA PRIVATE KEY-----\n"
-    let loaded: i32 = ca_store_load_pem_bundle(&store, key_pem, 73)
+    let loaded: i32 = ca_store_load_pem_bundle(@store, key_pem, 73)
 
     # Should skip non-certificate entries
     if loaded != 0
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 # ============================================================================
@@ -268,17 +268,17 @@ fn test_ca_store_load_non_cert_pem() -> i32
 [[test]]
 fn test_ca_store_load_nonexistent_file() -> i32
     var store: CaStore
-    ca_store_init(&store)
+    ca_store_init(@store)
 
     # File that definitely doesn't exist
     let path: *u8 = c"/nonexistent/path/to/certs.pem"
-    let loaded: i32 = ca_store_load_pem_file(&store, path, 30)
+    let loaded: i32 = ca_store_load_pem_file(@store, path, 30)
 
     if loaded != -1
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
         return 1
 
-    ca_store_destroy(&store)
+    ca_store_destroy(@store)
     return 0
 
 # ============================================================================
@@ -291,14 +291,14 @@ fn test_ca_store_multiple_init_destroy() -> i32
     var i: i32 = 0
     while i < 5
         var store: CaStore
-        ca_store_init(&store)
+        ca_store_init(@store)
 
-        if ca_store_valid(&store) != 1
+        if ca_store_valid(@store) != 1
             return 1
 
-        ca_store_destroy(&store)
+        ca_store_destroy(@store)
 
-        if ca_store_valid(&store) != 0
+        if ca_store_valid(@store) != 0
             return 2
 
         i += 1

--- a/projects/cryptosec/test/test_chacha20.ritz
+++ b/projects/cryptosec/test/test_chacha20.ritz
@@ -43,7 +43,7 @@ fn test_chacha20_block_rfc8439() -> i32
     nonce[11] = 0x00
 
     var out: [64]u8
-    chacha20_block(&key[0], 1, &nonce[0], &out[0])
+    chacha20_block(@key[0], 1, @nonce[0], @out[0])
 
     # Expected first 16 bytes: 10 f1 e7 e4 d1 3b 59 15 50 0f dd 1f a3 20 71 c4
     var expected: [16]u8
@@ -64,7 +64,7 @@ fn test_chacha20_block_rfc8439() -> i32
     expected[14] = 0x71
     expected[15] = 0xc4
 
-    if bytes_equal(&out[0], &expected[0], 16) == 0
+    if bytes_equal(@out[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -75,10 +75,10 @@ fn test_chacha20_block_zeros() -> i32
     var nonce: [12]u8
     var out: [64]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
 
-    chacha20_block(&key[0], 0, &nonce[0], &out[0])
+    chacha20_block(@key[0], 0, @nonce[0], @out[0])
 
     # Known test vector for all-zeros
     # First word should be 0x76b8e0ad
@@ -237,7 +237,7 @@ fn test_chacha20_encrypt_sunscreen() -> i32
     pt[113] = 0x2e # .
 
     var ct: [114]u8
-    chacha20_xor(&key[0], &nonce[0], 1, &pt[0], 114, &ct[0])
+    chacha20_xor(@key[0], @nonce[0], 1, @pt[0], 114, @ct[0])
 
     # Expected first 16 bytes of ciphertext
     var expected: [16]u8
@@ -258,7 +258,7 @@ fn test_chacha20_encrypt_sunscreen() -> i32
     expected[14] = 0x69
     expected[15] = 0x81
 
-    if bytes_equal(&ct[0], &expected[0], 16) == 0
+    if bytes_equal(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -287,13 +287,13 @@ fn test_chacha20_roundtrip() -> i32
         i += 1
 
     var ctx: ChaCha20
-    chacha20_init(&ctx, &key[0], &nonce[0])
-    chacha20_encrypt(&ctx, &pt[0], 64, &ct[0])
+    chacha20_init(@ctx, @key[0], @nonce[0])
+    chacha20_encrypt(@ctx, @pt[0], 64, @ct[0])
 
-    chacha20_init(&ctx, &key[0], &nonce[0])
-    chacha20_decrypt(&ctx, &ct[0], 64, &decrypted[0])
+    chacha20_init(@ctx, @key[0], @nonce[0])
+    chacha20_decrypt(@ctx, @ct[0], 64, @decrypted[0])
 
-    if bytes_equal(&pt[0], &decrypted[0], 64) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 64) == 0
         return 1
     return 0
 
@@ -306,17 +306,17 @@ fn test_chacha20_partial_block() -> i32
     var ct: [37]u8
     var decrypted: [37]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
 
     var i: i64 = 0
     while i < 37
         pt[i] = i as u8
         i += 1
 
-    chacha20_xor(&key[0], &nonce[0], 0, &pt[0], 37, &ct[0])
-    chacha20_xor(&key[0], &nonce[0], 0, &ct[0], 37, &decrypted[0])
+    chacha20_xor(@key[0], @nonce[0], 0, @pt[0], 37, @ct[0])
+    chacha20_xor(@key[0], @nonce[0], 0, @ct[0], 37, @decrypted[0])
 
-    if bytes_equal(&pt[0], &decrypted[0], 37) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 37) == 0
         return 1
     return 0

--- a/projects/cryptosec/test/test_chacha20_avx2.ritz
+++ b/projects/cryptosec/test/test_chacha20_avx2.ritz
@@ -44,7 +44,7 @@ fn test_chacha20_avx2_block_rfc8439() -> i32
     nonce[11] = 0x00
 
     var out: [64]u8
-    chacha20_block_avx2(&key[0], 1, &nonce[0], &out[0])
+    chacha20_block_avx2(@key[0], 1, @nonce[0], @out[0])
 
     # Expected first 16 bytes: 10 f1 e7 e4 d1 3b 59 15 50 0f dd 1f a3 20 71 c4
     var expected: [16]u8
@@ -65,7 +65,7 @@ fn test_chacha20_avx2_block_rfc8439() -> i32
     expected[14] = 0x71
     expected[15] = 0xc4
 
-    if bytes_equal(&out[0], &expected[0], 16) == 0
+    if bytes_equal(@out[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -76,10 +76,10 @@ fn test_chacha20_avx2_block_zeros() -> i32
     var nonce: [12]u8
     var out: [64]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
 
-    chacha20_block_avx2(&key[0], 0, &nonce[0], &out[0])
+    chacha20_block_avx2(@key[0], 0, @nonce[0], @out[0])
 
     # Known test vector for all-zeros
     # First word should be 0x76b8e0ad
@@ -126,11 +126,11 @@ fn test_chacha20_avx2_matches_scalar() -> i32
     nonce[11] = 0x78
 
     # Generate with both implementations
-    chacha20_block_avx2(&key[0], 42, &nonce[0], &out_avx2[0])
-    chacha20_block(&key[0], 42, &nonce[0], &out_scalar[0])
+    chacha20_block_avx2(@key[0], 42, @nonce[0], @out_avx2[0])
+    chacha20_block(@key[0], 42, @nonce[0], @out_scalar[0])
 
     # Must match exactly
-    if bytes_equal(&out_avx2[0], &out_scalar[0], 64) == 0
+    if bytes_equal(@out_avx2[0], @out_scalar[0], 64) == 0
         return 1
     return 0
 
@@ -142,17 +142,17 @@ fn test_chacha20_avx2_multiple_blocks() -> i32
     var out_avx2: [64]u8
     var out_scalar: [64]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
     key[0] = 0x42
 
     # Test several counter values
     var ctr: u32 = 0
     while ctr < 10
-        chacha20_block_avx2(&key[0], ctr, &nonce[0], &out_avx2[0])
-        chacha20_block(&key[0], ctr, &nonce[0], &out_scalar[0])
+        chacha20_block_avx2(@key[0], ctr, @nonce[0], @out_avx2[0])
+        chacha20_block(@key[0], ctr, @nonce[0], @out_scalar[0])
 
-        if bytes_equal(&out_avx2[0], &out_scalar[0], 64) == 0
+        if bytes_equal(@out_avx2[0], @out_scalar[0], 64) == 0
             return (ctr + 1) as i32
 
         ctr += 1
@@ -304,7 +304,7 @@ fn test_chacha20_avx2_encrypt_sunscreen() -> i32
     pt[113] = 0x2e # .
 
     var ct: [114]u8
-    chacha20_avx2_xor(&key[0], &nonce[0], 1, &pt[0], 114, &ct[0])
+    chacha20_avx2_xor(@key[0], @nonce[0], 1, @pt[0], 114, @ct[0])
 
     # Expected first 16 bytes of ciphertext
     var expected: [16]u8
@@ -325,7 +325,7 @@ fn test_chacha20_avx2_encrypt_sunscreen() -> i32
     expected[14] = 0x69
     expected[15] = 0x81
 
-    if bytes_equal(&ct[0], &expected[0], 16) == 0
+    if bytes_equal(@ct[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -354,13 +354,13 @@ fn test_chacha20_avx2_roundtrip() -> i32
         i += 1
 
     var ctx: ChaCha20Avx2
-    chacha20_avx2_init(&ctx, &key[0], &nonce[0])
-    chacha20_avx2_encrypt(&ctx, &pt[0], 64, &ct[0])
+    chacha20_avx2_init(@ctx, @key[0], @nonce[0])
+    chacha20_avx2_encrypt(@ctx, @pt[0], 64, @ct[0])
 
-    chacha20_avx2_init(&ctx, &key[0], &nonce[0])
-    chacha20_avx2_decrypt(&ctx, &ct[0], 64, &decrypted[0])
+    chacha20_avx2_init(@ctx, @key[0], @nonce[0])
+    chacha20_avx2_decrypt(@ctx, @ct[0], 64, @decrypted[0])
 
-    if bytes_equal(&pt[0], &decrypted[0], 64) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 64) == 0
         return 1
     return 0
 
@@ -373,18 +373,18 @@ fn test_chacha20_avx2_partial_block() -> i32
     var ct: [37]u8
     var decrypted: [37]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
 
     var i: i64 = 0
     while i < 37
         pt[i] = i as u8
         i += 1
 
-    chacha20_avx2_xor(&key[0], &nonce[0], 0, &pt[0], 37, &ct[0])
-    chacha20_avx2_xor(&key[0], &nonce[0], 0, &ct[0], 37, &decrypted[0])
+    chacha20_avx2_xor(@key[0], @nonce[0], 0, @pt[0], 37, @ct[0])
+    chacha20_avx2_xor(@key[0], @nonce[0], 0, @ct[0], 37, @decrypted[0])
 
-    if bytes_equal(&pt[0], &decrypted[0], 37) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 37) == 0
         return 1
     return 0
 
@@ -413,12 +413,12 @@ fn test_chacha20_avx2_full_ct_matches_scalar() -> i32
         i += 1
 
     # Encrypt with AVX2
-    chacha20_avx2_xor(&key[0], &nonce[0], 0, &pt[0], 200, &ct_avx2[0])
+    chacha20_avx2_xor(@key[0], @nonce[0], 0, @pt[0], 200, @ct_avx2[0])
 
     # Encrypt with scalar
-    chacha20_xor(&key[0], &nonce[0], 0, &pt[0], 200, &ct_scalar[0])
+    chacha20_xor(@key[0], @nonce[0], 0, @pt[0], 200, @ct_scalar[0])
 
     # Must match exactly
-    if bytes_equal(&ct_avx2[0], &ct_scalar[0], 200) == 0
+    if bytes_equal(@ct_avx2[0], @ct_scalar[0], 200) == 0
         return 1
     return 0

--- a/projects/cryptosec/test/test_chacha20_poly1305.ritz
+++ b/projects/cryptosec/test/test_chacha20_poly1305.ritz
@@ -205,7 +205,7 @@ fn test_chacha20_poly1305_rfc8439() -> i32
     var ct: [114]u8
     var tag: [16]u8
 
-    let ct_len: i64 = chacha20_poly1305_encrypt(&key[0], &nonce[0], &aad[0], 12, &pt[0], 114, &ct[0], &tag[0])
+    let ct_len: i64 = chacha20_poly1305_encrypt(@key[0], @nonce[0], @aad[0], 12, @pt[0], 114, @ct[0], @tag[0])
 
     # Expected ciphertext first 16 bytes: d3 1a 8d 34 64 8e 60 db 7b 86 af bc 53 ef 7e c2
     var expected_ct: [16]u8
@@ -226,7 +226,7 @@ fn test_chacha20_poly1305_rfc8439() -> i32
     expected_ct[14] = 0x7e
     expected_ct[15] = 0xc2
 
-    if bytes_equal(&ct[0], &expected_ct[0], 16) == 0
+    if bytes_equal(@ct[0], @expected_ct[0], 16) == 0
         return 1
 
     # Expected tag: 1a:e1:0b:59:4f:09:e2:6a:7e:90:2e:cb:d0:60:06:91
@@ -248,7 +248,7 @@ fn test_chacha20_poly1305_rfc8439() -> i32
     expected_tag[14] = 0x06
     expected_tag[15] = 0x91
 
-    if bytes_equal(&tag[0], &expected_tag[0], 16) == 0
+    if bytes_equal(@tag[0], @expected_tag[0], 16) == 0
         # Debug: return different codes for each byte position that doesn't match
         var i: i64 = 0
         while i < 16
@@ -290,12 +290,12 @@ fn test_chacha20_poly1305_roundtrip() -> i32
         pt[i] = (i * 5) as u8
         i += 1
 
-    let ct_len: i64 = chacha20_poly1305_encrypt(&key[0], &nonce[0], &aad[0], 16, &pt[0], 64, &ct[0], &tag[0])
-    let result: i32 = chacha20_poly1305_decrypt(&key[0], &nonce[0], &aad[0], 16, &ct[0], ct_len, &tag[0], &decrypted[0])
+    let ct_len: i64 = chacha20_poly1305_encrypt(@key[0], @nonce[0], @aad[0], 16, @pt[0], 64, @ct[0], @tag[0])
+    let result: i32 = chacha20_poly1305_decrypt(@key[0], @nonce[0], @aad[0], 16, @ct[0], ct_len, @tag[0], @decrypted[0])
 
     if result != 1
         return 1
-    if bytes_equal(&pt[0], &decrypted[0], 64) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 64) == 0
         return 2
     return 0
 
@@ -309,20 +309,20 @@ fn test_chacha20_poly1305_no_aad() -> i32
     var decrypted: [32]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
 
     var i: i64 = 0
     while i < 32
         pt[i] = i as u8
         i += 1
 
-    chacha20_poly1305_encrypt(&key[0], &nonce[0], nil, 0, &pt[0], 32, &ct[0], &tag[0])
-    let result: i32 = chacha20_poly1305_decrypt(&key[0], &nonce[0], nil, 0, &ct[0], 32, &tag[0], &decrypted[0])
+    chacha20_poly1305_encrypt(@key[0], @nonce[0], nil, 0, @pt[0], 32, @ct[0], @tag[0])
+    let result: i32 = chacha20_poly1305_decrypt(@key[0], @nonce[0], nil, 0, @ct[0], 32, @tag[0], @decrypted[0])
 
     if result != 1
         return 1
-    if bytes_equal(&pt[0], &decrypted[0], 32) == 0
+    if bytes_equal(@pt[0], @decrypted[0], 32) == 0
         return 2
     return 0
 
@@ -336,16 +336,16 @@ fn test_chacha20_poly1305_tampered_ct() -> i32
     var decrypted: [32]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&pt[0], 32)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@pt[0], 32)
 
-    chacha20_poly1305_encrypt(&key[0], &nonce[0], nil, 0, &pt[0], 32, &ct[0], &tag[0])
+    chacha20_poly1305_encrypt(@key[0], @nonce[0], nil, 0, @pt[0], 32, @ct[0], @tag[0])
 
     # Tamper with ciphertext
     ct[0] = ct[0] ^ 0x01
 
-    let result: i32 = chacha20_poly1305_decrypt(&key[0], &nonce[0], nil, 0, &ct[0], 32, &tag[0], &decrypted[0])
+    let result: i32 = chacha20_poly1305_decrypt(@key[0], @nonce[0], nil, 0, @ct[0], 32, @tag[0], @decrypted[0])
 
     if result != 0
         return 1
@@ -361,16 +361,16 @@ fn test_chacha20_poly1305_tampered_tag() -> i32
     var decrypted: [32]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&pt[0], 32)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@pt[0], 32)
 
-    chacha20_poly1305_encrypt(&key[0], &nonce[0], nil, 0, &pt[0], 32, &ct[0], &tag[0])
+    chacha20_poly1305_encrypt(@key[0], @nonce[0], nil, 0, @pt[0], 32, @ct[0], @tag[0])
 
     # Tamper with tag
     tag[0] = tag[0] ^ 0x01
 
-    let result: i32 = chacha20_poly1305_decrypt(&key[0], &nonce[0], nil, 0, &ct[0], 32, &tag[0], &decrypted[0])
+    let result: i32 = chacha20_poly1305_decrypt(@key[0], @nonce[0], nil, 0, @ct[0], 32, @tag[0], @decrypted[0])
 
     if result != 0
         return 1
@@ -388,15 +388,15 @@ fn test_chacha20_poly1305_wrong_aad() -> i32
     var decrypted: [16]u8
     var tag: [16]u8
 
-    mem_zero(&key[0], 32)
-    mem_zero(&nonce[0], 12)
-    mem_zero(&aad[0], 8)
-    mem_zero(&wrong_aad[0], 8)
-    mem_zero(&pt[0], 16)
+    mem_zero(@key[0], 32)
+    mem_zero(@nonce[0], 12)
+    mem_zero(@aad[0], 8)
+    mem_zero(@wrong_aad[0], 8)
+    mem_zero(@pt[0], 16)
     wrong_aad[0] = 1
 
-    chacha20_poly1305_encrypt(&key[0], &nonce[0], &aad[0], 8, &pt[0], 16, &ct[0], &tag[0])
-    let result: i32 = chacha20_poly1305_decrypt(&key[0], &nonce[0], &wrong_aad[0], 8, &ct[0], 16, &tag[0], &decrypted[0])
+    chacha20_poly1305_encrypt(@key[0], @nonce[0], @aad[0], 8, @pt[0], 16, @ct[0], @tag[0])
+    let result: i32 = chacha20_poly1305_decrypt(@key[0], @nonce[0], @wrong_aad[0], 8, @ct[0], 16, @tag[0], @decrypted[0])
 
     if result != 0
         return 1
@@ -426,10 +426,10 @@ fn test_chacha20_poly1305_empty_pt() -> i32
         i += 1
 
     # Encrypt empty plaintext with AAD
-    chacha20_poly1305_encrypt(&key[0], &nonce[0], &aad[0], 16, nil, 0, nil, &tag[0])
+    chacha20_poly1305_encrypt(@key[0], @nonce[0], @aad[0], 16, nil, 0, nil, @tag[0])
 
     # Decrypt should succeed
-    let result: i32 = chacha20_poly1305_decrypt(&key[0], &nonce[0], &aad[0], 16, nil, 0, &tag[0], nil)
+    let result: i32 = chacha20_poly1305_decrypt(@key[0], @nonce[0], @aad[0], 16, nil, 0, @tag[0], nil)
 
     if result != 1
         return 1

--- a/projects/cryptosec/test/test_cpuid.ritz
+++ b/projects/cryptosec/test/test_cpuid.ritz
@@ -134,7 +134,7 @@ fn test_cpuid_raw_leaf_0() -> i32
     var ecx: i32 = 0
     var edx: i32 = 0
 
-    cpuid_raw(0, 0, &eax, &ebx, &ecx, &edx)
+    cpuid_raw(0, 0, @eax, @ebx, @ecx, @edx)
 
     # EAX should contain max supported leaf (at least 1 for any x86-64 CPU)
     if eax < 1
@@ -157,7 +157,7 @@ fn test_cpuid_raw_leaf_1() -> i32
     var ecx: i32 = 0
     var edx: i32 = 0
 
-    cpuid_raw(1, 0, &eax, &ebx, &ecx, &edx)
+    cpuid_raw(1, 0, @eax, @ebx, @ecx, @edx)
 
     # EAX contains processor info (stepping, model, family)
     # Should be non-zero for any real CPU
@@ -184,7 +184,7 @@ fn test_cpuid_raw_leaf_1() -> i32
 fn test_cpu_detect_features_struct() -> i32
     var features: CpuFeatures
 
-    cpu_detect_features(&features)
+    cpu_detect_features(@features)
 
     # Verify all fields are valid booleans
     if features.has_aes_ni != 0 && features.has_aes_ni != 1
@@ -205,7 +205,7 @@ fn test_cpu_detect_features_struct() -> i32
 [[test]]
 fn test_cpu_detect_features_matches_individual() -> i32
     var features: CpuFeatures
-    cpu_detect_features(&features)
+    cpu_detect_features(@features)
 
     # Struct should match individual function calls
     if features.has_aes_ni != cpu_has_aes_ni()

--- a/projects/cryptosec/test/test_ed25519.ritz
+++ b/projects/cryptosec/test/test_ed25519.ritz
@@ -12,11 +12,11 @@ import lib.mem
 fn test_ed25519_vector1() -> i32
     # Get base point
     var B: Ge25519
-    ge_basepoint(&B)
+    ge_basepoint(@B)
 
     # Encode base point
     var bytes: [32]u8
-    ge_tobytes(&bytes[0], &B)
+    ge_tobytes(@bytes[0], @B)
 
     # Check encoding is non-zero
     var all_zero: i32 = 1
@@ -35,10 +35,10 @@ fn test_ed25519_vector1() -> i32
 [[test]]
 fn test_basepoint_encoding() -> i32
     var B: Ge25519
-    ge_basepoint(&B)
+    ge_basepoint(@B)
 
     var B_bytes: [32]u8
-    ge_tobytes(&B_bytes[0], &B)
+    ge_tobytes(@B_bytes[0], @B)
 
     # Expected encoding of base point (y-coordinate with sign bit = 0)
     # Base point y = 4/5, x is positive (odd, so sign bit = 1)
@@ -82,7 +82,7 @@ fn test_basepoint_encoding() -> i32
     expected[31] = 0x66
 
     # Check encoding matches expected
-    if mem_eq(&B_bytes[0], &expected[0], 32) != 1
+    if mem_eq(@B_bytes[0], @expected[0], 32) != 1
         # Debug: return first differing byte position + 100
         var i: i32 = 0
         while i < 32
@@ -97,15 +97,15 @@ fn test_basepoint_encoding() -> i32
 [[test]]
 fn test_ge_double_neutral() -> i32
     var zero: Ge25519
-    ge_zero(&zero)
+    ge_zero(@zero)
 
     var doubled: Ge25519
-    ge_double(&doubled, &zero)
+    ge_double(@doubled, @zero)
 
     # Doubling the neutral element should give neutral element
     # Check Z is non-zero (valid point)
     var z_bytes: [32]u8
-    fe_tobytes(&z_bytes[0], &doubled.Z)
+    fe_tobytes(@z_bytes[0], @doubled.Z)
 
     # Z should not be all zeros
     var z_nonzero: i32 = 0
@@ -124,21 +124,21 @@ fn test_ge_double_neutral() -> i32
 [[test]]
 fn test_ge_add_neutral() -> i32
     var B: Ge25519
-    ge_basepoint(&B)
+    ge_basepoint(@B)
 
     var zero: Ge25519
-    ge_zero(&zero)
+    ge_zero(@zero)
 
     var result: Ge25519
-    ge_add(&result, &B, &zero)
+    ge_add(@result, @B, @zero)
 
     # B + 0 should equal B
     var B_bytes: [32]u8
     var result_bytes: [32]u8
-    ge_tobytes(&B_bytes[0], &B)
-    ge_tobytes(&result_bytes[0], &result)
+    ge_tobytes(@B_bytes[0], @B)
+    ge_tobytes(@result_bytes[0], @result)
 
-    if mem_eq(&B_bytes[0], &result_bytes[0], 32) != 1
+    if mem_eq(@B_bytes[0], @result_bytes[0], 32) != 1
         return 1
 
     return 0
@@ -147,23 +147,23 @@ fn test_ge_add_neutral() -> i32
 [[test]]
 fn test_scalarmult_one() -> i32
     var B: Ge25519
-    ge_basepoint(&B)
+    ge_basepoint(@B)
 
     # Scalar = 1
     var one: [32]u8
-    mem_zero(&one[0], 32)
+    mem_zero(@one[0], 32)
     one[0] = 1
 
     var result: Ge25519
-    ge_scalarmult(&result, &one[0], &B)
+    ge_scalarmult(@result, @one[0], @B)
 
     # 1 * B should equal B
     var B_bytes: [32]u8
     var result_bytes: [32]u8
-    ge_tobytes(&B_bytes[0], &B)
-    ge_tobytes(&result_bytes[0], &result)
+    ge_tobytes(@B_bytes[0], @B)
+    ge_tobytes(@result_bytes[0], @result)
 
-    if mem_eq(&B_bytes[0], &result_bytes[0], 32) != 1
+    if mem_eq(@B_bytes[0], @result_bytes[0], 32) != 1
         return 1
 
     return 0
@@ -173,12 +173,12 @@ fn test_scalarmult_one() -> i32
 fn test_ed25519_keygen_basic() -> i32
     # Test seed (all zeros - for simplicity)
     var seed: [32]u8
-    mem_zero(&seed[0], 32)
+    mem_zero(@seed[0], 32)
 
     var privkey: [32]u8
     var pubkey: [32]u8
 
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Check pubkey is non-zero
     var all_zero: i32 = 1
@@ -269,9 +269,9 @@ fn test_rfc8032_vector1_keygen() -> i32
     var privkey: [32]u8
     var pubkey: [32]u8
 
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
-    if mem_eq(&pubkey[0], &expected_pubkey[0], 32) != 1
+    if mem_eq(@pubkey[0], @expected_pubkey[0], 32) != 1
         # Debug: return first differing byte position + 100
         var i: i32 = 0
         while i < 32
@@ -286,14 +286,14 @@ fn test_rfc8032_vector1_keygen() -> i32
 [[test]]
 fn test_scalarmult_two() -> i32
     var B: Ge25519
-    ge_basepoint(&B)
+    ge_basepoint(@B)
 
     # Compute 2*B via doubling
     var B2_dbl: Ge25519
-    ge_double(&B2_dbl, &B)
+    ge_double(@B2_dbl, @B)
 
     var dbl_bytes: [32]u8
-    ge_tobytes(&dbl_bytes[0], &B2_dbl)
+    ge_tobytes(@dbl_bytes[0], @B2_dbl)
 
     # Expected encoding of 2*B (computed in Python)
     # c9a3f86aae465f0e56513864510f3997561fa2c9e85ea21dc2292309f3cd6022
@@ -331,18 +331,18 @@ fn test_scalarmult_two() -> i32
     expected_2B[30] = 0x60
     expected_2B[31] = 0x22
 
-    if mem_eq(&dbl_bytes[0], &expected_2B[0], 32) != 1
+    if mem_eq(@dbl_bytes[0], @expected_2B[0], 32) != 1
         # Debug: return first byte of computed value
         return dbl_bytes[0] as i32
 
     # Also verify B + B = 2B (test addition)
     var B_plus_B: Ge25519
-    ge_add(&B_plus_B, &B, &B)
+    ge_add(@B_plus_B, @B, @B)
 
     var add_bytes: [32]u8
-    ge_tobytes(&add_bytes[0], &B_plus_B)
+    ge_tobytes(@add_bytes[0], @B_plus_B)
 
-    if mem_eq(&add_bytes[0], &expected_2B[0], 32) != 1
+    if mem_eq(@add_bytes[0], @expected_2B[0], 32) != 1
         # Return 200 + first byte to distinguish from doubling failure
         return 200 + (add_bytes[0] as i32)
 
@@ -357,11 +357,11 @@ fn test_scalarmult_two() -> i32
 fn test_sc_reduce_basic() -> i32
     # Test that reducing a small value (< l) gives same value
     var x: [64]u8
-    mem_zero(&x[0], 64)
+    mem_zero(@x[0], 64)
     x[0] = 0x10
     x[1] = 0x20
 
-    sc_reduce(&x[0])
+    sc_reduce(@x[0])
 
     # Should be unchanged
     if x[0] != 0x10
@@ -380,13 +380,13 @@ fn test_sc_muladd_simple() -> i32
     var c: [32]u8
     var out: [32]u8
 
-    mem_zero(&a[0], 32)
-    mem_zero(&b[0], 32)
-    mem_zero(&c[0], 32)
+    mem_zero(@a[0], 32)
+    mem_zero(@b[0], 32)
+    mem_zero(@c[0], 32)
     a[0] = 1
     b[0] = 1
 
-    sc_muladd(&out[0], &a[0], &b[0], &c[0])
+    sc_muladd(@out[0], @a[0], @b[0], @c[0])
 
     if out[0] != 1
         return out[0] as i32 + 100
@@ -436,7 +436,7 @@ fn test_rfc8032_vector1_hash() -> i32
     seed[31] = 0x60
 
     var hash: [64]u8
-    sha512(&seed[0], 32, &hash[0])
+    sha512(@seed[0], 32, @hash[0])
 
     # Clamp first 32 bytes
     hash[0] = hash[0] & 0xf8
@@ -445,9 +445,9 @@ fn test_rfc8032_vector1_hash() -> i32
 
     # Test that scalarmult gives correct pubkey
     var A: Ge25519
-    ge_scalarmult_base(&A, &hash[0])
+    ge_scalarmult_base(@A, @hash[0])
     var pubkey: [32]u8
-    ge_tobytes(&pubkey[0], &A)
+    ge_tobytes(@pubkey[0], @A)
 
     var expected_pubkey: [32]u8
     expected_pubkey[0] = 0xd7
@@ -483,7 +483,7 @@ fn test_rfc8032_vector1_hash() -> i32
     expected_pubkey[30] = 0x51
     expected_pubkey[31] = 0x1a
 
-    if mem_eq(&pubkey[0], &expected_pubkey[0], 32) != 1
+    if mem_eq(@pubkey[0], @expected_pubkey[0], 32) != 1
         var i: i32 = 0
         while i < 32
             if pubkey[i] != expected_pubkey[i]
@@ -498,11 +498,11 @@ fn test_rfc8032_vector1_hash() -> i32
 fn test_sc_reduce_identity() -> i32
     # Create a 64-byte array with a small value in first 32 bytes
     var x: [64]u8
-    mem_zero(&x[0], 64)
+    mem_zero(@x[0], 64)
     x[0] = 0x42
     x[10] = 0x12
 
-    sc_reduce(&x[0])
+    sc_reduce(@x[0])
 
     # Value should be unchanged (it's already < l)
     if x[0] != 0x42
@@ -523,7 +523,7 @@ fn test_sc_reduce_full_input() -> i32
         i += 1
 
     # This should reduce without crashing
-    sc_reduce(&x[0])
+    sc_reduce(@x[0])
 
     # Result should be in [0, l), so first 32 bytes should not be all zero
     # (unless we got extremely unlucky)
@@ -584,10 +584,10 @@ fn test_L_variable_index() -> i32
 [[test]]
 fn test_sc_reduce_single_high() -> i32
     var x: [64]u8
-    mem_zero(&x[0], 64)
+    mem_zero(@x[0], 64)
     x[32] = 0x01  # 2^256
 
-    sc_reduce(&x[0])
+    sc_reduce(@x[0])
 
     # 2^256 mod l should be:
     # l = 2^252 + 27742317777372353535851937790883648493
@@ -696,16 +696,16 @@ fn helper_read_with_big_array(s: *u8) -> u8
 [[test]]
 fn test_function_call_pointer() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
     # Test 1: simple pointer read
-    let val1: u8 = helper_read_pointer(&data[0])
+    let val1: u8 = helper_read_pointer(@data[0])
     if val1 != 0xb6
         return 1
 
     # Test 2: pointer read with big local array
-    let val2: u8 = helper_read_with_big_array(&data[0])
+    let val2: u8 = helper_read_with_big_array(@data[0])
     if val2 != 0xb6
         return 2 + (val2 as i32)
 
@@ -728,11 +728,11 @@ fn helper_process_array(s: *u8)
 [[test]]
 fn test_process_array_identity() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
     data[1] = 0x42
 
-    helper_process_array(&data[0])
+    helper_process_array(@data[0])
 
     if data[0] != 0xb6
         return 1 + (data[0] as i32)
@@ -847,10 +847,10 @@ fn read_one_byte_ret_i64_v3(s: *u8) -> i64
 [[test]]
 fn test_read_via_return_i64() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
-    let val: i64 = read_one_byte_ret_i64(&data[0])
+    let val: i64 = read_one_byte_ret_i64(@data[0])
     if val != 182
         return 1
 
@@ -859,10 +859,10 @@ fn test_read_via_return_i64() -> i32
 [[test]]
 fn test_read_via_return_u8() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
-    let val: u8 = read_one_byte_ret_u8(&data[0])
+    let val: u8 = read_one_byte_ret_u8(@data[0])
     if val != 0xb6
         return 1
 
@@ -871,10 +871,10 @@ fn test_read_via_return_u8() -> i32
 [[test]]
 fn test_read_via_return_i64_v2() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
-    let val: i64 = read_one_byte_ret_i64_v2(&data[0])
+    let val: i64 = read_one_byte_ret_i64_v2(@data[0])
     if val != 182
         return 1
 
@@ -883,10 +883,10 @@ fn test_read_via_return_i64_v2() -> i32
 [[test]]
 fn test_read_via_return_i64_v3() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
-    let val: i64 = read_one_byte_ret_i64_v3(&data[0])
+    let val: i64 = read_one_byte_ret_i64_v3(@data[0])
     if val != 182
         return 1
 
@@ -895,11 +895,11 @@ fn test_read_via_return_i64_v3() -> i32
 [[test]]
 fn test_ultra_simple_read() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
     var results: [1]i64
-    read_one_byte(&data[0], &results[0])
+    read_one_byte(@data[0], @results[0])
 
     if results[0] != 182
         return 1
@@ -913,11 +913,11 @@ fn read_one_byte_order(result: *i64, s: *u8)
 [[test]]
 fn test_read_order_swap() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
     var results: [1]i64
-    read_one_byte_order(&results[0], &data[0])
+    read_one_byte_order(@results[0], @data[0])
 
     if results[0] != 182
         return 1
@@ -939,11 +939,11 @@ fn simple_debug(s: *u8, result: *i64) -> i32
 [[test]]
 fn test_simple_read_through_function() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
     var results: [2]i64
-    simple_debug(&data[0], &results[0])
+    simple_debug(@data[0], @results[0])
 
     # results[0] should be x[0] = 182
     # results[1] should be s[0] = 182
@@ -959,11 +959,11 @@ fn test_simple_read_through_function() -> i32
 # @test
 fn debug_my_sc_reduce() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
     var results: [8]i64
-    my_sc_reduce_debug(&data[0], &results[0])
+    my_sc_reduce_debug(@data[0], @results[0])
 
     # First just check what was read
     # results[6] = s[0] as i64 (raw byte from pointer after loop)
@@ -1045,10 +1045,10 @@ fn my_sc_reduce_inline(s: *u8)
 [[test]]
 fn test_my_sc_reduce_inline() -> i32
     var data: [64]u8
-    mem_zero(&data[0], 64)
+    mem_zero(@data[0], 64)
     data[0] = 0xb6
 
-    my_sc_reduce_inline(&data[0])
+    my_sc_reduce_inline(@data[0])
 
     if data[0] != 0xb6
         return data[0] as i32
@@ -1069,7 +1069,7 @@ fn test_compare_sc_reduce_methods() -> i32
 
     # Method 2: Through pointer
     var s: [64]u8
-    mem_zero(&s[0], 64)
+    mem_zero(@s[0], 64)
     s[0] = 0xb6
 
     var x2: [64]i64
@@ -1282,7 +1282,7 @@ fn test_sc_reduce_rfc8032_vector1() -> i32
     r_hash[62] = 0x35
     r_hash[63] = 0x2d
 
-    sc_reduce(&r_hash[0])
+    sc_reduce(@r_hash[0])
 
     # Expected: f38907308c893deaf244787db4af53682249107418afc2edc58f75ac58a07404
     var expected: [32]u8
@@ -1319,7 +1319,7 @@ fn test_sc_reduce_rfc8032_vector1() -> i32
     expected[30] = 0x74
     expected[31] = 0x04
 
-    if mem_eq(&r_hash[0], &expected[0], 32) != 1
+    if mem_eq(@r_hash[0], @expected[0], 32) != 1
         var i: i32 = 0
         while i < 32
             if r_hash[i] != expected[i]
@@ -1376,10 +1376,10 @@ fn test_scalarmult_base_rfc8032_r() -> i32
     r[31] = 0x04
 
     var R: Ge25519
-    ge_scalarmult_base(&R, &r[0])
+    ge_scalarmult_base(@R, @r[0])
 
     var R_bytes: [32]u8
-    ge_tobytes(&R_bytes[0], &R)
+    ge_tobytes(@R_bytes[0], @R)
 
     # Expected R
     var expected_R: [32]u8
@@ -1416,7 +1416,7 @@ fn test_scalarmult_base_rfc8032_r() -> i32
     expected_R[30] = 0x01
     expected_R[31] = 0x55
 
-    if mem_eq(&R_bytes[0], &expected_R[0], 32) != 1
+    if mem_eq(@R_bytes[0], @expected_R[0], 32) != 1
         var i: i32 = 0
         while i < 32
             if R_bytes[i] != expected_R[i]
@@ -1466,11 +1466,11 @@ fn test_rfc8032_vector1_r_hash() -> i32
 
     # hash = SHA512(seed)
     var hash: [64]u8
-    sha512(&seed[0], 32, &hash[0])
+    sha512(@seed[0], 32, @hash[0])
 
     # r_hash = SHA512(prefix)  where prefix = hash[32:64]
     var r_hash: [64]u8
-    sha512(&hash[32], 32, &r_hash[0])
+    sha512(@hash[32], 32, @r_hash[0])
 
     # For debugging, just check r_hash[0] is not zero
     if r_hash[0] == 0
@@ -1478,14 +1478,14 @@ fn test_rfc8032_vector1_r_hash() -> i32
             return 1  # Unexpected all-zero start
 
     # Now reduce
-    sc_reduce(&r_hash[0])
+    sc_reduce(@r_hash[0])
 
     # After reduction, compute R = r * B
     var R: Ge25519
-    ge_scalarmult_base(&R, &r_hash[0])
+    ge_scalarmult_base(@R, @r_hash[0])
 
     var R_bytes: [32]u8
-    ge_tobytes(&R_bytes[0], &R)
+    ge_tobytes(@R_bytes[0], @R)
 
     # Expected R
     var expected_R: [32]u8
@@ -1522,7 +1522,7 @@ fn test_rfc8032_vector1_r_hash() -> i32
     expected_R[30] = 0x01
     expected_R[31] = 0x55
 
-    if mem_eq(&R_bytes[0], &expected_R[0], 32) != 1
+    if mem_eq(@R_bytes[0], @expected_R[0], 32) != 1
         var i: i32 = 0
         while i < 32
             if R_bytes[i] != expected_R[i]
@@ -1572,25 +1572,25 @@ fn test_rfc8032_vector1_R_only() -> i32
 
     # Step 1: hash = SHA512(seed)
     var hash: [64]u8
-    sha512(&seed[0], 32, &hash[0])
+    sha512(@seed[0], 32, @hash[0])
 
     # Step 2: r = SHA512(prefix) mod l (empty message)
     # prefix = hash[32:64]
     var r_hash: [64]u8
     var ctx: Sha512
-    sha512_init(&ctx)
-    sha512_update(&ctx, &hash[32], 32)
+    sha512_init(@ctx)
+    sha512_update(@ctx, @hash[32], 32)
     # Empty message, so no more updates
-    sha512_final(&ctx, &r_hash[0])
+    sha512_final(@ctx, @r_hash[0])
 
-    sc_reduce(&r_hash[0])
+    sc_reduce(@r_hash[0])
 
     # Step 3: R = r * B
     var R: Ge25519
-    ge_scalarmult_base(&R, &r_hash[0])
+    ge_scalarmult_base(@R, @r_hash[0])
 
     var R_bytes: [32]u8
-    ge_tobytes(&R_bytes[0], &R)
+    ge_tobytes(@R_bytes[0], @R)
 
     # Expected R from signature
     var expected_R: [32]u8
@@ -1627,7 +1627,7 @@ fn test_rfc8032_vector1_R_only() -> i32
     expected_R[30] = 0x01
     expected_R[31] = 0x55
 
-    if mem_eq(&R_bytes[0], &expected_R[0], 32) != 1
+    if mem_eq(@R_bytes[0], @expected_R[0], 32) != 1
         # Debug: return first differing byte + 100
         var i: i32 = 0
         while i < 32
@@ -1682,7 +1682,7 @@ fn test_rfc8032_vector1_sign() -> i32
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Empty message
     var msg: [1]u8
@@ -1690,7 +1690,7 @@ fn test_rfc8032_vector1_sign() -> i32
 
     # Sign empty message (msg_len = 0)
     var sig: [64]u8
-    ed25519_sign(&sig[0], &msg[0], 0, &privkey[0])
+    ed25519_sign(@sig[0], @msg[0], 0, @privkey[0])
 
     # Expected signature from RFC 8032
     var expected_sig: [64]u8
@@ -1760,7 +1760,7 @@ fn test_rfc8032_vector1_sign() -> i32
     expected_sig[63] = 0x0b
 
     # Check R (first 32 bytes)
-    if mem_eq(&sig[0], &expected_sig[0], 32) != 1
+    if mem_eq(@sig[0], @expected_sig[0], 32) != 1
         # Debug: return 100 + first differing byte in R
         var i: i32 = 0
         while i < 32
@@ -1770,7 +1770,7 @@ fn test_rfc8032_vector1_sign() -> i32
         return 1
 
     # Check s (second 32 bytes)
-    if mem_eq(&sig[32], &expected_sig[32], 32) != 1
+    if mem_eq(@sig[32], @expected_sig[32], 32) != 1
         # Debug: return 200 + first differing byte in s
         var i: i32 = 32
         while i < 64
@@ -1889,7 +1889,7 @@ fn test_rfc8032_vector1_verify() -> i32
     msg[0] = 0
 
     # Verify should succeed (return 0)
-    let result: i32 = ed25519_verify(&sig[0], &msg[0], 0, &pubkey[0])
+    let result: i32 = ed25519_verify(@sig[0], @msg[0], 0, @pubkey[0])
     if result != 0
         return 1
 
@@ -1900,18 +1900,18 @@ fn test_rfc8032_vector1_verify() -> i32
 fn test_fe_sqrt_simple() -> i32
     # 4 = 2^2, sqrt(4) = 2
     var four: Fe25519
-    fe_zero(&four)
+    fe_zero(@four)
     four.l0 = 4
 
     var two: Fe25519
-    let result: i32 = fe_sqrt(&two, &four)
+    let result: i32 = fe_sqrt(@two, @four)
     if result != 0
         return 1  # Failed to find sqrt
 
     # Check two^2 == 4
     var check: Fe25519
-    fe_sq(&check, &two)
-    fe_reduce(&check)
+    fe_sq(@check, @two)
+    fe_reduce(@check)
     if check.l0 != 4
         return 2
     if check.l1 != 0
@@ -1923,13 +1923,13 @@ fn test_fe_sqrt_simple() -> i32
 [[test]]
 fn test_encode_decode_basepoint() -> i32
     var B: Ge25519
-    ge_basepoint(&B)
+    ge_basepoint(@B)
 
     var bytes: [32]u8
-    ge_tobytes(&bytes[0], &B)
+    ge_tobytes(@bytes[0], @B)
 
     var B2: Ge25519
-    if ge_frombytes(&B2, &bytes[0]) != 0
+    if ge_frombytes(@B2, @bytes[0]) != 0
         return 1
 
     return 0
@@ -1973,10 +1973,10 @@ fn test_encode_decode_pubkey() -> i32
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     var A: Ge25519
-    if ge_frombytes(&A, &pubkey[0]) != 0
+    if ge_frombytes(@A, @pubkey[0]) != 0
         return 1
 
     return 0
@@ -2020,7 +2020,7 @@ fn test_verify_manual_debug() -> i32
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Empty message
     var msg: [1]u8
@@ -2028,50 +2028,50 @@ fn test_verify_manual_debug() -> i32
 
     # Sign
     var sig: [64]u8
-    ed25519_sign(&sig[0], &msg[0], 0, &privkey[0])
+    ed25519_sign(@sig[0], @msg[0], 0, @privkey[0])
 
     # Step 1: Decode public key A
     var A: Ge25519
-    if ge_frombytes(&A, &pubkey[0]) != 0
+    if ge_frombytes(@A, @pubkey[0]) != 0
         return 10
 
     # Step 2: Decode R from signature
     var R: Ge25519
-    if ge_frombytes(&R, &sig[0]) != 0
+    if ge_frombytes(@R, @sig[0]) != 0
         return 20
 
     # Step 3: k = SHA512(R || A || msg) mod l
     var k_hash: [64]u8
     var ctx: Sha512
-    sha512_init(&ctx)
-    sha512_update(&ctx, &sig[0], 32)  # R
-    sha512_update(&ctx, &pubkey[0], 32)  # A
-    sha512_update(&ctx, &msg[0], 0)
-    sha512_final(&ctx, &k_hash[0])
-    sc_reduce(&k_hash[0])
+    sha512_init(@ctx)
+    sha512_update(@ctx, @sig[0], 32)  # R
+    sha512_update(@ctx, @pubkey[0], 32)  # A
+    sha512_update(@ctx, @msg[0], 0)
+    sha512_final(@ctx, @k_hash[0])
+    sc_reduce(@k_hash[0])
 
     # Step 4: [s]B
     var sB: Ge25519
-    ge_scalarmult_base(&sB, &sig[32])
+    ge_scalarmult_base(@sB, @sig[32])
 
     # Step 5: [k]A
     var kA: Ge25519
-    ge_scalarmult(&kA, &k_hash[0], &A)
+    ge_scalarmult(@kA, @k_hash[0], @A)
 
     # Step 6: -kA
     var neg_kA: Ge25519
-    ge_neg(&neg_kA, &kA)
+    ge_neg(@neg_kA, @kA)
 
     # Step 7: check = sB - kA
     var check: Ge25519
-    ge_add(&check, &sB, &neg_kA)
+    ge_add(@check, @sB, @neg_kA)
 
     # Step 8: encode check
     var check_bytes: [32]u8
-    ge_tobytes(&check_bytes[0], &check)
+    ge_tobytes(@check_bytes[0], @check)
 
     # Step 9: Compare with R
-    if mem_eq(&check_bytes[0], &sig[0], 32) != 1
+    if mem_eq(@check_bytes[0], @sig[0], 32) != 1
         # Find first differing byte
         var i: i32 = 0
         while i < 32
@@ -2121,7 +2121,7 @@ fn test_sign_then_verify_rfc8032_v1() -> i32
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Empty message
     var msg: [1]u8
@@ -2129,10 +2129,10 @@ fn test_sign_then_verify_rfc8032_v1() -> i32
 
     # Sign
     var sig: [64]u8
-    ed25519_sign(&sig[0], &msg[0], 0, &privkey[0])
+    ed25519_sign(@sig[0], @msg[0], 0, @privkey[0])
 
     # Verify the signature we just made
-    let result: i32 = ed25519_verify(&sig[0], &msg[0], 0, &pubkey[0])
+    let result: i32 = ed25519_verify(@sig[0], @msg[0], 0, @pubkey[0])
     if result != 0
         return 1
 
@@ -2158,7 +2158,7 @@ fn test_ed25519_sign_verify_roundtrip() -> i32
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Test message: "hello"
     var msg: [5]u8
@@ -2170,10 +2170,10 @@ fn test_ed25519_sign_verify_roundtrip() -> i32
 
     # Sign the message
     var sig: [64]u8
-    ed25519_sign(&sig[0], &msg[0], 5, &privkey[0])
+    ed25519_sign(@sig[0], @msg[0], 5, @privkey[0])
 
     # Verify the signature
-    let result: i32 = ed25519_verify(&sig[0], &msg[0], 5, &pubkey[0])
+    let result: i32 = ed25519_verify(@sig[0], @msg[0], 5, @pubkey[0])
     if result != 0
         return 1
 
@@ -2184,13 +2184,13 @@ fn test_ed25519_sign_verify_roundtrip() -> i32
 fn test_ed25519_verify_tampered_msg() -> i32
     # Generate keypair
     var seed: [32]u8
-    mem_zero(&seed[0], 32)
+    mem_zero(@seed[0], 32)
     seed[0] = 0xaa
     seed[1] = 0xbb
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Sign message "test"
     var msg: [4]u8
@@ -2200,13 +2200,13 @@ fn test_ed25519_verify_tampered_msg() -> i32
     msg[3] = 0x74  # 't'
 
     var sig: [64]u8
-    ed25519_sign(&sig[0], &msg[0], 4, &privkey[0])
+    ed25519_sign(@sig[0], @msg[0], 4, @privkey[0])
 
     # Tamper with message
     msg[0] = 0x54  # 'T' instead of 't'
 
     # Verify should fail (return != 0)
-    let result: i32 = ed25519_verify(&sig[0], &msg[0], 4, &pubkey[0])
+    let result: i32 = ed25519_verify(@sig[0], @msg[0], 4, @pubkey[0])
     if result == 0
         return 1  # Should have failed!
 
@@ -2217,13 +2217,13 @@ fn test_ed25519_verify_tampered_msg() -> i32
 fn test_ed25519_verify_tampered_sig() -> i32
     # Generate keypair
     var seed: [32]u8
-    mem_zero(&seed[0], 32)
+    mem_zero(@seed[0], 32)
     seed[0] = 0xcc
     seed[1] = 0xdd
 
     var privkey: [32]u8
     var pubkey: [32]u8
-    ed25519_keygen(&pubkey[0], &privkey[0], &seed[0])
+    ed25519_keygen(@pubkey[0], @privkey[0], @seed[0])
 
     # Sign message "data"
     var msg: [4]u8
@@ -2233,13 +2233,13 @@ fn test_ed25519_verify_tampered_sig() -> i32
     msg[3] = 0x61  # 'a'
 
     var sig: [64]u8
-    ed25519_sign(&sig[0], &msg[0], 4, &privkey[0])
+    ed25519_sign(@sig[0], @msg[0], 4, @privkey[0])
 
     # Tamper with signature (modify s component)
     sig[32] = sig[32] ^ 0x01
 
     # Verify should fail
-    let result: i32 = ed25519_verify(&sig[0], &msg[0], 4, &pubkey[0])
+    let result: i32 = ed25519_verify(@sig[0], @msg[0], 4, @pubkey[0])
     if result == 0
         return 1  # Should have failed!
 

--- a/projects/cryptosec/test/test_helpers.ritz
+++ b/projects/cryptosec/test/test_helpers.ritz
@@ -95,7 +95,7 @@ pub fn print_hex_bytes(data: *u8, len: i32)
         var buf: [2]u8
         buf[0] = hi
         buf[1] = lo
-        sys_write(1, &buf[0], 2)
+        sys_write(1, @buf[0], 2)
         i += 1
     var newline: u8 = 0x0a
-    sys_write(1, &newline, 1)
+    sys_write(1, @newline, 1)

--- a/projects/cryptosec/test/test_hkdf.ritz
+++ b/projects/cryptosec/test/test_hkdf.ritz
@@ -77,10 +77,10 @@ fn test_hkdf_sha256_rfc5869_test1() -> i32
         i += 1
 
     var okm: [42]u8
-    hkdf_sha256(&salt[0], 13, &ikm[0], 22, &info[0], 10, &okm[0], 42)
+    hkdf_sha256(@salt[0], 13, @ikm[0], 22, @info[0], 10, @okm[0], 42)
 
     let expected: *u8 = c"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
-    if bytes_eq_hex(&okm[0], expected, 42) != 1
+    if bytes_eq_hex(@okm[0], expected, 42) != 1
         return 1
     0
 
@@ -111,10 +111,10 @@ fn test_hkdf_sha256_rfc5869_test2() -> i32
         i += 1
 
     var okm: [82]u8
-    hkdf_sha256(&salt[0], 80, &ikm[0], 80, &info[0], 80, &okm[0], 82)
+    hkdf_sha256(@salt[0], 80, @ikm[0], 80, @info[0], 80, @okm[0], 82)
 
     let expected: *u8 = c"b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
-    if bytes_eq_hex(&okm[0], expected, 82) != 1
+    if bytes_eq_hex(@okm[0], expected, 82) != 1
         return 1
     0
 
@@ -133,10 +133,10 @@ fn test_hkdf_sha256_rfc5869_test3() -> i32
         i += 1
 
     var okm: [42]u8
-    hkdf_sha256(null, 0, &ikm[0], 22, null, 0, &okm[0], 42)
+    hkdf_sha256(null, 0, @ikm[0], 22, null, 0, @okm[0], 42)
 
     let expected: *u8 = c"8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"
-    if bytes_eq_hex(&okm[0], expected, 42) != 1
+    if bytes_eq_hex(@okm[0], expected, 42) != 1
         return 1
     0
 
@@ -160,10 +160,10 @@ fn test_hkdf_extract_basic() -> i32
         i += 1
 
     var prk: [32]u8
-    hkdf_extract(&salt[0], 13, &ikm[0], 22, &prk[0])
+    hkdf_extract(@salt[0], 13, @ikm[0], 22, @prk[0])
 
     let expected: *u8 = c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
-    if bytes_eq_hex(&prk[0], expected, 32) != 1
+    if bytes_eq_hex(@prk[0], expected, 32) != 1
         return 1
     0
 
@@ -177,10 +177,10 @@ fn test_hkdf_extract_no_salt() -> i32
         i += 1
 
     var prk: [32]u8
-    hkdf_extract(null, 0, &ikm[0], 22, &prk[0])
+    hkdf_extract(null, 0, @ikm[0], 22, @prk[0])
 
     # PRK should not be all zeros
-    if mem_is_zero(&prk[0], 32) == 1
+    if mem_is_zero(@prk[0], 32) == 1
         return 1
     0
 
@@ -193,7 +193,7 @@ fn test_hkdf_expand_basic() -> i32
     # Test expand step with known PRK
     # PRK from test case 1
     var prk: [32]u8
-    fill_from_hex(&prk[0], c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
+    fill_from_hex(@prk[0], c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
 
     var info: [10]u8
     var i: i32 = 0
@@ -202,10 +202,10 @@ fn test_hkdf_expand_basic() -> i32
         i += 1
 
     var okm: [42]u8
-    hkdf_expand(&prk[0], &info[0], 10, &okm[0], 42)
+    hkdf_expand(@prk[0], @info[0], 10, @okm[0], 42)
 
     let expected: *u8 = c"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
-    if bytes_eq_hex(&okm[0], expected, 42) != 1
+    if bytes_eq_hex(@okm[0], expected, 42) != 1
         return 1
     0
 
@@ -213,13 +213,13 @@ fn test_hkdf_expand_basic() -> i32
 fn test_hkdf_expand_no_info() -> i32
     # Expand with zero-length info
     var prk: [32]u8
-    fill_from_hex(&prk[0], c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
+    fill_from_hex(@prk[0], c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
 
     var okm: [32]u8
-    hkdf_expand(&prk[0], null, 0, &okm[0], 32)
+    hkdf_expand(@prk[0], null, 0, @okm[0], 32)
 
     # Output should not be all zeros
-    if mem_is_zero(&okm[0], 32) == 1
+    if mem_is_zero(@okm[0], 32) == 1
         return 1
     0
 
@@ -242,10 +242,10 @@ fn test_hkdf_deterministic() -> i32
     var okm1: [32]u8
     var okm2: [32]u8
 
-    hkdf_sha256(salt, 4, &ikm[0], 16, info, 4, &okm1[0], 32)
-    hkdf_sha256(salt, 4, &ikm[0], 16, info, 4, &okm2[0], 32)
+    hkdf_sha256(salt, 4, @ikm[0], 16, info, 4, @okm1[0], 32)
+    hkdf_sha256(salt, 4, @ikm[0], 16, info, 4, @okm2[0], 32)
 
-    if mem_eq(&okm1[0], &okm2[0], 32) != 1
+    if mem_eq(@okm1[0], @okm2[0], 32) != 1
         return 1
     0
 
@@ -265,10 +265,10 @@ fn test_hkdf_different_info_different_output() -> i32
     var okm1: [32]u8
     var okm2: [32]u8
 
-    hkdf_sha256(salt, 4, &ikm[0], 16, info1, 5, &okm1[0], 32)
-    hkdf_sha256(salt, 4, &ikm[0], 16, info2, 5, &okm2[0], 32)
+    hkdf_sha256(salt, 4, @ikm[0], 16, info1, 5, @okm1[0], 32)
+    hkdf_sha256(salt, 4, @ikm[0], 16, info2, 5, @okm2[0], 32)
 
-    if mem_eq(&okm1[0], &okm2[0], 32) == 1
+    if mem_eq(@okm1[0], @okm2[0], 32) == 1
         return 1  # Should be different!
     0
 
@@ -282,9 +282,9 @@ fn test_hkdf_short_output() -> i32
         i += 1
 
     var okm: [16]u8
-    hkdf_sha256(null, 0, &ikm[0], 16, null, 0, &okm[0], 16)
+    hkdf_sha256(null, 0, @ikm[0], 16, null, 0, @okm[0], 16)
 
-    if mem_is_zero(&okm[0], 16) == 1
+    if mem_is_zero(@okm[0], 16) == 1
         return 1
     0
 

--- a/projects/cryptosec/test/test_hmac.ritz
+++ b/projects/cryptosec/test/test_hmac.ritz
@@ -57,10 +57,10 @@ fn test_hmac_sha256_rfc4231_test1() -> i32
     let data: *u8 = c"Hi There"
     var mac: [32]u8
 
-    hmac_sha256(&key[0], 20, data, 8, &mac[0])
+    hmac_sha256(@key[0], 20, data, 8, @mac[0])
 
     let expected: *u8 = c"b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
-    if hash_eq_hex(&mac[0], expected, 32) != 1
+    if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
 
@@ -75,10 +75,10 @@ fn test_hmac_sha256_rfc4231_test2() -> i32
     let data: *u8 = c"what do ya want for nothing?"
     var mac: [32]u8
 
-    hmac_sha256(key, 4, data, 28, &mac[0])
+    hmac_sha256(key, 4, data, 28, @mac[0])
 
     let expected: *u8 = c"5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
-    if hash_eq_hex(&mac[0], expected, 32) != 1
+    if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
 
@@ -102,10 +102,10 @@ fn test_hmac_sha256_rfc4231_test3() -> i32
         i += 1
 
     var mac: [32]u8
-    hmac_sha256(&key[0], 20, &data[0], 50, &mac[0])
+    hmac_sha256(@key[0], 20, @data[0], 50, @mac[0])
 
     let expected: *u8 = c"773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe"
-    if hash_eq_hex(&mac[0], expected, 32) != 1
+    if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
 
@@ -129,10 +129,10 @@ fn test_hmac_sha256_rfc4231_test4() -> i32
         i += 1
 
     var mac: [32]u8
-    hmac_sha256(&key[0], 25, &data[0], 50, &mac[0])
+    hmac_sha256(@key[0], 25, @data[0], 50, @mac[0])
 
     let expected: *u8 = c"82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b"
-    if hash_eq_hex(&mac[0], expected, 32) != 1
+    if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
 
@@ -152,10 +152,10 @@ fn test_hmac_sha256_rfc4231_test6() -> i32
     let data: *u8 = c"Test Using Larger Than Block-Size Key - Hash Key First"
     var mac: [32]u8
 
-    hmac_sha256(&key[0], 131, data, 54, &mac[0])
+    hmac_sha256(@key[0], 131, data, 54, @mac[0])
 
     let expected: *u8 = c"60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"
-    if hash_eq_hex(&mac[0], expected, 32) != 1
+    if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
 
@@ -175,10 +175,10 @@ fn test_hmac_sha256_rfc4231_test7() -> i32
     let data: *u8 = c"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm."
     var mac: [32]u8
 
-    hmac_sha256(&key[0], 131, data, 152, &mac[0])
+    hmac_sha256(@key[0], 131, data, 152, @mac[0])
 
     let expected: *u8 = c"9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2"
-    if hash_eq_hex(&mac[0], expected, 32) != 1
+    if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
 
@@ -196,10 +196,10 @@ fn test_hmac_sha256_empty_data() -> i32
         i += 1
 
     var mac: [32]u8
-    hmac_sha256(&key[0], 16, c"", 0, &mac[0])
+    hmac_sha256(@key[0], 16, c"", 0, @mac[0])
 
     # Just verify it produces output (not all zeros)
-    if mem_is_zero(&mac[0], 32) == 1
+    if mem_is_zero(@mac[0], 32) == 1
         return 1
     0
 
@@ -212,10 +212,10 @@ fn test_hmac_sha256_deterministic() -> i32
     var mac1: [32]u8
     var mac2: [32]u8
 
-    hmac_sha256(key, 6, data, 7, &mac1[0])
-    hmac_sha256(key, 6, data, 7, &mac2[0])
+    hmac_sha256(key, 6, data, 7, @mac1[0])
+    hmac_sha256(key, 6, data, 7, @mac2[0])
 
-    if mem_eq(&mac1[0], &mac2[0], 32) != 1
+    if mem_eq(@mac1[0], @mac2[0], 32) != 1
         return 1
     0
 
@@ -229,10 +229,10 @@ fn test_hmac_sha256_different_keys() -> i32
     var mac1: [32]u8
     var mac2: [32]u8
 
-    hmac_sha256(key1, 4, data, 7, &mac1[0])
-    hmac_sha256(key2, 4, data, 7, &mac2[0])
+    hmac_sha256(key1, 4, data, 7, @mac1[0])
+    hmac_sha256(key2, 4, data, 7, @mac2[0])
 
-    if mem_eq(&mac1[0], &mac2[0], 32) == 1
+    if mem_eq(@mac1[0], @mac2[0], 32) == 1
         return 1  # Should be different!
     0
 
@@ -246,10 +246,10 @@ fn test_hmac_sha256_different_data() -> i32
     var mac1: [32]u8
     var mac2: [32]u8
 
-    hmac_sha256(key, 6, data1, 8, &mac1[0])
-    hmac_sha256(key, 6, data2, 8, &mac2[0])
+    hmac_sha256(key, 6, data1, 8, @mac1[0])
+    hmac_sha256(key, 6, data2, 8, @mac2[0])
 
-    if mem_eq(&mac1[0], &mac2[0], 32) == 1
+    if mem_eq(@mac1[0], @mac2[0], 32) == 1
         return 1  # Should be different!
     0
 
@@ -273,10 +273,10 @@ fn test_hmac_sha512_rfc4231_test1() -> i32
     let data: *u8 = c"Hi There"
     var mac: [64]u8
 
-    hmac_sha512(&key[0], 20, data, 8, &mac[0])
+    hmac_sha512(@key[0], 20, data, 8, @mac[0])
 
     let expected: *u8 = c"87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"
-    if hash_eq_hex(&mac[0], expected, 64) != 1
+    if hash_eq_hex(@mac[0], expected, 64) != 1
         return 1
     0
 
@@ -292,10 +292,10 @@ fn test_hmac_sha512_rfc4231_test2() -> i32
     let data: *u8 = c"what do ya want for nothing?"
     var mac: [64]u8
 
-    hmac_sha512(key, 4, data, 28, &mac[0])
+    hmac_sha512(key, 4, data, 28, @mac[0])
 
     let expected: *u8 = c"164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"
-    if hash_eq_hex(&mac[0], expected, 64) != 1
+    if hash_eq_hex(@mac[0], expected, 64) != 1
         return 1
     0
 
@@ -307,10 +307,10 @@ fn test_hmac_sha512_deterministic() -> i32
     var mac1: [64]u8
     var mac2: [64]u8
 
-    hmac_sha512(key, 6, data, 7, &mac1[0])
-    hmac_sha512(key, 6, data, 7, &mac2[0])
+    hmac_sha512(key, 6, data, 7, @mac1[0])
+    hmac_sha512(key, 6, data, 7, @mac2[0])
 
-    if mem_eq(&mac1[0], &mac2[0], 64) != 1
+    if mem_eq(@mac1[0], @mac2[0], 64) != 1
         return 1
     0
 
@@ -334,10 +334,10 @@ fn test_hmac_sha384_rfc4231_test1() -> i32
     let data: *u8 = c"Hi There"
     var mac: [48]u8
 
-    hmac_sha384(&key[0], 20, data, 8, &mac[0])
+    hmac_sha384(@key[0], 20, data, 8, @mac[0])
 
     let expected: *u8 = c"afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6"
-    if hash_eq_hex(&mac[0], expected, 48) != 1
+    if hash_eq_hex(@mac[0], expected, 48) != 1
         return 1
     0
 
@@ -353,10 +353,10 @@ fn test_hmac_sha384_rfc4231_test2() -> i32
     let data: *u8 = c"what do ya want for nothing?"
     var mac: [48]u8
 
-    hmac_sha384(key, 4, data, 28, &mac[0])
+    hmac_sha384(key, 4, data, 28, @mac[0])
 
     let expected: *u8 = c"af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649"
-    if hash_eq_hex(&mac[0], expected, 48) != 1
+    if hash_eq_hex(@mac[0], expected, 48) != 1
         return 1
     0
 
@@ -368,10 +368,10 @@ fn test_hmac_sha384_deterministic() -> i32
     var mac1: [48]u8
     var mac2: [48]u8
 
-    hmac_sha384(key, 6, data, 7, &mac1[0])
-    hmac_sha384(key, 6, data, 7, &mac2[0])
+    hmac_sha384(key, 6, data, 7, @mac1[0])
+    hmac_sha384(key, 6, data, 7, @mac2[0])
 
-    if mem_eq(&mac1[0], &mac2[0], 48) != 1
+    if mem_eq(@mac1[0], @mac2[0], 48) != 1
         return 1
     0
 

--- a/projects/cryptosec/test/test_mem.ritz
+++ b/projects/cryptosec/test/test_mem.ritz
@@ -24,7 +24,7 @@ fn test_mem_zero_basic() -> i32
     buf[1] = 0xBB
     buf[15] = 0xFF
 
-    mem_zero(&buf[0], 16)
+    mem_zero(@buf[0], 16)
 
     assert buf[0] == 0, "buf[0] should be zero"
     assert buf[1] == 0, "buf[1] should be zero"
@@ -39,7 +39,7 @@ fn test_mem_zero_partial() -> i32
         buf[i] = 0xFF
 
     # Zero middle 8 bytes
-    mem_zero(&buf[4], 8)
+    mem_zero(@buf[4], 8)
 
     assert buf[0] == 0xFF, "buf[0] should be unchanged"
     assert buf[3] == 0xFF, "buf[3] should be unchanged"
@@ -54,7 +54,7 @@ fn test_mem_zero_empty() -> i32
     var buf: [4]u8
     buf[0] = 0xAA
 
-    mem_zero(&buf[0], 0)
+    mem_zero(@buf[0], 0)
 
     assert buf[0] == 0xAA, "buf[0] should be unchanged"
     0
@@ -72,7 +72,7 @@ fn test_mem_eq_equal() -> i32
         a[i] = i as u8
         b[i] = i as u8
 
-    let result: i32 = mem_eq(&a[0], &b[0], 8)
+    let result: i32 = mem_eq(@a[0], @b[0], 8)
     assert result == 1, "identical buffers should be equal"
     0
 
@@ -88,7 +88,7 @@ fn test_mem_eq_different() -> i32
     # Differ in one byte
     b[4] = 0xFF
 
-    let result: i32 = mem_eq(&a[0], &b[0], 8)
+    let result: i32 = mem_eq(@a[0], @b[0], 8)
     assert result == 0, "different buffers should not be equal"
     0
 
@@ -97,7 +97,7 @@ fn test_mem_eq_first_byte_differs() -> i32
     var a: [4]u8 = [1, 2, 3, 4]
     var b: [4]u8 = [0, 2, 3, 4]
 
-    let result: i32 = mem_eq(&a[0], &b[0], 4)
+    let result: i32 = mem_eq(@a[0], @b[0], 4)
     assert result == 0, "first byte difference should be detected"
     0
 
@@ -106,7 +106,7 @@ fn test_mem_eq_last_byte_differs() -> i32
     var a: [4]u8 = [1, 2, 3, 4]
     var b: [4]u8 = [1, 2, 3, 5]
 
-    let result: i32 = mem_eq(&a[0], &b[0], 4)
+    let result: i32 = mem_eq(@a[0], @b[0], 4)
     assert result == 0, "last byte difference should be detected"
     0
 
@@ -116,7 +116,7 @@ fn test_mem_eq_empty() -> i32
     var b: [4]u8 = [0x11, 0x22, 0x33, 0x44]
 
     # Zero length comparison should return equal
-    let result: i32 = mem_eq(&a[0], &b[0], 0)
+    let result: i32 = mem_eq(@a[0], @b[0], 0)
     assert result == 1, "zero length should be equal"
     0
 
@@ -132,7 +132,7 @@ fn test_mem_copy_basic() -> i32
     for i in 0..8
         dst[i] = 0
 
-    mem_copy(&dst[0], &src[0], 8)
+    mem_copy(@dst[0], @src[0], 8)
 
     assert dst[0] == 1, "dst[0] should be 1"
     assert dst[7] == 8, "dst[7] should be 8"
@@ -147,7 +147,7 @@ fn test_mem_copy_partial() -> i32
         dst[i] = 0
 
     # Copy middle 4 bytes to offset 2 in dst
-    mem_copy(&dst[2], &src[2], 4)
+    mem_copy(@dst[2], @src[2], 4)
 
     assert dst[0] == 0, "dst[0] should be unchanged"
     assert dst[1] == 0, "dst[1] should be unchanged"
@@ -161,7 +161,7 @@ fn test_mem_copy_empty() -> i32
     var src: [4]u8 = [1, 2, 3, 4]
     var dst: [4]u8 = [0xAA, 0xBB, 0xCC, 0xDD]
 
-    mem_copy(&dst[0], &src[0], 0)
+    mem_copy(@dst[0], @src[0], 0)
 
     assert dst[0] == 0xAA, "dst should be unchanged"
     0
@@ -237,7 +237,7 @@ fn test_mem_is_zero_all_zeros() -> i32
     for i in 0..16
         buf[i] = 0
 
-    let result: i32 = mem_is_zero(&buf[0], 16)
+    let result: i32 = mem_is_zero(@buf[0], 16)
     assert result == 1, "all zeros should return 1"
     0
 
@@ -248,7 +248,7 @@ fn test_mem_is_zero_has_nonzero() -> i32
         buf[i] = 0
     buf[8] = 1
 
-    let result: i32 = mem_is_zero(&buf[0], 16)
+    let result: i32 = mem_is_zero(@buf[0], 16)
     assert result == 0, "buffer with nonzero should return 0"
     0
 
@@ -256,6 +256,6 @@ fn test_mem_is_zero_has_nonzero() -> i32
 fn test_mem_is_zero_empty() -> i32
     var buf: [4]u8 = [0xFF, 0xFF, 0xFF, 0xFF]
 
-    let result: i32 = mem_is_zero(&buf[0], 0)
+    let result: i32 = mem_is_zero(@buf[0], 0)
     assert result == 1, "empty buffer should return 1"
     0

--- a/projects/cryptosec/test/test_p256.ritz
+++ b/projects/cryptosec/test/test_p256.ritz
@@ -13,7 +13,7 @@ import lib.mem
 [[test]]
 fn test_fep256_zero() -> i32
     var a: FeP256
-    fep256_zero(&a)
+    fep256_zero(@a)
 
     if a.limbs[0] != 0
         return 1
@@ -23,14 +23,14 @@ fn test_fep256_zero() -> i32
         return 3
     if a.limbs[3] != 0
         return 4
-    if fep256_is_zero(&a) != 1
+    if fep256_is_zero(@a) != 1
         return 5
     return 0
 
 [[test]]
 fn test_fep256_one() -> i32
     var a: FeP256
-    fep256_one(&a)
+    fep256_one(@a)
 
     if a.limbs[0] != 1
         return 1
@@ -40,7 +40,7 @@ fn test_fep256_one() -> i32
         return 3
     if a.limbs[3] != 0
         return 4
-    if fep256_is_zero(&a) != 0
+    if fep256_is_zero(@a) != 0
         return 5
     return 0
 
@@ -54,7 +54,7 @@ fn test_fep256_copy() -> i32
     a.limbs[2] = 0x0011223344556677
     a.limbs[3] = 0x8899AABBCCDDEEFF
 
-    fep256_copy(&b, &a)
+    fep256_copy(@b, @a)
 
     if b.limbs[0] != a.limbs[0]
         return 1
@@ -76,9 +76,9 @@ fn test_fep256_cmp_equal() -> i32
     a.limbs[2] = 0x9ABC
     a.limbs[3] = 0xDEF0
 
-    fep256_copy(&b, &a)
+    fep256_copy(@b, @a)
 
-    if fep256_cmp(&a, &b) != 0
+    if fep256_cmp(@a, @b) != 0
         return 1
     return 0
 
@@ -87,11 +87,11 @@ fn test_fep256_cmp_less() -> i32
     var a: FeP256
     var b: FeP256
 
-    fep256_one(&a)
-    fep256_zero(&b)
+    fep256_one(@a)
+    fep256_zero(@b)
     b.limbs[0] = 2
 
-    if fep256_cmp(&a, &b) != -1
+    if fep256_cmp(@a, @b) != -1
         return 1
     return 0
 
@@ -100,12 +100,12 @@ fn test_fep256_cmp_greater() -> i32
     var a: FeP256
     var b: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[3] = 1
 
-    fep256_one(&b)
+    fep256_one(@b)
 
-    if fep256_cmp(&a, &b) != 1
+    if fep256_cmp(@a, @b) != 1
         return 1
     return 0
 
@@ -123,7 +123,7 @@ fn test_fep256_from_bytes() -> i32
         i += 1
 
     var a: FeP256
-    fep256_from_bytes(&a, &data[0])
+    fep256_from_bytes(@a, @data[0])
 
     # In little-endian limbs:
     # limbs[3] = 0x0102030405060708
@@ -149,7 +149,7 @@ fn test_fep256_to_bytes() -> i32
     a.limbs[3] = 0x0102030405060708
 
     var out: [32]u8
-    fep256_to_bytes(&a, &out[0])
+    fep256_to_bytes(@a, @out[0])
 
     # Should get sequential bytes 1-32
     var i: i32 = 0
@@ -168,12 +168,12 @@ fn test_fep256_roundtrip() -> i32
     a.limbs[3] = 0x0011223344556677
 
     var bytes: [32]u8
-    fep256_to_bytes(&a, &bytes[0])
+    fep256_to_bytes(@a, @bytes[0])
 
     var b: FeP256
-    fep256_from_bytes(&b, &bytes[0])
+    fep256_from_bytes(@b, @bytes[0])
 
-    if fep256_cmp(&a, &b) != 0
+    if fep256_cmp(@a, @b) != 0
         return 1
     return 0
 
@@ -187,9 +187,9 @@ fn test_fep256_add_simple() -> i32
     var b: FeP256
     var c: FeP256
 
-    fep256_one(&a)
-    fep256_one(&b)
-    fep256_add(&c, &a, &b)
+    fep256_one(@a)
+    fep256_one(@b)
+    fep256_add(@c, @a, @b)
 
     if c.limbs[0] != 2
         return 1
@@ -207,11 +207,11 @@ fn test_fep256_add_with_carry() -> i32
     var b: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 0xFFFFFFFFFFFFFFFF
 
-    fep256_one(&b)
-    fep256_add(&c, &a, &b)
+    fep256_one(@b)
+    fep256_add(@c, @a, @b)
 
     # Should carry to limb 1
     if c.limbs[0] != 0
@@ -230,13 +230,13 @@ fn test_fep256_sub_simple() -> i32
     var b: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 5
 
-    fep256_zero(&b)
+    fep256_zero(@b)
     b.limbs[0] = 3
 
-    fep256_sub(&c, &a, &b)
+    fep256_sub(@c, @a, @b)
 
     if c.limbs[0] != 2
         return 1
@@ -251,9 +251,9 @@ fn test_fep256_sub_wrap() -> i32
     var b: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
-    fep256_one(&b)
-    fep256_sub(&c, &a, &b)
+    fep256_zero(@a)
+    fep256_one(@b)
+    fep256_sub(@c, @a, @b)
 
     # Result should be p - 1
     # p = FFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
@@ -277,10 +277,10 @@ fn test_fep256_neg_zero() -> i32
     var a: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
-    fep256_neg(&c, &a)
+    fep256_zero(@a)
+    fep256_neg(@c, @a)
 
-    if fep256_is_zero(&c) != 1
+    if fep256_is_zero(@c) != 1
         return 1
     return 0
 
@@ -289,8 +289,8 @@ fn test_fep256_neg_one() -> i32
     var a: FeP256
     var c: FeP256
 
-    fep256_one(&a)
-    fep256_neg(&c, &a)
+    fep256_one(@a)
+    fep256_neg(@c, @a)
 
     # -1 mod p -= 1
     if c.limbs[0] != 0xFFFFFFFFFFFFFFFE
@@ -304,13 +304,13 @@ fn test_fep256_neg_double() -> i32
     var b: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 12345
 
-    fep256_neg(&b, &a)
-    fep256_neg(&c, &b)
+    fep256_neg(@b, @a)
+    fep256_neg(@c, @b)
 
-    if fep256_cmp(&a, &c) != 0
+    if fep256_cmp(@a, @c) != 0
         return 1
     return 0
 
@@ -324,13 +324,13 @@ fn test_fep256_mul_one() -> i32
     var one: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 0x123456789ABCDEF0
 
-    fep256_one(&one)
-    fep256_mul(&c, &a, &one)
+    fep256_one(@one)
+    fep256_mul(@c, @a, @one)
 
-    if fep256_cmp(&a, &c) != 0
+    if fep256_cmp(@a, @c) != 0
         return 1
     return 0
 
@@ -340,13 +340,13 @@ fn test_fep256_mul_zero() -> i32
     var zero: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 0x123456789ABCDEF0
 
-    fep256_zero(&zero)
-    fep256_mul(&c, &a, &zero)
+    fep256_zero(@zero)
+    fep256_mul(@c, @a, @zero)
 
-    if fep256_is_zero(&c) != 1
+    if fep256_is_zero(@c) != 1
         return 1
     return 0
 
@@ -356,13 +356,13 @@ fn test_fep256_mul_small() -> i32
     var b: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 7
 
-    fep256_zero(&b)
+    fep256_zero(@b)
     b.limbs[0] = 11
 
-    fep256_mul(&c, &a, &b)
+    fep256_mul(@c, @a, @b)
 
     if c.limbs[0] != 77
         return 1
@@ -379,10 +379,10 @@ fn test_fep256_sqr_small() -> i32
     var a: FeP256
     var c: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 9
 
-    fep256_sqr(&c, &a)
+    fep256_sqr(@c, @a)
 
     if c.limbs[0] != 81
         return 1
@@ -396,14 +396,14 @@ fn test_fep256_sqr_equals_mul() -> i32
     var sqr: FeP256
     var mul: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 0x123456789ABCDEF0
     a.limbs[1] = 0xFEDCBA9876543210
 
-    fep256_sqr(&sqr, &a)
-    fep256_mul(&mul, &a, &a)
+    fep256_sqr(@sqr, @a)
+    fep256_mul(@mul, @a, @a)
 
-    if fep256_cmp(&sqr, &mul) != 0
+    if fep256_cmp(@sqr, @mul) != 0
         return 1
     return 0
 
@@ -417,8 +417,8 @@ fn test_fep256_inv_one() -> i32
     var one: FeP256
     var inv: FeP256
 
-    fep256_one(&one)
-    fep256_inv(&inv, &one)
+    fep256_one(@one)
+    fep256_inv(@inv, @one)
 
     if inv.limbs[0] != 1
         return 1
@@ -441,10 +441,10 @@ fn test_fep256_inv_self_inverse() -> i32
     # var a: FeP256
     # var inv: FeP256
     # var prod: FeP256
-    # fep256_zero(&a)
+    # fep256_zero(@a)
     # a.limbs[0] = 0x123456789ABCDEF0
-    # fep256_inv(&inv, &a)
-    # fep256_mul(&prod, &a, &inv)
+    # fep256_inv(@inv, @a)
+    # fep256_mul(@prod, @a, @inv)
     # if prod.limbs[0] != 1
     #     return 1
     # if prod.limbs[1] != 0
@@ -463,7 +463,7 @@ fn test_fep256_inv_self_inverse() -> i32
 fn test_fep256_curve_b() -> i32
     # b = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B
     var b: FeP256
-    fep256_set_b(&b)
+    fep256_set_b(@b)
 
     if b.limbs[0] != 0x3BCE3C3E27D2604B
         return 1
@@ -479,7 +479,7 @@ fn test_fep256_curve_b() -> i32
 fn test_fep256_generator_x() -> i32
     # Gx = 0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296
     var gx: FeP256
-    fep256_set_gx(&gx)
+    fep256_set_gx(@gx)
 
     if gx.limbs[0] != 0xF4A13945D898C296
         return 1
@@ -495,7 +495,7 @@ fn test_fep256_generator_x() -> i32
 fn test_fep256_generator_y() -> i32
     # Gy = 0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5
     var gy: FeP256
-    fep256_set_gy(&gy)
+    fep256_set_gy(@gy)
 
     if gy.limbs[0] != 0xCBB6406837BF51F5
         return 1
@@ -519,18 +519,18 @@ fn test_fep256_add_sub_identity() -> i32
     var c: FeP256
     var d: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 0xDEADBEEF
     a.limbs[1] = 0xCAFEBABE
 
-    fep256_zero(&b)
+    fep256_zero(@b)
     b.limbs[0] = 0x12345678
     b.limbs[2] = 0x9ABCDEF0
 
-    fep256_add(&c, &a, &b)
-    fep256_sub(&d, &c, &b)
+    fep256_add(@c, @a, @b)
+    fep256_sub(@d, @c, @b)
 
-    if fep256_cmp(&a, &d) != 0
+    if fep256_cmp(@a, @d) != 0
         return 1
     return 0
 
@@ -546,25 +546,25 @@ fn test_fep256_mul_distributive() -> i32
     var ac: FeP256
     var right: FeP256
 
-    fep256_zero(&a)
+    fep256_zero(@a)
     a.limbs[0] = 7
 
-    fep256_zero(&b)
+    fep256_zero(@b)
     b.limbs[0] = 11
 
-    fep256_zero(&c)
+    fep256_zero(@c)
     c.limbs[0] = 13
 
     # Left: a * (b + c)
-    fep256_add(&bc, &b, &c)
-    fep256_mul(&left, &a, &bc)
+    fep256_add(@bc, @b, @c)
+    fep256_mul(@left, @a, @bc)
 
     # Right: a*b + a*c
-    fep256_mul(&ab, &a, &b)
-    fep256_mul(&ac, &a, &c)
-    fep256_add(&right, &ab, &ac)
+    fep256_mul(@ab, @a, @b)
+    fep256_mul(@ac, @a, @c)
+    fep256_add(@right, @ab, @ac)
 
-    if fep256_cmp(&left, &right) != 0
+    if fep256_cmp(@left, @right) != 0
         return 1
     return 0
 
@@ -575,19 +575,19 @@ fn test_fep256_mul_distributive() -> i32
 [[test]]
 fn test_p256_point_identity() -> i32
     var p: P256Point
-    p256_point_identity(&p)
+    p256_point_identity(@p)
 
-    if p256_point_is_identity(&p) != 1
+    if p256_point_is_identity(@p) != 1
         return 1
     return 0
 
 [[test]]
 fn test_p256_point_generator() -> i32
     var g: P256Point
-    p256_point_generator(&g)
+    p256_point_generator(@g)
 
     # Should not be identity
-    if p256_point_is_identity(&g) != 0
+    if p256_point_is_identity(@g) != 0
         return 1
 
     # Z should be 1 (affine representation)
@@ -602,14 +602,14 @@ fn test_p256_point_copy() -> i32
     var g: P256Point
     var p: P256Point
 
-    p256_point_generator(&g)
-    p256_point_copy(&p, &g)
+    p256_point_generator(@g)
+    p256_point_copy(@p, @g)
 
-    if fep256_cmp(&p.x, &g.x) != 0
+    if fep256_cmp(@p.x, @g.x) != 0
         return 1
-    if fep256_cmp(&p.y, &g.y) != 0
+    if fep256_cmp(@p.y, @g.y) != 0
         return 2
-    if fep256_cmp(&p.z, &g.z) != 0
+    if fep256_cmp(@p.z, @g.z) != 0
         return 3
     return 0
 
@@ -619,9 +619,9 @@ fn test_p256_mul_large() -> i32
     # 2 * 2 = 4
     var two: FeP256
     var four: FeP256
-    fep256_zero(&two)
+    fep256_zero(@two)
     two.limbs[0] = 2
-    fep256_sqr(&four, &two)
+    fep256_sqr(@four, @two)
     if four.limbs[0] != 4
         return 1
     if four.limbs[1] != 0
@@ -634,11 +634,11 @@ fn test_p256_sqr_gx() -> i32
     # Just verify no crash and result is non-zero
     var gx: FeP256
     var gx2: FeP256
-    fep256_set_gx(&gx)
-    fep256_sqr(&gx2, &gx)
+    fep256_set_gx(@gx)
+    fep256_sqr(@gx2, @gx)
 
     # Result should be non-zero
-    if fep256_is_zero(&gx2) == 1
+    if fep256_is_zero(@gx2) == 1
         return 1
     return 0
 
@@ -647,39 +647,39 @@ fn test_p256_curve_equation_parts() -> i32
     # Test individual parts of y^2 = x^3 - 3x + b
     var gx: FeP256
     var gy: FeP256
-    fep256_set_gx(&gx)
-    fep256_set_gy(&gy)
+    fep256_set_gx(@gx)
+    fep256_set_gy(@gy)
 
     # y^2
     var y2: FeP256
-    fep256_sqr(&y2, &gy)
+    fep256_sqr(@y2, @gy)
 
     # x^2
     var x2: FeP256
-    fep256_sqr(&x2, &gx)
+    fep256_sqr(@x2, @gx)
 
     # x^3
     var x3: FeP256
-    fep256_mul(&x3, &x2, &gx)
+    fep256_mul(@x3, @x2, @gx)
 
     # Should all be non-zero
-    if fep256_is_zero(&y2) == 1
+    if fep256_is_zero(@y2) == 1
         return 1
-    if fep256_is_zero(&x2) == 1
+    if fep256_is_zero(@x2) == 1
         return 2
-    if fep256_is_zero(&x3) == 1
+    if fep256_is_zero(@x3) == 1
         return 3
 
     # 3*x
     var x3times: FeP256
-    fep256_add(&x3times, &gx, &gx)
-    fep256_add(&x3times, &x3times, &gx)
+    fep256_add(@x3times, @gx, @gx)
+    fep256_add(@x3times, @x3times, @gx)
 
     # -3*x
     var neg3x: FeP256
-    fep256_neg(&neg3x, &x3times)
+    fep256_neg(@neg3x, @x3times)
 
-    if fep256_is_zero(&neg3x) == 1
+    if fep256_is_zero(@neg3x) == 1
         return 4  # -3x should not be zero
 
     return 0
@@ -689,10 +689,10 @@ fn test_p256_generator_on_curve() -> i32
     # Verify G is on the curve: y^2 = x^3 - 3x + b
     var gx: FeP256
     var gy: FeP256
-    fep256_set_gx(&gx)
-    fep256_set_gy(&gy)
+    fep256_set_gx(@gx)
+    fep256_set_gy(@gy)
 
-    if p256_affine_on_curve(&gx, &gy) != 1
+    if p256_affine_on_curve(@gx, @gy) != 1
         return 1
     return 0
 
@@ -702,10 +702,10 @@ fn test_p256_point_double_identity() -> i32
     var identity: P256Point
     var doubled: P256Point
 
-    p256_point_identity(&identity)
-    p256_point_double(&doubled, &identity)
+    p256_point_identity(@identity)
+    p256_point_double(@doubled, @identity)
 
-    if p256_point_is_identity(&doubled) != 1
+    if p256_point_is_identity(@doubled) != 1
         return 1
     return 0
 
@@ -716,9 +716,9 @@ fn test_p256_point_add_identity() -> i32
     var identity: P256Point
     var sum: P256Point
 
-    p256_point_generator(&g)
-    p256_point_identity(&identity)
-    p256_point_add(&sum, &g, &identity)
+    p256_point_generator(@g)
+    p256_point_identity(@identity)
+    p256_point_add(@sum, @g, @identity)
 
     # Convert both to affine and compare
     var gx: FeP256
@@ -726,12 +726,12 @@ fn test_p256_point_add_identity() -> i32
     var sx: FeP256
     var sy: FeP256
 
-    p256_point_to_affine(&g, &gx, &gy)
-    p256_point_to_affine(&sum, &sx, &sy)
+    p256_point_to_affine(@g, @gx, @gy)
+    p256_point_to_affine(@sum, @sx, @sy)
 
-    if fep256_cmp(&gx, &sx) != 0
+    if fep256_cmp(@gx, @sx) != 0
         return 1
-    if fep256_cmp(&gy, &sy) != 0
+    if fep256_cmp(@gy, @sy) != 0
         return 2
     return 0
 
@@ -742,11 +742,11 @@ fn test_p256_point_neg() -> i32
     var neg_g: P256Point
     var sum: P256Point
 
-    p256_point_generator(&g)
-    p256_point_neg(&neg_g, &g)
-    p256_point_add(&sum, &g, &neg_g)
+    p256_point_generator(@g)
+    p256_point_neg(@neg_g, @g)
+    p256_point_add(@sum, @g, @neg_g)
 
-    if p256_point_is_identity(&sum) != 1
+    if p256_point_is_identity(@sum) != 1
         return 1
     return 0
 
@@ -757,9 +757,9 @@ fn test_p256_double_equals_add_self() -> i32
     var doubled: P256Point
     var added: P256Point
 
-    p256_point_generator(&g)
-    p256_point_double(&doubled, &g)
-    p256_point_add(&added, &g, &g)
+    p256_point_generator(@g)
+    p256_point_double(@doubled, @g)
+    p256_point_add(@added, @g, @g)
 
     # Convert to affine and compare
     var dx: FeP256
@@ -767,12 +767,12 @@ fn test_p256_double_equals_add_self() -> i32
     var ax: FeP256
     var ay: FeP256
 
-    p256_point_to_affine(&doubled, &dx, &dy)
-    p256_point_to_affine(&added, &ax, &ay)
+    p256_point_to_affine(@doubled, @dx, @dy)
+    p256_point_to_affine(@added, @ax, @ay)
 
-    if fep256_cmp(&dx, &ax) != 0
+    if fep256_cmp(@dx, @ax) != 0
         return 1
-    if fep256_cmp(&dy, &ay) != 0
+    if fep256_cmp(@dy, @ay) != 0
         return 2
     return 0
 
@@ -782,10 +782,10 @@ fn test_p256_double_on_curve() -> i32
     var g: P256Point
     var doubled: P256Point
 
-    p256_point_generator(&g)
-    p256_point_double(&doubled, &g)
+    p256_point_generator(@g)
+    p256_point_double(@doubled, @g)
 
-    if p256_point_on_curve(&doubled) != 1
+    if p256_point_on_curve(@doubled) != 1
         return 1
     return 0
 
@@ -796,15 +796,15 @@ fn test_p256_double_on_curve() -> i32
 [[test]]
 fn test_scalar256_zero() -> i32
     var a: Scalar256
-    scalar256_zero(&a)
-    if scalar256_is_zero(&a) != 1
+    scalar256_zero(@a)
+    if scalar256_is_zero(@a) != 1
         return 1
     return 0
 
 [[test]]
 fn test_scalar256_one() -> i32
     var a: Scalar256
-    scalar256_one(&a)
+    scalar256_one(@a)
     if a.limbs[0] != 1
         return 1
     if a.limbs[1] != 0
@@ -823,8 +823,8 @@ fn test_scalar256_copy() -> i32
     a.limbs[1] = 0x5678
     a.limbs[2] = 0x9ABC
     a.limbs[3] = 0xDEF0
-    scalar256_copy(&b, &a)
-    if scalar256_cmp(&a, &b) != 0
+    scalar256_copy(@b, @a)
+    if scalar256_cmp(@a, @b) != 0
         return 1
     return 0
 
@@ -833,9 +833,9 @@ fn test_scalar256_add_simple() -> i32
     var a: Scalar256
     var b: Scalar256
     var c: Scalar256
-    scalar256_one(&a)
-    scalar256_one(&b)
-    scalar256_add(&c, &a, &b)
+    scalar256_one(@a)
+    scalar256_one(@b)
+    scalar256_add(@c, @a, @b)
     if c.limbs[0] != 2
         return 1
     return 0
@@ -845,11 +845,11 @@ fn test_scalar256_sub_simple() -> i32
     var a: Scalar256
     var b: Scalar256
     var c: Scalar256
-    scalar256_zero(&a)
+    scalar256_zero(@a)
     a.limbs[0] = 5
-    scalar256_zero(&b)
+    scalar256_zero(@b)
     b.limbs[0] = 3
-    scalar256_sub(&c, &a, &b)
+    scalar256_sub(@c, @a, @b)
     if c.limbs[0] != 2
         return 1
     return 0
@@ -859,11 +859,11 @@ fn test_scalar256_mul_small() -> i32
     var a: Scalar256
     var b: Scalar256
     var c: Scalar256
-    scalar256_zero(&a)
+    scalar256_zero(@a)
     a.limbs[0] = 7
-    scalar256_zero(&b)
+    scalar256_zero(@b)
     b.limbs[0] = 11
-    scalar256_mul(&c, &a, &b)
+    scalar256_mul(@c, @a, @b)
     if c.limbs[0] != 77
         return 1
     return 0
@@ -877,9 +877,9 @@ fn test_scalar256_bytes_roundtrip() -> i32
     a.limbs[2] = 0xFEDCBA9876543210
     a.limbs[3] = 0x0011223344556677
     var bytes: [32]u8
-    scalar256_to_bytes(&a, &bytes[0])
-    scalar256_from_bytes(&b, &bytes[0])
-    if scalar256_cmp(&a, &b) != 0
+    scalar256_to_bytes(@a, @bytes[0])
+    scalar256_from_bytes(@b, @bytes[0])
+    if scalar256_cmp(@a, @b) != 0
         return 1
     return 0
 
@@ -887,7 +887,7 @@ fn test_scalar256_bytes_roundtrip() -> i32
 fn test_get_p256_order() -> i32
     # n = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
     var n: Scalar256
-    get_p256_order(&n)
+    get_p256_order(@n)
     if n.limbs[0] != 0xF3B9CAC2FC632551
         return 1
     if n.limbs[1] != 0xBCE6FAADA7179E84
@@ -915,14 +915,14 @@ fn test_ecdsa_sig_bytes_roundtrip() -> i32
     sig.s.limbs[3] = 0x8888888888888888
 
     var bytes: [64]u8
-    ecdsa_sig_to_bytes(&sig, &bytes[0])
+    ecdsa_sig_to_bytes(@sig, @bytes[0])
 
     var sig2: EcdsaSignature
-    ecdsa_sig_from_bytes(&sig2, &bytes[0])
+    ecdsa_sig_from_bytes(@sig2, @bytes[0])
 
-    if scalar256_cmp(&sig.r, &sig2.r) != 0
+    if scalar256_cmp(@sig.r, @sig2.r) != 0
         return 1
-    if scalar256_cmp(&sig.s, &sig2.s) != 0
+    if scalar256_cmp(@sig.s, @sig2.s) != 0
         return 2
     return 0
 
@@ -934,26 +934,26 @@ fn test_ecdsa_sig_bytes_roundtrip() -> i32
 fn test_ecdsa_pubkey_from_privkey() -> i32
     # Use a small private key for testing
     var priv_key: Scalar256
-    scalar256_zero(&priv_key)
+    scalar256_zero(@priv_key)
     priv_key.limbs[0] = 1  # d = 1, so Q should equal G
 
     var pub_key: P256Point
-    ecdsa_p256_pubkey_from_privkey(&pub_key, &priv_key)
+    ecdsa_p256_pubkey_from_privkey(@pub_key, @priv_key)
 
     # Q = 1 * G = G
     var G: P256Point
-    p256_point_generator(&G)
+    p256_point_generator(@G)
 
     var qx: FeP256
     var qy: FeP256
     var gx: FeP256
     var gy: FeP256
-    p256_point_to_affine(&pub_key, &qx, &qy)
-    p256_point_to_affine(&G, &gx, &gy)
+    p256_point_to_affine(@pub_key, @qx, @qy)
+    p256_point_to_affine(@G, @gx, @gy)
 
-    if fep256_cmp(&qx, &gx) != 0
+    if fep256_cmp(@qx, @gx) != 0
         return 1
-    if fep256_cmp(&qy, &gy) != 0
+    if fep256_cmp(@qy, @gy) != 0
         return 2
     return 0
 
@@ -961,32 +961,32 @@ fn test_ecdsa_pubkey_from_privkey() -> i32
 fn test_ecdsa_pubkey_from_privkey_2() -> i32
     # d = 2, so Q = 2*G
     var priv_key: Scalar256
-    scalar256_zero(&priv_key)
+    scalar256_zero(@priv_key)
     priv_key.limbs[0] = 2
 
     var pub_key: P256Point
-    ecdsa_p256_pubkey_from_privkey(&pub_key, &priv_key)
+    ecdsa_p256_pubkey_from_privkey(@pub_key, @priv_key)
 
     # Should be on curve
-    if p256_point_on_curve(&pub_key) != 1
+    if p256_point_on_curve(@pub_key) != 1
         return 1
 
     # Q should equal 2*G (computed via doubling)
     var G: P256Point
     var twoG: P256Point
-    p256_point_generator(&G)
-    p256_point_double(&twoG, &G)
+    p256_point_generator(@G)
+    p256_point_double(@twoG, @G)
 
     var qx: FeP256
     var qy: FeP256
     var twogx: FeP256
     var twogy: FeP256
-    p256_point_to_affine(&pub_key, &qx, &qy)
-    p256_point_to_affine(&twoG, &twogx, &twogy)
+    p256_point_to_affine(@pub_key, @qx, @qy)
+    p256_point_to_affine(@twoG, @twogx, @twogy)
 
-    if fep256_cmp(&qx, &twogx) != 0
+    if fep256_cmp(@qx, @twogx) != 0
         return 2
-    if fep256_cmp(&qy, &twogy) != 0
+    if fep256_cmp(@qy, @twogy) != 0
         return 3
     return 0
 
@@ -1001,8 +1001,8 @@ fn test_ecdsa_pubkey_from_privkey_2() -> i32
 fn test_ecdsa_verify_rejects_zero_r() -> i32
     # Create invalid signature with r=0
     var sig: EcdsaSignature
-    scalar256_zero(&sig.r)
-    scalar256_one(&sig.s)
+    scalar256_zero(@sig.r)
+    scalar256_one(@sig.s)
 
     var hash: [32]u8
     var i: i32 = 0
@@ -1011,10 +1011,10 @@ fn test_ecdsa_verify_rejects_zero_r() -> i32
         i += 1
 
     var pub_key: P256Point
-    p256_point_generator(&pub_key)
+    p256_point_generator(@pub_key)
 
     # Should reject
-    if ecdsa_p256_verify(&hash[0], &sig, &pub_key) != 0
+    if ecdsa_p256_verify(@hash[0], @sig, @pub_key) != 0
         return 1
     return 0
 
@@ -1022,8 +1022,8 @@ fn test_ecdsa_verify_rejects_zero_r() -> i32
 fn test_ecdsa_verify_rejects_zero_s() -> i32
     # Create invalid signature with s=0
     var sig: EcdsaSignature
-    scalar256_one(&sig.r)
-    scalar256_zero(&sig.s)
+    scalar256_one(@sig.r)
+    scalar256_zero(@sig.s)
 
     var hash: [32]u8
     var i: i32 = 0
@@ -1032,10 +1032,10 @@ fn test_ecdsa_verify_rejects_zero_s() -> i32
         i += 1
 
     var pub_key: P256Point
-    p256_point_generator(&pub_key)
+    p256_point_generator(@pub_key)
 
     # Should reject
-    if ecdsa_p256_verify(&hash[0], &sig, &pub_key) != 0
+    if ecdsa_p256_verify(@hash[0], @sig, @pub_key) != 0
         return 1
     return 0
 
@@ -1043,8 +1043,8 @@ fn test_ecdsa_verify_rejects_zero_s() -> i32
 fn test_ecdsa_verify_rejects_r_ge_n() -> i32
     # Create invalid signature with r >= n
     var sig: EcdsaSignature
-    get_p256_order(&sig.r)  # r = n (invalid, must be < n)
-    scalar256_one(&sig.s)
+    get_p256_order(@sig.r)  # r = n (invalid, must be < n)
+    scalar256_one(@sig.s)
 
     var hash: [32]u8
     var i: i32 = 0
@@ -1053,10 +1053,10 @@ fn test_ecdsa_verify_rejects_r_ge_n() -> i32
         i += 1
 
     var pub_key: P256Point
-    p256_point_generator(&pub_key)
+    p256_point_generator(@pub_key)
 
     # Should reject
-    if ecdsa_p256_verify(&hash[0], &sig, &pub_key) != 0
+    if ecdsa_p256_verify(@hash[0], @sig, @pub_key) != 0
         return 1
     return 0
 
@@ -1071,15 +1071,15 @@ fn test_ecdsa_sign_verify_roundtrip() -> i32
     # Use a small but valid private key for testing
     # d = 0x0000000000000000000000000000000000000000000000000000000000000003
     var priv_key: Scalar256
-    scalar256_zero(&priv_key)
+    scalar256_zero(@priv_key)
     priv_key.limbs[0] = 3
 
     # Generate public key Q = d * G
     var pub_key: P256Point
-    ecdsa_p256_pubkey_from_privkey(&pub_key, &priv_key)
+    ecdsa_p256_pubkey_from_privkey(@pub_key, @priv_key)
 
     # Verify public key is on curve
-    if p256_point_on_curve(&pub_key) != 1
+    if p256_point_on_curve(@pub_key) != 1
         return 1
 
     # Create a simple hash (SHA-256 of "test message")
@@ -1092,26 +1092,26 @@ fn test_ecdsa_sign_verify_roundtrip() -> i32
 
     # Sign the hash
     var sig: EcdsaSignature
-    let sign_result: i32 = ecdsa_p256_sign(&sig, &hash[0], &priv_key)
+    let sign_result: i32 = ecdsa_p256_sign(@sig, @hash[0], @priv_key)
     if sign_result != 1
         return 2
 
     # Verify r and s are non-zero
-    if scalar256_is_zero(&sig.r) == 1
+    if scalar256_is_zero(@sig.r) == 1
         return 3
-    if scalar256_is_zero(&sig.s) == 1
+    if scalar256_is_zero(@sig.s) == 1
         return 4
 
     # Verify r and s are less than n
     var n: Scalar256
-    get_p256_order(&n)
-    if scalar256_cmp(&sig.r, &n) >= 0
+    get_p256_order(@n)
+    if scalar256_cmp(@sig.r, @n) >= 0
         return 5
-    if scalar256_cmp(&sig.s, &n) >= 0
+    if scalar256_cmp(@sig.s, @n) >= 0
         return 6
 
     # Verify the signature
-    let verify_result: i32 = ecdsa_p256_verify(&hash[0], &sig, &pub_key)
+    let verify_result: i32 = ecdsa_p256_verify(@hash[0], @sig, @pub_key)
     if verify_result != 1
         return 7
 
@@ -1121,11 +1121,11 @@ fn test_ecdsa_sign_verify_roundtrip() -> i32
 fn test_ecdsa_verify_rejects_wrong_hash() -> i32
     # Sign with one hash, verify with different hash
     var priv_key: Scalar256
-    scalar256_zero(&priv_key)
+    scalar256_zero(@priv_key)
     priv_key.limbs[0] = 5
 
     var pub_key: P256Point
-    ecdsa_p256_pubkey_from_privkey(&pub_key, &priv_key)
+    ecdsa_p256_pubkey_from_privkey(@pub_key, @priv_key)
 
     # Original hash
     var hash1: [32]u8
@@ -1136,7 +1136,7 @@ fn test_ecdsa_verify_rejects_wrong_hash() -> i32
 
     # Sign with hash1
     var sig: EcdsaSignature
-    if ecdsa_p256_sign(&sig, &hash1[0], &priv_key) != 1
+    if ecdsa_p256_sign(@sig, @hash1[0], @priv_key) != 1
         return 1
 
     # Different hash (modified)
@@ -1147,11 +1147,11 @@ fn test_ecdsa_verify_rejects_wrong_hash() -> i32
         i += 1
 
     # Verify with hash2 should fail
-    if ecdsa_p256_verify(&hash2[0], &sig, &pub_key) != 0
+    if ecdsa_p256_verify(@hash2[0], @sig, @pub_key) != 0
         return 2
 
     # Verify with original hash1 should still work
-    if ecdsa_p256_verify(&hash1[0], &sig, &pub_key) != 1
+    if ecdsa_p256_verify(@hash1[0], @sig, @pub_key) != 1
         return 3
 
     return 0
@@ -1160,17 +1160,17 @@ fn test_ecdsa_verify_rejects_wrong_hash() -> i32
 fn test_ecdsa_verify_rejects_wrong_pubkey() -> i32
     # Sign with one key, verify with different key
     var priv_key1: Scalar256
-    scalar256_zero(&priv_key1)
+    scalar256_zero(@priv_key1)
     priv_key1.limbs[0] = 7
 
     var priv_key2: Scalar256
-    scalar256_zero(&priv_key2)
+    scalar256_zero(@priv_key2)
     priv_key2.limbs[0] = 11
 
     var pub_key1: P256Point
     var pub_key2: P256Point
-    ecdsa_p256_pubkey_from_privkey(&pub_key1, &priv_key1)
-    ecdsa_p256_pubkey_from_privkey(&pub_key2, &priv_key2)
+    ecdsa_p256_pubkey_from_privkey(@pub_key1, @priv_key1)
+    ecdsa_p256_pubkey_from_privkey(@pub_key2, @priv_key2)
 
     var hash: [32]u8
     var i: i32 = 0
@@ -1180,15 +1180,15 @@ fn test_ecdsa_verify_rejects_wrong_pubkey() -> i32
 
     # Sign with priv_key1
     var sig: EcdsaSignature
-    if ecdsa_p256_sign(&sig, &hash[0], &priv_key1) != 1
+    if ecdsa_p256_sign(@sig, @hash[0], @priv_key1) != 1
         return 1
 
     # Verify with pub_key2 should fail
-    if ecdsa_p256_verify(&hash[0], &sig, &pub_key2) != 0
+    if ecdsa_p256_verify(@hash[0], @sig, @pub_key2) != 0
         return 2
 
     # Verify with pub_key1 should succeed
-    if ecdsa_p256_verify(&hash[0], &sig, &pub_key1) != 1
+    if ecdsa_p256_verify(@hash[0], @sig, @pub_key1) != 1
         return 3
 
     return 0
@@ -1197,7 +1197,7 @@ fn test_ecdsa_verify_rejects_wrong_pubkey() -> i32
 fn test_ecdsa_deterministic_signature() -> i32
     # RFC 6979: Same key + same hash = same signature
     var priv_key: Scalar256
-    scalar256_zero(&priv_key)
+    scalar256_zero(@priv_key)
     priv_key.limbs[0] = 13
 
     var hash: [32]u8
@@ -1209,15 +1209,15 @@ fn test_ecdsa_deterministic_signature() -> i32
     var sig1: EcdsaSignature
     var sig2: EcdsaSignature
 
-    if ecdsa_p256_sign(&sig1, &hash[0], &priv_key) != 1
+    if ecdsa_p256_sign(@sig1, @hash[0], @priv_key) != 1
         return 1
-    if ecdsa_p256_sign(&sig2, &hash[0], &priv_key) != 1
+    if ecdsa_p256_sign(@sig2, @hash[0], @priv_key) != 1
         return 2
 
     # Both signatures should be identical (deterministic)
-    if scalar256_cmp(&sig1.r, &sig2.r) != 0
+    if scalar256_cmp(@sig1.r, @sig2.r) != 0
         return 3
-    if scalar256_cmp(&sig1.s, &sig2.s) != 0
+    if scalar256_cmp(@sig1.s, @sig2.s) != 0
         return 4
 
     return 0

--- a/projects/cryptosec/test/test_pem.ritz
+++ b/projects/cryptosec/test/test_pem.ritz
@@ -16,7 +16,7 @@ import lib.pem
 fn test_base64_decode_empty() -> i32
     # Empty input -> empty output
     var out: [16]u8
-    let len: i64 = base64_decode(c"", 0, &out[0], 16)
+    let len: i64 = base64_decode(c"", 0, @out[0], 16)
     if len != 0
         return 1
     return 0
@@ -25,7 +25,7 @@ fn test_base64_decode_empty() -> i32
 fn test_base64_decode_simple() -> i32
     # "TWFu" -> "Man" (classic base64 example)
     var out: [16]u8
-    let len: i64 = base64_decode(c"TWFu", 4, &out[0], 16)
+    let len: i64 = base64_decode(c"TWFu", 4, @out[0], 16)
     if len != 3
         return 1
     if out[0] != 77  # 'M'
@@ -40,7 +40,7 @@ fn test_base64_decode_simple() -> i32
 fn test_base64_decode_padding_1() -> i32
     # "TWE=" -> "Ma" (1 padding byte)
     var out: [16]u8
-    let len: i64 = base64_decode(c"TWE=", 4, &out[0], 16)
+    let len: i64 = base64_decode(c"TWE=", 4, @out[0], 16)
     if len != 2
         return 1
     if out[0] != 77  # 'M'
@@ -53,7 +53,7 @@ fn test_base64_decode_padding_1() -> i32
 fn test_base64_decode_padding_2() -> i32
     # "TQ==" -> "M" (2 padding bytes)
     var out: [16]u8
-    let len: i64 = base64_decode(c"TQ==", 4, &out[0], 16)
+    let len: i64 = base64_decode(c"TQ==", 4, @out[0], 16)
     if len != 1
         return 1
     if out[0] != 77  # 'M'
@@ -76,7 +76,7 @@ fn test_base64_decode_with_newlines() -> i32
     input[8] = '='
 
     var out: [16]u8
-    let len: i64 = base64_decode(&input[0], 9, &out[0], 16)
+    let len: i64 = base64_decode(@input[0], 9, @out[0], 16)
     if len != 5
         return 1
     if out[0] != 'H'
@@ -95,7 +95,7 @@ fn test_base64_decode_with_newlines() -> i32
 fn test_base64_decode_buffer_too_small() -> i32
     # Output buffer too small should return error
     var out: [2]u8
-    let len: i64 = base64_decode(c"TWFu", 4, &out[0], 2)  # needs 3 bytes
+    let len: i64 = base64_decode(c"TWFu", 4, @out[0], 2)  # needs 3 bytes
     if len != -1
         return 1
     return 0
@@ -104,7 +104,7 @@ fn test_base64_decode_buffer_too_small() -> i32
 fn test_base64_decode_hello_world() -> i32
     # "SGVsbG8gV29ybGQ=" -> "Hello World"
     var out: [16]u8
-    let len: i64 = base64_decode(c"SGVsbG8gV29ybGQ=", 16, &out[0], 16)
+    let len: i64 = base64_decode(c"SGVsbG8gV29ybGQ=", 16, @out[0], 16)
     if len != 11
         return 1
     if out[0] != 'H'
@@ -122,7 +122,7 @@ fn test_base64_encode_simple() -> i32
     input[2] = 'n'
 
     var out: [16]u8
-    let len: i64 = base64_encode(&input[0], 3, &out[0], 16)
+    let len: i64 = base64_encode(@input[0], 3, @out[0], 16)
     if len != 4
         return 1
     if out[0] != 'T'
@@ -143,7 +143,7 @@ fn test_base64_encode_padding_1() -> i32
     input[1] = 'a'
 
     var out: [16]u8
-    let len: i64 = base64_encode(&input[0], 2, &out[0], 16)
+    let len: i64 = base64_encode(@input[0], 2, @out[0], 16)
     if len != 4
         return 1
     if out[0] != 'T'
@@ -163,7 +163,7 @@ fn test_base64_encode_padding_2() -> i32
     input[0] = 'M'
 
     var out: [16]u8
-    let len: i64 = base64_encode(&input[0], 1, &out[0], 16)
+    let len: i64 = base64_encode(@input[0], 1, @out[0], 16)
     if len != 4
         return 1
     if out[0] != 'T'
@@ -190,16 +190,16 @@ fn test_base64_roundtrip() -> i32
     original[7] = 0xBE
 
     var encoded: [16]u8
-    let enc_len: i64 = base64_encode(&original[0], 8, &encoded[0], 16)
+    let enc_len: i64 = base64_encode(@original[0], 8, @encoded[0], 16)
     if enc_len != 12
         return 1
 
     var decoded: [16]u8
-    let dec_len: i64 = base64_decode(&encoded[0], enc_len, &decoded[0], 16)
+    let dec_len: i64 = base64_decode(@encoded[0], enc_len, @decoded[0], 16)
     if dec_len != 8
         return 2
 
-    if mem_eq(&original[0], &decoded[0], 8) != 1
+    if mem_eq(@original[0], @decoded[0], 8) != 1
         return 3
 
     return 0
@@ -235,7 +235,7 @@ fn test_pem_parse_simple() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    let result: i64 = pem_parse_entry(pem, 52, &entry, &der_buf[0], 64)
+    let result: i64 = pem_parse_entry(pem, 52, @entry, @der_buf[0], 64)
     if result <= 0
         return 1
 
@@ -272,7 +272,7 @@ fn test_pem_parse_certificate_type() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    let result: i64 = pem_parse_entry(pem, 62, &entry, &der_buf[0], 64)
+    let result: i64 = pem_parse_entry(pem, 62, @entry, @der_buf[0], 64)
     if result <= 0
         return 1
 
@@ -293,13 +293,13 @@ fn test_pem_iterator() -> i32
     let pem: *u8 = c"-----BEGIN A-----\nYQ==\n-----END A-----\n-----BEGIN B-----\nYg==\n-----END B-----\n"
 
     var iter: PemIterator
-    pem_iterator_init(&iter, pem, 82)
+    pem_iterator_init(@iter, pem, 82)
 
     var entry: PemEntry
     var der_buf: [64]u8
 
     # First entry: "A" -> "a"
-    let r1: i32 = pem_iterator_next(&iter, &entry, &der_buf[0], 64)
+    let r1: i32 = pem_iterator_next(@iter, @entry, @der_buf[0], 64)
     if r1 != 1
         return 1
     if entry.type_label[0] != 'A'
@@ -308,7 +308,7 @@ fn test_pem_iterator() -> i32
         return 3
 
     # Second entry: "B" -> "b"
-    let r2: i32 = pem_iterator_next(&iter, &entry, &der_buf[0], 64)
+    let r2: i32 = pem_iterator_next(@iter, @entry, @der_buf[0], 64)
     if r2 != 1
         return 4
     if entry.type_label[0] != 'B'
@@ -317,7 +317,7 @@ fn test_pem_iterator() -> i32
         return 6
 
     # No more entries
-    let r3: i32 = pem_iterator_next(&iter, &entry, &der_buf[0], 64)
+    let r3: i32 = pem_iterator_next(@iter, @entry, @der_buf[0], 64)
     if r3 != 0
         return 7
 
@@ -341,7 +341,7 @@ fn test_pem_parse_no_entry() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    let result: i64 = pem_parse_entry(pem, 22, &entry, &der_buf[0], 64)
+    let result: i64 = pem_parse_entry(pem, 22, @entry, @der_buf[0], 64)
     if result != 0
         return 1
 
@@ -354,7 +354,7 @@ fn test_pem_parse_missing_end() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    let result: i64 = pem_parse_entry(pem, 31, &entry, &der_buf[0], 64)
+    let result: i64 = pem_parse_entry(pem, 31, @entry, @der_buf[0], 64)
     if result != -1
         return 1
 
@@ -402,7 +402,7 @@ fn test_pem_parse_with_crlf() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    let result: i64 = pem_parse_entry(&pem[0], i as i64, &entry, &der_buf[0], 64)
+    let result: i64 = pem_parse_entry(@pem[0], i as i64, @entry, @der_buf[0], 64)
     if result <= 0
         return 1
 
@@ -421,7 +421,7 @@ fn test_pem_empty_content() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    let result: i64 = pem_parse_entry(pem, 43, &entry, &der_buf[0], 64)
+    let result: i64 = pem_parse_entry(pem, 43, @entry, @der_buf[0], 64)
     if result <= 0
         return 1
 
@@ -436,12 +436,12 @@ fn test_pem_type_is() -> i32
     var entry: PemEntry
     var der_buf: [64]u8
 
-    pem_parse_entry(pem, 57, &entry, &der_buf[0], 64)
+    pem_parse_entry(pem, 57, @entry, @der_buf[0], 64)
 
-    if pem_type_is(&entry, c"CERTIFICATE", 11) != 1
+    if pem_type_is(@entry, c"CERTIFICATE", 11) != 1
         return 1
 
-    if pem_type_is(&entry, c"KEY", 3) != 0
+    if pem_type_is(@entry, c"KEY", 3) != 0
         return 2
 
     return 0

--- a/projects/cryptosec/test/test_poly1305.ritz
+++ b/projects/cryptosec/test/test_poly1305.ritz
@@ -93,7 +93,7 @@ fn test_poly1305_rfc8439() -> i32
     msg[33] = 0x70  # p
 
     var tag: [16]u8
-    poly1305_mac(&key[0], &msg[0], 34, &tag[0])
+    poly1305_mac(@key[0], @msg[0], 34, @tag[0])
 
     # Expected tag: a8:06:1d:c1:30:51:36:c6:c2:2b:8b:af:0c:01:27:a9
     var expected: [16]u8
@@ -114,7 +114,7 @@ fn test_poly1305_rfc8439() -> i32
     expected[14] = 0x27
     expected[15] = 0xa9
 
-    if bytes_equal(&tag[0], &expected[0], 16) == 0
+    if bytes_equal(@tag[0], @expected[0], 16) == 0
         return 1
     return 0
 
@@ -128,7 +128,7 @@ fn test_poly1305_empty() -> i32
         i += 1
 
     var tag: [16]u8
-    poly1305_mac(&key[0], nil, 0, &tag[0])
+    poly1305_mac(@key[0], nil, 0, @tag[0])
 
     # For empty message, tag should just be s (the second half of key) clamped
     # This is a basic sanity check
@@ -154,18 +154,18 @@ fn test_poly1305_streaming() -> i32
 
     # One-shot
     var tag1: [16]u8
-    poly1305_mac(&key[0], &msg[0], 48, &tag1[0])
+    poly1305_mac(@key[0], @msg[0], 48, @tag1[0])
 
     # Streaming in chunks
     var tag2: [16]u8
     var ctx: Poly1305
-    poly1305_init(&ctx, &key[0])
-    poly1305_update(&ctx, &msg[0], 16)
-    poly1305_update(&ctx, &msg[16], 16)
-    poly1305_update(&ctx, &msg[32], 16)
-    poly1305_final(&ctx, &tag2[0])
+    poly1305_init(@ctx, @key[0])
+    poly1305_update(@ctx, @msg[0], 16)
+    poly1305_update(@ctx, @msg[16], 16)
+    poly1305_update(@ctx, @msg[32], 16)
+    poly1305_final(@ctx, @tag2[0])
 
-    if bytes_equal(&tag1[0], &tag2[0], 16) == 0
+    if bytes_equal(@tag1[0], @tag2[0], 16) == 0
         return 1
     return 0
 
@@ -173,14 +173,14 @@ fn test_poly1305_streaming() -> i32
 [[test]]
 fn test_poly1305_single_byte() -> i32
     var key: [32]u8
-    mem_zero(&key[0], 32)
+    mem_zero(@key[0], 32)
     key[0] = 1
 
     var msg: [1]u8
     msg[0] = 0x41  # 'A'
 
     var tag: [16]u8
-    poly1305_mac(&key[0], &msg[0], 1, &tag[0])
+    poly1305_mac(@key[0], @msg[0], 1, @tag[0])
 
     # Just verify we get a non-zero tag
     var sum: u32 = 0

--- a/projects/cryptosec/test/test_random.ritz
+++ b/projects/cryptosec/test/test_random.ritz
@@ -25,14 +25,14 @@ fn test_getrandom_syscall() -> i32
         buf[i] = 0
         i += 1
 
-    let result: i64 = getrandom(&buf[0], 32, 0)
+    let result: i64 = getrandom(@buf[0], 32, 0)
 
     # Should return 32 (bytes written)
     if result != 32
         return 1
 
     # Buffer should not be all zeros (statistically impossible)
-    let is_zero: i32 = mem_is_zero(&buf[0], 32)
+    let is_zero: i32 = mem_is_zero(@buf[0], 32)
     if is_zero == 1
         return 2
 
@@ -47,14 +47,14 @@ fn test_random_bytes_fills_buffer() -> i32
         buf[i] = 0
         i += 1
 
-    let result: i32 = random_bytes(&buf[0], 64)
+    let result: i32 = random_bytes(@buf[0], 64)
 
     # Should succeed
     if result != 0
         return 1
 
     # Should not be all zeros
-    if mem_is_zero(&buf[0], 64) == 1
+    if mem_is_zero(@buf[0], 64) == 1
         return 2
 
     0
@@ -64,7 +64,7 @@ fn test_random_bytes_zero_length() -> i32
     var buf: [8]u8
     buf[0] = 42  # Sentinel value
 
-    let result: i32 = random_bytes(&buf[0], 0)
+    let result: i32 = random_bytes(@buf[0], 0)
 
     # Should succeed with 0 length
     if result != 0
@@ -124,11 +124,11 @@ fn test_random_bytes_different_calls() -> i32
     var buf1: [32]u8
     var buf2: [32]u8
 
-    random_bytes(&buf1[0], 32)
-    random_bytes(&buf2[0], 32)
+    random_bytes(@buf1[0], 32)
+    random_bytes(@buf2[0], 32)
 
     # Buffers should be different
-    if mem_eq(&buf1[0], &buf2[0], 32) == 1
+    if mem_eq(@buf1[0], @buf2[0], 32) == 1
         return 1
 
     0
@@ -142,7 +142,7 @@ fn test_random_bytes_distribution() -> i32
     # Statistical test: count bytes in upper vs lower half
     # Should be roughly 50/50 with high probability
     var buf: [256]u8
-    random_bytes(&buf[0], 256)
+    random_bytes(@buf[0], 256)
 
     var upper_count: i32 = 0
     var i: i32 = 0
@@ -215,18 +215,18 @@ fn test_random_bytes_large_buffer() -> i32
         buf[i] = 0
         i += 1
 
-    let result: i32 = random_bytes(&buf[0], 512)
+    let result: i32 = random_bytes(@buf[0], 512)
 
     if result != 0
         return 1
 
     # Check that the buffer is not all zeros
-    if mem_is_zero(&buf[0], 512) == 1
+    if mem_is_zero(@buf[0], 512) == 1
         return 2
 
     # Check that different parts of the buffer are different
     # (not just repeating the same pattern)
-    if mem_eq(&buf[0], &buf[256], 256) == 1
+    if mem_eq(@buf[0], @buf[256], 256) == 1
         return 3
 
     0

--- a/projects/cryptosec/test/test_rsa.ritz
+++ b/projects/cryptosec/test/test_rsa.ritz
@@ -11,7 +11,7 @@ import lib.mem
 [[test]]
 fn test_rsa_pubkey_init()
     var key: RsaPublicKey
-    rsa_pubkey_init(&key)
+    rsa_pubkey_init(@key)
     assert key.n_len == 0
     assert key.e == 0
 
@@ -36,7 +36,7 @@ fn test_rsa_parse_raw_pubkey()
     der[9] = 0x03
 
     var key: RsaPublicKey
-    let result: i32 = rsa_parse_public_key(&der[0], 10, &key)
+    let result: i32 = rsa_parse_public_key(@der[0], 10, @key)
     assert result == 0
     assert key.e == 3
     # Modulus should be 0xd5 = 213 (leading zeros stripped)
@@ -65,7 +65,7 @@ fn test_rsa_parse_pubkey_65537()
     der[10] = 0x01
 
     var key: RsaPublicKey
-    let result: i32 = rsa_parse_public_key(&der[0], 11, &key)
+    let result: i32 = rsa_parse_public_key(@der[0], 11, @key)
     assert result == 0
     assert key.e == 65537
     assert key.n_len == 2
@@ -85,9 +85,9 @@ fn test_rsa_verify_sha256_basic()
 
     # Use known test values
     # n = 0xbb (187 = 11 * 17), e = 3
-    bigint_from_u64(&base, 100)
-    bigint_from_u64(&n, 187)
-    bigint_mod_exp_u32(&result, &base, 3, &n)
+    bigint_from_u64(@base, 100)
+    bigint_from_u64(@n, 187)
+    bigint_mod_exp_u32(@result, @base, 3, @n)
     # 100^3 mod 187 = 1000000 mod 187 = 111
     assert result.limbs[0] == 111
 
@@ -98,7 +98,7 @@ fn test_rsa_verify_sha256_basic()
 [[test]]
 fn test_sha256_digest_info_prefix()
     var prefix: [19]u8
-    let len: i32 = get_sha256_digest_info_prefix(&prefix[0])
+    let len: i32 = get_sha256_digest_info_prefix(@prefix[0])
     assert len == 19
     # Verify DER encoding
     assert prefix[0] == 0x30
@@ -124,7 +124,7 @@ fn test_sha256_digest_info_prefix()
 [[test]]
 fn test_sha384_digest_info_prefix()
     var prefix: [19]u8
-    let len: i32 = get_sha384_digest_info_prefix(&prefix[0])
+    let len: i32 = get_sha384_digest_info_prefix(@prefix[0])
     assert len == 19
     # DER: 30 41 30 0d 06 09 60 86 48 01 65 03 04 02 02 05 00 04 30
     assert prefix[0] == 0x30
@@ -135,7 +135,7 @@ fn test_sha384_digest_info_prefix()
 [[test]]
 fn test_sha512_digest_info_prefix()
     var prefix: [19]u8
-    let len: i32 = get_sha512_digest_info_prefix(&prefix[0])
+    let len: i32 = get_sha512_digest_info_prefix(@prefix[0])
     assert len == 19
     # DER: 30 51 30 0d 06 09 60 86 48 01 65 03 04 02 03 05 00 04 40
     assert prefix[0] == 0x30
@@ -225,15 +225,15 @@ fn test_rsa_256bit_modexp()
     n_bytes[30] = 0x32
     n_bytes[31] = 0x11
 
-    bigint_from_bytes(&a, &a_bytes[0], 32)
-    bigint_from_bytes(&n, &n_bytes[0], 32)
+    bigint_from_bytes(@a, @a_bytes[0], 32)
+    bigint_from_bytes(@n, @n_bytes[0], 32)
 
     # Compute a^65537 mod n
-    bigint_mod_exp_u32(&result, &a, 65537, &n)
+    bigint_mod_exp_u32(@result, @a, 65537, @n)
 
     # Result should be some value < n
-    assert bigint_lt(&result, &n) == 1
-    assert bigint_is_zero(&result) == 0
+    assert bigint_lt(@result, @n) == 1
+    assert bigint_is_zero(@result) == 0
 
 # ============================================================================
 # Invalid Signature Tests
@@ -242,7 +242,7 @@ fn test_rsa_256bit_modexp()
 [[test]]
 fn test_rsa_invalid_signature_length()
     var key: RsaPublicKey
-    rsa_pubkey_init(&key)
+    rsa_pubkey_init(@key)
 
     # Set up a minimal key with 128-byte modulus
     key.n_len = 128
@@ -265,13 +265,13 @@ fn test_rsa_invalid_signature_length()
         sig[i] = 0
         i += 1
 
-    let result: i32 = rsa_verify_pkcs1_sha256(&key, &msg[0], 4, &sig[0], 64)
+    let result: i32 = rsa_verify_pkcs1_sha256(@key, @msg[0], 4, @sig[0], 64)
     assert result == 0
 
 [[test]]
 fn test_rsa_signature_too_large()
     var key: RsaPublicKey
-    rsa_pubkey_init(&key)
+    rsa_pubkey_init(@key)
 
     # Small modulus
     key.n[0] = 0x10
@@ -289,7 +289,7 @@ fn test_rsa_signature_too_large()
     sig[0] = 0xff
 
     # This should fail because modulus is too small (< 128 bytes)
-    let result: i32 = rsa_verify_pkcs1_sha256(&key, &msg[0], 4, &sig[0], 1)
+    let result: i32 = rsa_verify_pkcs1_sha256(@key, @msg[0], 4, @sig[0], 1)
     assert result == 0
 
 # ============================================================================
@@ -313,7 +313,7 @@ fn test_rsa_signature_roundtrip_tiny()
     # an invalid signature and confirming it's rejected.
 
     var key: RsaPublicKey
-    rsa_pubkey_init(&key)
+    rsa_pubkey_init(@key)
     key.n_len = 128
     key.e = 3
 
@@ -338,7 +338,7 @@ fn test_rsa_signature_roundtrip_tiny()
         i += 1
 
     # This should fail because the decrypted signature won't have valid PKCS#1 padding
-    let result: i32 = rsa_verify_pkcs1_sha256(&key, &msg[0], 5, &bad_sig[0], 128)
+    let result: i32 = rsa_verify_pkcs1_sha256(@key, @msg[0], 5, @bad_sig[0], 128)
     assert result == 0
 
     # Create another invalid signature - random-looking data
@@ -347,5 +347,5 @@ fn test_rsa_signature_roundtrip_tiny()
         bad_sig[i] = (i * 17 + 5) as u8
         i += 1
 
-    let result2: i32 = rsa_verify_pkcs1_sha256(&key, &msg[0], 5, &bad_sig[0], 128)
+    let result2: i32 = rsa_verify_pkcs1_sha256(@key, @msg[0], 5, @bad_sig[0], 128)
     assert result2 == 0

--- a/projects/cryptosec/test/test_sha256.ritz
+++ b/projects/cryptosec/test/test_sha256.ritz
@@ -52,10 +52,10 @@ fn test_sha256_empty() -> i32
     # SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     var hash: [32]u8
     let msg: *u8 = c""
-    sha256(msg, 0, &hash[0])
+    sha256(msg, 0, @hash[0])
 
     let expected: *u8 = c"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -64,10 +64,10 @@ fn test_sha256_abc() -> i32
     # SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
     var hash: [32]u8
     let msg: *u8 = c"abc"
-    sha256(msg, 3, &hash[0])
+    sha256(msg, 3, @hash[0])
 
     let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -77,10 +77,10 @@ fn test_sha256_448_bits() -> i32
     # = 248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
     var hash: [32]u8
     let msg: *u8 = c"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
-    sha256(msg, 56, &hash[0])
+    sha256(msg, 56, @hash[0])
 
     let expected: *u8 = c"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -90,10 +90,10 @@ fn test_sha256_896_bits() -> i32
     # = cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1
     var hash: [32]u8
     let msg: *u8 = c"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
-    sha256(msg, 112, &hash[0])
+    sha256(msg, 112, @hash[0])
 
     let expected: *u8 = c"cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -106,10 +106,10 @@ fn test_sha256_single_a() -> i32
     # SHA-256("a") = ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
     var hash: [32]u8
     let msg: *u8 = c"a"
-    sha256(msg, 1, &hash[0])
+    sha256(msg, 1, @hash[0])
 
     let expected: *u8 = c"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -119,10 +119,10 @@ fn test_sha256_single_zero_byte() -> i32
     var msg: [1]u8
     msg[0] = 0
     var hash: [32]u8
-    sha256(&msg[0], 1, &hash[0])
+    sha256(@msg[0], 1, @hash[0])
 
     let expected: *u8 = c"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -136,10 +136,10 @@ fn test_sha256_55_bytes() -> i32
     # SHA-256("0123456789012345678901234567890123456789012345678901234")
     var hash: [32]u8
     let msg: *u8 = c"0123456789012345678901234567890123456789012345678901234"
-    sha256(msg, 55, &hash[0])
+    sha256(msg, 55, @hash[0])
 
     let expected: *u8 = c"f34d5a0f80c0cbf84c8c0b90218c22637abd199965249da736a20143c8c9c9d9"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -149,10 +149,10 @@ fn test_sha256_56_bytes() -> i32
     # SHA-256("01234567890123456789012345678901234567890123456789012345")
     var hash: [32]u8
     let msg: *u8 = c"01234567890123456789012345678901234567890123456789012345"
-    sha256(msg, 56, &hash[0])
+    sha256(msg, 56, @hash[0])
 
     let expected: *u8 = c"83aa034bda83e458a0dc9cbce0d4e354716aa0ff770ed37ac0ed2b292052e4af"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -162,10 +162,10 @@ fn test_sha256_64_bytes() -> i32
     # SHA-256("0123456789012345678901234567890123456789012345678901234567890123")
     var hash: [32]u8
     let msg: *u8 = c"0123456789012345678901234567890123456789012345678901234567890123"
-    sha256(msg, 64, &hash[0])
+    sha256(msg, 64, @hash[0])
 
     let expected: *u8 = c"9674d9e078535b7cec43284387a6ee39956188e735a85452b0050b55341cda56"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -178,11 +178,11 @@ fn test_sha256_128_bytes() -> i32
         msg[i] = 97  # 'a'
         i += 1
     var hash: [32]u8
-    sha256(&msg[0], 128, &hash[0])
+    sha256(@msg[0], 128, @hash[0])
 
     # SHA-256("a" * 128)
     let expected: *u8 = c"6836cf13bac400e9105071cd6af47084dfacad4e5e302c94bfed24e013afb73e"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -194,13 +194,13 @@ fn test_sha256_128_bytes() -> i32
 fn test_sha256_streaming_single_update() -> i32
     # Same as one-shot for "abc"
     var ctx: Sha256
-    sha256_init(&ctx)
-    sha256_update(&ctx, c"abc", 3)
+    sha256_init(@ctx)
+    sha256_update(@ctx, c"abc", 3)
     var hash: [32]u8
-    sha256_final(&ctx, &hash[0])
+    sha256_final(@ctx, @hash[0])
 
     let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -208,15 +208,15 @@ fn test_sha256_streaming_single_update() -> i32
 fn test_sha256_streaming_multiple_updates() -> i32
     # Hash "abc" as three separate updates
     var ctx: Sha256
-    sha256_init(&ctx)
-    sha256_update(&ctx, c"a", 1)
-    sha256_update(&ctx, c"b", 1)
-    sha256_update(&ctx, c"c", 1)
+    sha256_init(@ctx)
+    sha256_update(@ctx, c"a", 1)
+    sha256_update(@ctx, c"b", 1)
+    sha256_update(@ctx, c"c", 1)
     var hash: [32]u8
-    sha256_final(&ctx, &hash[0])
+    sha256_final(@ctx, @hash[0])
 
     let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -224,19 +224,19 @@ fn test_sha256_streaming_multiple_updates() -> i32
 fn test_sha256_streaming_cross_block() -> i32
     # Update that crosses block boundary
     var ctx: Sha256
-    sha256_init(&ctx)
+    sha256_init(@ctx)
     # First update: 60 bytes (fills most of first block)
     let part1: *u8 = c"012345678901234567890123456789012345678901234567890123456789"
-    sha256_update(&ctx, part1, 60)
+    sha256_update(@ctx, part1, 60)
     # Second update: 10 bytes (crosses into second block)
     let part2: *u8 = c"0123456789"
-    sha256_update(&ctx, part2, 10)
+    sha256_update(@ctx, part2, 10)
     var hash: [32]u8
-    sha256_final(&ctx, &hash[0])
+    sha256_final(@ctx, @hash[0])
 
     # SHA-256("0123456789" * 7) = 70 chars total
     let expected: *u8 = c"57445fa40b08c60cdcba7ca39c756de614d11482e3f15a925f548688c19e58f4"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -244,15 +244,15 @@ fn test_sha256_streaming_cross_block() -> i32
 fn test_sha256_streaming_empty_updates() -> i32
     # Empty updates should be handled gracefully
     var ctx: Sha256
-    sha256_init(&ctx)
-    sha256_update(&ctx, c"", 0)
-    sha256_update(&ctx, c"abc", 3)
-    sha256_update(&ctx, c"", 0)
+    sha256_init(@ctx)
+    sha256_update(@ctx, c"", 0)
+    sha256_update(@ctx, c"abc", 3)
+    sha256_update(@ctx, c"", 0)
     var hash: [32]u8
-    sha256_final(&ctx, &hash[0])
+    sha256_final(@ctx, @hash[0])
 
     let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-    if hash_eq_hex(&hash[0], expected) != 1
+    if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -282,12 +282,12 @@ fn test_sha256_rfc6234_test4() -> i32
         msg[i] = (i + 1) as u8
         i += 1
     var hash: [32]u8
-    sha256(&msg[0], 64, &hash[0])
+    sha256(@msg[0], 64, @hash[0])
 
     # SHA-256(0x0102030405...3f40) = known value
     # Actually compute: we just verify it doesn't crash and produces 32 bytes
     # Real test would need actual expected value
-    if mem_is_zero(&hash[0], 32) == 1
+    if mem_is_zero(@hash[0], 32) == 1
         return 1  # Hash should not be all zeros
     0
 
@@ -302,10 +302,10 @@ fn test_sha256_deterministic() -> i32
     var hash2: [32]u8
     let msg: *u8 = c"test message"
 
-    sha256(msg, 12, &hash1[0])
-    sha256(msg, 12, &hash2[0])
+    sha256(msg, 12, @hash1[0])
+    sha256(msg, 12, @hash2[0])
 
-    if mem_eq(&hash1[0], &hash2[0], 32) != 1
+    if mem_eq(@hash1[0], @hash2[0], 32) != 1
         return 1
     0
 
@@ -315,10 +315,10 @@ fn test_sha256_different_inputs_different_outputs() -> i32
     var hash1: [32]u8
     var hash2: [32]u8
 
-    sha256(c"hello", 5, &hash1[0])
-    sha256(c"world", 5, &hash2[0])
+    sha256(c"hello", 5, @hash1[0])
+    sha256(c"world", 5, @hash2[0])
 
-    if mem_eq(&hash1[0], &hash2[0], 32) == 1
+    if mem_eq(@hash1[0], @hash2[0], 32) == 1
         return 1  # Should be different!
     0
 

--- a/projects/cryptosec/test/test_sha512.ritz
+++ b/projects/cryptosec/test/test_sha512.ritz
@@ -56,9 +56,9 @@ fn test_sha512_empty() -> i32
     # SHA-512("")
     var hash: [64]u8
     let msg: *u8 = c""
-    sha512(msg, 0, &hash[0])
+    sha512(msg, 0, @hash[0])
     let expected: *u8 = c"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
-    if hash512_eq_hex(&hash[0], expected) != 1
+    if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -67,9 +67,9 @@ fn test_sha512_abc() -> i32
     # SHA-512("abc")
     var hash: [64]u8
     let msg: *u8 = c"abc"
-    sha512(msg, 3, &hash[0])
+    sha512(msg, 3, @hash[0])
     let expected: *u8 = c"ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
-    if hash512_eq_hex(&hash[0], expected) != 1
+    if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -78,9 +78,9 @@ fn test_sha512_448_bits() -> i32
     # SHA-512("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
     var hash: [64]u8
     let msg: *u8 = c"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
-    sha512(msg, 56, &hash[0])
+    sha512(msg, 56, @hash[0])
     let expected: *u8 = c"204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"
-    if hash512_eq_hex(&hash[0], expected) != 1
+    if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -89,9 +89,9 @@ fn test_sha512_896_bits() -> i32
     # SHA-512("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")
     var hash: [64]u8
     let msg: *u8 = c"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
-    sha512(msg, 112, &hash[0])
+    sha512(msg, 112, @hash[0])
     let expected: *u8 = c"8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909"
-    if hash512_eq_hex(&hash[0], expected) != 1
+    if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -104,14 +104,14 @@ fn test_sha512_incremental() -> i32
     let c: *u8 = c"c"
 
     var ctx: Sha512 = sha512_new()
-    sha512_init(&ctx)
-    sha512_update(&ctx, a, 1)
-    sha512_update(&ctx, b, 1)
-    sha512_update(&ctx, c, 1)
-    sha512_final(&ctx, &hash[0])
+    sha512_init(@ctx)
+    sha512_update(@ctx, a, 1)
+    sha512_update(@ctx, b, 1)
+    sha512_update(@ctx, c, 1)
+    sha512_final(@ctx, @hash[0])
 
     let expected: *u8 = c"ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
-    if hash512_eq_hex(&hash[0], expected) != 1
+    if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -120,9 +120,9 @@ fn test_sha512_single_byte() -> i32
     # SHA-512("a")
     var hash: [64]u8
     let msg: *u8 = c"a"
-    sha512(msg, 1, &hash[0])
+    sha512(msg, 1, @hash[0])
     let expected: *u8 = c"1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"
-    if hash512_eq_hex(&hash[0], expected) != 1
+    if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -135,9 +135,9 @@ fn test_sha384_empty() -> i32
     # SHA-384("")
     var hash: [48]u8
     let msg: *u8 = c""
-    sha384(msg, 0, &hash[0])
+    sha384(msg, 0, @hash[0])
     let expected: *u8 = c"38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
-    if hash384_eq_hex(&hash[0], expected) != 1
+    if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -146,9 +146,9 @@ fn test_sha384_abc() -> i32
     # SHA-384("abc")
     var hash: [48]u8
     let msg: *u8 = c"abc"
-    sha384(msg, 3, &hash[0])
+    sha384(msg, 3, @hash[0])
     let expected: *u8 = c"cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
-    if hash384_eq_hex(&hash[0], expected) != 1
+    if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -157,9 +157,9 @@ fn test_sha384_448_bits() -> i32
     # SHA-384("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
     var hash: [48]u8
     let msg: *u8 = c"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
-    sha384(msg, 56, &hash[0])
+    sha384(msg, 56, @hash[0])
     let expected: *u8 = c"3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b"
-    if hash384_eq_hex(&hash[0], expected) != 1
+    if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -172,14 +172,14 @@ fn test_sha384_incremental() -> i32
     let c: *u8 = c"c"
 
     var ctx: Sha384 = sha384_new()
-    sha384_init(&ctx)
-    sha384_update(&ctx, a, 1)
-    sha384_update(&ctx, b, 1)
-    sha384_update(&ctx, c, 1)
-    sha384_final(&ctx, &hash[0])
+    sha384_init(@ctx)
+    sha384_update(@ctx, a, 1)
+    sha384_update(@ctx, b, 1)
+    sha384_update(@ctx, c, 1)
+    sha384_final(@ctx, @hash[0])
 
     let expected: *u8 = c"cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
-    if hash384_eq_hex(&hash[0], expected) != 1
+    if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
 
@@ -193,9 +193,9 @@ fn test_sha512_deterministic() -> i32
     var hash1: [64]u8
     var hash2: [64]u8
     let msg: *u8 = c"hello"
-    sha512(msg, 5, &hash1[0])
-    sha512(msg, 5, &hash2[0])
-    if mem_eq(&hash1[0], &hash2[0], 64) != 1
+    sha512(msg, 5, @hash1[0])
+    sha512(msg, 5, @hash2[0])
+    if mem_eq(@hash1[0], @hash2[0], 64) != 1
         return 1
     0
 
@@ -204,9 +204,9 @@ fn test_sha384_deterministic() -> i32
     var hash1: [48]u8
     var hash2: [48]u8
     let msg: *u8 = c"hello"
-    sha384(msg, 5, &hash1[0])
-    sha384(msg, 5, &hash2[0])
-    if mem_eq(&hash1[0], &hash2[0], 48) != 1
+    sha384(msg, 5, @hash1[0])
+    sha384(msg, 5, @hash2[0])
+    if mem_eq(@hash1[0], @hash2[0], 48) != 1
         return 1
     0
 
@@ -216,10 +216,10 @@ fn test_sha512_different_inputs() -> i32
     var hash2: [64]u8
     let msg1: *u8 = c"abc"
     let msg2: *u8 = c"abd"
-    sha512(msg1, 3, &hash1[0])
-    sha512(msg2, 3, &hash2[0])
+    sha512(msg1, 3, @hash1[0])
+    sha512(msg2, 3, @hash2[0])
     # Different inputs should produce different outputs
-    if mem_eq(&hash1[0], &hash2[0], 64) == 1
+    if mem_eq(@hash1[0], @hash2[0], 64) == 1
         return 1
     0
 
@@ -232,14 +232,14 @@ fn test_sha512_large_message() -> i32
         msg[i] = 0x61  # 'a'
         i += 1
     var hash: [64]u8
-    sha512(&msg[0], 200, &hash[0])
+    sha512(@msg[0], 200, @hash[0])
     # Just verify it doesn't crash and produces non-zero output
     var zeros: [64]u8
     i = 0
     while i < 64
         zeros[i] = 0
         i += 1
-    if mem_eq(&hash[0], &zeros[0], 64) == 1
+    if mem_eq(@hash[0], @zeros[0], 64) == 1
         return 1
     0
 
@@ -251,13 +251,13 @@ fn test_sha384_large_message() -> i32
         msg[i] = 0x61
         i += 1
     var hash: [48]u8
-    sha384(&msg[0], 200, &hash[0])
+    sha384(@msg[0], 200, @hash[0])
     var zeros: [48]u8
     i = 0
     while i < 48
         zeros[i] = 0
         i += 1
-    if mem_eq(&hash[0], &zeros[0], 48) == 1
+    if mem_eq(@hash[0], @zeros[0], 48) == 1
         return 1
     0
 
@@ -270,12 +270,12 @@ fn test_sha512_block_boundary() -> i32
         msg[i] = 0x62  # 'b'
         i += 1
     var hash: [64]u8
-    sha512(&msg[0], 128, &hash[0])
+    sha512(@msg[0], 128, @hash[0])
     var zeros: [64]u8
     i = 0
     while i < 64
         zeros[i] = 0
         i += 1
-    if mem_eq(&hash[0], &zeros[0], 64) == 1
+    if mem_eq(@hash[0], @zeros[0], 64) == 1
         return 1
     0

--- a/projects/cryptosec/test/test_sha_ni.ritz
+++ b/projects/cryptosec/test/test_sha_ni.ritz
@@ -21,9 +21,9 @@ fn test_sha256rnds2_compiles() -> i32
     var cdgh: [4]i32
     var abef: [4]i32
     var wk: [4]i32
-    mem_zero(&cdgh[0] as *u8, 16)
-    mem_zero(&abef[0] as *u8, 16)
-    mem_zero(&wk[0] as *u8, 16)
+    mem_zero(@cdgh[0] as *u8, 16)
+    mem_zero(@abef[0] as *u8, 16)
+    mem_zero(@wk[0] as *u8, 16)
 
     # Set some non-zero values
     abef[0] = 0x6a09e667 as i32  # SHA-256 initial state a
@@ -36,16 +36,16 @@ fn test_sha256rnds2_compiles() -> i32
     cdgh[3] = 0x5be0cd19 as i32  # h
 
     # Load into vectors
-    var v_cdgh: v4i32 = simd_loadu(&cdgh[0])
-    var v_abef: v4i32 = simd_loadu(&abef[0])
-    var v_wk: v4i32 = simd_loadu(&wk[0])
+    var v_cdgh: v4i32 = simd_loadu(@cdgh[0])
+    var v_abef: v4i32 = simd_loadu(@abef[0])
+    var v_wk: v4i32 = simd_loadu(@wk[0])
 
     # Call the intrinsic
     var result: v4i32 = sha256rnds2(v_cdgh, v_abef, v_wk)
 
     # Store result
     var out: [4]i32
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     # Verify something happened (output != input)
     # For non-zero SHA-256 state, the output should be different from input
@@ -60,19 +60,19 @@ fn test_sha256msg1_compiles() -> i32
 
     var v0: [4]i32
     var v1: [4]i32
-    mem_zero(&v0[0] as *u8, 16)
-    mem_zero(&v1[0] as *u8, 16)
+    mem_zero(@v0[0] as *u8, 16)
+    mem_zero(@v1[0] as *u8, 16)
 
     v0[0] = 0x61626364 as i32  # "abcd"
     v1[0] = 0x65666768 as i32  # "efgh"
 
-    var vec0: v4i32 = simd_loadu(&v0[0])
-    var vec1: v4i32 = simd_loadu(&v1[0])
+    var vec0: v4i32 = simd_loadu(@v0[0])
+    var vec1: v4i32 = simd_loadu(@v1[0])
 
     var result: v4i32 = sha256msg1(vec0, vec1)
 
     var out: [4]i32
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     # Just verify it ran without crashing
     return 0
@@ -85,16 +85,16 @@ fn test_sha256msg2_compiles() -> i32
 
     var v4: [4]i32
     var v3: [4]i32
-    mem_zero(&v4[0] as *u8, 16)
-    mem_zero(&v3[0] as *u8, 16)
+    mem_zero(@v4[0] as *u8, 16)
+    mem_zero(@v3[0] as *u8, 16)
 
-    var vec4: v4i32 = simd_loadu(&v4[0])
-    var vec3: v4i32 = simd_loadu(&v3[0])
+    var vec4: v4i32 = simd_loadu(@v4[0])
+    var vec3: v4i32 = simd_loadu(@v3[0])
 
     var result: v4i32 = sha256msg2(vec4, vec3)
 
     var out: [4]i32
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     return 0
 
@@ -109,16 +109,16 @@ fn test_aesenc_compiles() -> i32
 
     var state: [2]i64
     var rkey: [2]i64
-    mem_zero(&state[0] as *u8, 16)
-    mem_zero(&rkey[0] as *u8, 16)
+    mem_zero(@state[0] as *u8, 16)
+    mem_zero(@rkey[0] as *u8, 16)
 
-    var v_state: v2i64 = simd_loadu(&state[0])
-    var v_rkey: v2i64 = simd_loadu(&rkey[0])
+    var v_state: v2i64 = simd_loadu(@state[0])
+    var v_rkey: v2i64 = simd_loadu(@rkey[0])
 
     var result: v2i64 = aesenc(v_state, v_rkey)
 
     var out: [2]i64
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     # For zero input and zero key, AES produces a specific output
     # Just verify it ran without crashing
@@ -131,16 +131,16 @@ fn test_aesenclast_compiles() -> i32
 
     var state: [2]i64
     var rkey: [2]i64
-    mem_zero(&state[0] as *u8, 16)
-    mem_zero(&rkey[0] as *u8, 16)
+    mem_zero(@state[0] as *u8, 16)
+    mem_zero(@rkey[0] as *u8, 16)
 
-    var v_state: v2i64 = simd_loadu(&state[0])
-    var v_rkey: v2i64 = simd_loadu(&rkey[0])
+    var v_state: v2i64 = simd_loadu(@state[0])
+    var v_rkey: v2i64 = simd_loadu(@rkey[0])
 
     var result: v2i64 = aesenclast(v_state, v_rkey)
 
     var out: [2]i64
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     return 0
 
@@ -151,16 +151,16 @@ fn test_aesdec_compiles() -> i32
 
     var state: [2]i64
     var rkey: [2]i64
-    mem_zero(&state[0] as *u8, 16)
-    mem_zero(&rkey[0] as *u8, 16)
+    mem_zero(@state[0] as *u8, 16)
+    mem_zero(@rkey[0] as *u8, 16)
 
-    var v_state: v2i64 = simd_loadu(&state[0])
-    var v_rkey: v2i64 = simd_loadu(&rkey[0])
+    var v_state: v2i64 = simd_loadu(@state[0])
+    var v_rkey: v2i64 = simd_loadu(@rkey[0])
 
     var result: v2i64 = aesdec(v_state, v_rkey)
 
     var out: [2]i64
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     return 0
 
@@ -171,16 +171,16 @@ fn test_aesdeclast_compiles() -> i32
 
     var state: [2]i64
     var rkey: [2]i64
-    mem_zero(&state[0] as *u8, 16)
-    mem_zero(&rkey[0] as *u8, 16)
+    mem_zero(@state[0] as *u8, 16)
+    mem_zero(@rkey[0] as *u8, 16)
 
-    var v_state: v2i64 = simd_loadu(&state[0])
-    var v_rkey: v2i64 = simd_loadu(&rkey[0])
+    var v_state: v2i64 = simd_loadu(@state[0])
+    var v_rkey: v2i64 = simd_loadu(@rkey[0])
 
     var result: v2i64 = aesdeclast(v_state, v_rkey)
 
     var out: [2]i64
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     return 0
 
@@ -190,15 +190,15 @@ fn test_aeskeygenassist_compiles() -> i32
         return 0
 
     var key: [2]i64
-    mem_zero(&key[0] as *u8, 16)
+    mem_zero(@key[0] as *u8, 16)
 
-    var v_key: v2i64 = simd_loadu(&key[0])
+    var v_key: v2i64 = simd_loadu(@key[0])
 
     # rcon = 0x01 (first round constant)
     var result: v2i64 = aeskeygenassist(v_key, 0x01)
 
     var out: [2]i64
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     return 0
 
@@ -208,13 +208,13 @@ fn test_aesimc_compiles() -> i32
         return 0
 
     var rkey: [2]i64
-    mem_zero(&rkey[0] as *u8, 16)
+    mem_zero(@rkey[0] as *u8, 16)
 
-    var v_rkey: v2i64 = simd_loadu(&rkey[0])
+    var v_rkey: v2i64 = simd_loadu(@rkey[0])
 
     var result: v2i64 = aesimc(v_rkey)
 
     var out: [2]i64
-    simd_storeu(&out[0], result)
+    simd_storeu(@out[0], result)
 
     return 0

--- a/projects/cryptosec/test/test_tls13_client.ritz
+++ b/projects/cryptosec/test/test_tls13_client.ritz
@@ -13,7 +13,7 @@ import lib.tls13_handshake
 [[test]]
 fn test_config_init() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     if cfg.num_cipher_suites != 2
         return 1
@@ -29,9 +29,9 @@ fn test_config_init() -> i32
 [[test]]
 fn test_config_set_hostname() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
-    tls_config_set_hostname(&cfg, c"example.com", 11)
+    tls_config_set_hostname(@cfg, c"example.com", 11)
 
     if cfg.hostname_len != 11
         return 1
@@ -48,11 +48,11 @@ fn test_config_set_hostname() -> i32
 [[test]]
 fn test_client_init() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
-    tls_config_set_hostname(&cfg, c"test.local", 10)
+    tls_config_init(@cfg)
+    tls_config_set_hostname(@cfg, c"test.local", 10)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     if client.state != TLS_STATE_INIT
         return 1
@@ -69,14 +69,14 @@ fn test_client_init() -> i32
 [[test]]
 fn test_client_start() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
-    tls_config_set_hostname(&cfg, c"example.com", 11)
+    tls_config_init(@cfg)
+    tls_config_set_hostname(@cfg, c"example.com", 11)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     var out: [1024]u8
-    let len: i64 = tls_client_start(&client, &out[0], 1024)
+    let len: i64 = tls_client_start(@client, @out[0], 1024)
 
     if len < 50
         return 1
@@ -98,13 +98,13 @@ fn test_client_start() -> i32
 [[test]]
 fn test_client_start_small_buffer() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     var out: [10]u8  # Too small
-    let len: i64 = tls_client_start(&client, &out[0], 10)
+    let len: i64 = tls_client_start(@client, @out[0], 10)
 
     if len >= 0
         return 1  # Should have failed
@@ -121,18 +121,18 @@ fn test_client_start_small_buffer() -> i32
 [[test]]
 fn test_client_state_accessors() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
-    if tls_client_state(&client) != TLS_STATE_INIT
+    if tls_client_state(@client) != TLS_STATE_INIT
         return 1
 
-    if tls_client_is_connected(&client) != 0
+    if tls_client_is_connected(@client) != 0
         return 2
 
-    if tls_client_error(&client) != 0
+    if tls_client_error(@client) != 0
         return 3
 
     return 0
@@ -140,17 +140,17 @@ fn test_client_state_accessors() -> i32
 [[test]]
 fn test_client_process_wrong_state() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     # Try to process data without starting handshake
     var data: [10]u8
     var out: [100]u8
     var out_len: i64 = 0
 
-    let result: i32 = tls_client_process(&client, &data[0], 10, &out[0], 100, &out_len)
+    let result: i32 = tls_client_process(@client, @data[0], 10, @out[0], 100, @out_len)
 
     # Should fail - wrong state
     if result != TLS_RESULT_ERROR
@@ -165,14 +165,14 @@ fn test_client_process_wrong_state() -> i32
 [[test]]
 fn test_client_needs_more_data() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     # Start handshake
     var ch_out: [1024]u8
-    tls_client_start(&client, &ch_out[0], 1024)
+    tls_client_start(@client, @ch_out[0], 1024)
 
     # Send incomplete data
     var partial: [3]u8
@@ -183,7 +183,7 @@ fn test_client_needs_more_data() -> i32
     var out: [100]u8
     var out_len: i64 = 0
 
-    let result: i32 = tls_client_process(&client, &partial[0], 3, &out[0], 100, &out_len)
+    let result: i32 = tls_client_process(@client, @partial[0], 3, @out[0], 100, @out_len)
 
     if result != TLS_RESULT_NEED_INPUT
         return 1
@@ -193,14 +193,14 @@ fn test_client_needs_more_data() -> i32
 [[test]]
 fn test_client_wrong_content_type() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     # Start handshake
     var ch_out: [1024]u8
-    tls_client_start(&client, &ch_out[0], 1024)
+    tls_client_start(@client, @ch_out[0], 1024)
 
     # Send wrong content type
     var data: [10]u8
@@ -215,7 +215,7 @@ fn test_client_wrong_content_type() -> i32
     var out: [100]u8
     var out_len: i64 = 0
 
-    let result: i32 = tls_client_process(&client, &data[0], 7, &out[0], 100, &out_len)
+    let result: i32 = tls_client_process(@client, @data[0], 7, @out[0], 100, @out_len)
 
     if result != TLS_RESULT_ERROR
         return 1
@@ -232,15 +232,15 @@ fn test_client_wrong_content_type() -> i32
 [[test]]
 fn test_write_not_connected() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     var data: [10]u8
     var out: [100]u8
 
-    let result: i64 = tls_client_write(&client, &data[0], 10, &out[0], 100)
+    let result: i64 = tls_client_write(@client, @data[0], 10, @out[0], 100)
 
     if result >= 0
         return 1  # Should fail - not connected
@@ -250,15 +250,15 @@ fn test_write_not_connected() -> i32
 [[test]]
 fn test_read_not_connected() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     var data: [10]u8
     var out: [100]u8
 
-    let result: i64 = tls_client_read(&client, &data[0], 10, &out[0], 100)
+    let result: i64 = tls_client_read(@client, @data[0], 10, @out[0], 100)
 
     if result >= 0
         return 1  # Should fail - not connected
@@ -272,13 +272,13 @@ fn test_read_not_connected() -> i32
 [[test]]
 fn test_close_not_connected() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     var out: [100]u8
-    let result: i64 = tls_client_close(&client, &out[0], 100)
+    let result: i64 = tls_client_close(@client, @out[0], 100)
 
     if result != 0
         return 1  # Should return 0 (nothing to send) when not connected
@@ -292,17 +292,17 @@ fn test_close_not_connected() -> i32
 [[test]]
 fn test_client_free() -> i32
     var cfg: TlsConfig
-    tls_config_init(&cfg)
+    tls_config_init(@cfg)
 
     var client: TlsClient
-    tls_client_init(&client, &cfg)
+    tls_client_init(@client, @cfg)
 
     # Start handshake to populate some sensitive data
     var out: [1024]u8
-    tls_client_start(&client, &out[0], 1024)
+    tls_client_start(@client, @out[0], 1024)
 
     # Free should zero sensitive data
-    tls_client_free(&client)
+    tls_client_free(@client)
 
     # Check that shared secret is zeroed
     var all_zero: i32 = 1

--- a/projects/cryptosec/test/test_tls13_handshake.ritz
+++ b/projects/cryptosec/test/test_tls13_handshake.ritz
@@ -14,7 +14,7 @@ import lib.tls13_kdf
 [[test]]
 fn test_transcript_init() -> i32
     var t: Transcript
-    transcript_init(&t)
+    transcript_init(@t)
 
     if t.bytes_hashed != 0
         return 1
@@ -26,13 +26,13 @@ fn test_transcript_init() -> i32
 [[test]]
 fn test_transcript_update_and_hash() -> i32
     var t: Transcript
-    transcript_init(&t)
+    transcript_init(@t)
 
     # Hash "abc"
-    transcript_update(&t, c"abc", 3)
+    transcript_update(@t, c"abc", 3)
 
     var hash: [32]u8
-    transcript_hash(&t, &hash[0])
+    transcript_hash(@t, @hash[0])
 
     # SHA-256("abc") = ba7816bf...
     if hash[0] != 0xba
@@ -49,14 +49,14 @@ fn test_transcript_update_and_hash() -> i32
 [[test]]
 fn test_transcript_incremental() -> i32
     var t: Transcript
-    transcript_init(&t)
+    transcript_init(@t)
 
     # Hash in parts
-    transcript_update(&t, c"a", 1)
-    transcript_update(&t, c"bc", 2)
+    transcript_update(@t, c"a", 1)
+    transcript_update(@t, c"bc", 2)
 
     var hash: [32]u8
-    transcript_hash(&t, &hash[0])
+    transcript_hash(@t, @hash[0])
 
     # Should be same as SHA-256("abc")
     if hash[0] != 0xba
@@ -69,21 +69,21 @@ fn test_transcript_incremental() -> i32
 [[test]]
 fn test_transcript_multiple_hashes() -> i32
     var t: Transcript
-    transcript_init(&t)
+    transcript_init(@t)
 
-    transcript_update(&t, c"hello", 5)
+    transcript_update(@t, c"hello", 5)
 
     var hash1: [32]u8
-    transcript_hash(&t, &hash1[0])
+    transcript_hash(@t, @hash1[0])
 
     # Update more
-    transcript_update(&t, c"world", 5)
+    transcript_update(@t, c"world", 5)
 
     var hash2: [32]u8
-    transcript_hash(&t, &hash2[0])
+    transcript_hash(@t, @hash2[0])
 
     # Hashes should be different
-    if mem_eq(&hash1[0], &hash2[0], 32) == 1
+    if mem_eq(@hash1[0], @hash2[0], 32) == 1
         return 1
 
     return 0
@@ -95,7 +95,7 @@ fn test_transcript_multiple_hashes() -> i32
 [[test]]
 fn test_client_hello_init() -> i32
     var ch: ClientHello
-    client_hello_init(&ch)
+    client_hello_init(@ch)
 
     # Should have random data (check it's not all zeros)
     var all_zero: i32 = 1
@@ -128,9 +128,9 @@ fn test_client_hello_init() -> i32
 [[test]]
 fn test_client_hello_set_hostname() -> i32
     var ch: ClientHello
-    client_hello_init(&ch)
+    client_hello_init(@ch)
 
-    client_hello_set_hostname(&ch, c"example.com", 11)
+    client_hello_set_hostname(@ch, c"example.com", 11)
 
     if ch.hostname_len != 11
         return 1
@@ -145,11 +145,11 @@ fn test_client_hello_set_hostname() -> i32
 [[test]]
 fn test_client_hello_serialize() -> i32
     var ch: ClientHello
-    client_hello_init(&ch)
-    client_hello_set_hostname(&ch, c"test.local", 10)
+    client_hello_init(@ch)
+    client_hello_set_hostname(@ch, c"test.local", 10)
 
     var buf: [512]u8
-    let len: i64 = client_hello_serialize(&ch, &buf[0], 512)
+    let len: i64 = client_hello_serialize(@ch, @buf[0], 512)
 
     if len < 100
         return 1  # Too short
@@ -167,10 +167,10 @@ fn test_client_hello_serialize() -> i32
 [[test]]
 fn test_client_hello_extensions() -> i32
     var ch: ClientHello
-    client_hello_init(&ch)
+    client_hello_init(@ch)
 
     var buf: [512]u8
-    let len: i64 = client_hello_serialize(&ch, &buf[0], 512)
+    let len: i64 = client_hello_serialize(@ch, @buf[0], 512)
 
     # Look for supported_versions extension (type 43 = 0x002B)
     var found_versions: i32 = 0
@@ -264,7 +264,7 @@ fn test_server_hello_parse_basic() -> i32
     let total_len: i32 = pos + 2 + ext_len
 
     var sh: ServerHello
-    let result: i32 = server_hello_parse(&data[0], total_len as i64, &sh)
+    let result: i32 = server_hello_parse(@data[0], total_len as i64, @sh)
 
     if result != 0
         return 1 + (-result)
@@ -322,7 +322,7 @@ fn test_server_hello_missing_version() -> i32
     pos = pos + 2
 
     var sh: ServerHello
-    let result: i32 = server_hello_parse(&data[0], pos as i64, &sh)
+    let result: i32 = server_hello_parse(@data[0], pos as i64, @sh)
 
     # Should fail because no TLS 1.3 version
     if result >= 0
@@ -342,7 +342,7 @@ fn test_encrypted_extensions_empty() -> i32
     data[1] = 0
 
     var ee: EncryptedExtensions
-    let result: i32 = encrypted_extensions_parse(&data[0], 2, &ee)
+    let result: i32 = encrypted_extensions_parse(@data[0], 2, @ee)
 
     if result != 0
         return 1
@@ -368,7 +368,7 @@ fn test_encrypted_extensions_with_sni() -> i32
     data[5] = 0  # Length 0
 
     var ee: EncryptedExtensions
-    let result: i32 = encrypted_extensions_parse(&data[0], 6, &ee)
+    let result: i32 = encrypted_extensions_parse(@data[0], 6, @ee)
 
     if result != 0
         return 1
@@ -420,7 +420,7 @@ fn test_certificate_parse_single() -> i32
     pos = pos + 2
 
     var cm: CertificateMessage
-    let result: i32 = certificate_parse(&data[0], pos as i64, &cm)
+    let result: i32 = certificate_parse(@data[0], pos as i64, @cm)
 
     if result != 0
         return 1
@@ -489,7 +489,7 @@ fn test_certificate_parse_chain() -> i32
     pos = pos + 2
 
     var cm: CertificateMessage
-    let result: i32 = certificate_parse(&data[0], pos as i64, &cm)
+    let result: i32 = certificate_parse(@data[0], pos as i64, @cm)
 
     if result != 0
         return 1
@@ -528,7 +528,7 @@ fn test_certificate_verify_parse() -> i32
         i += 1
 
     var cv: CertificateVerify
-    let result: i32 = certificate_verify_parse(&data[0], 36, &cv)
+    let result: i32 = certificate_verify_parse(@data[0], 36, @cv)
 
     if result != 0
         return 1
@@ -562,7 +562,7 @@ fn test_finished_compute() -> i32
         transcript_hash[i] = (i + 0x10) as u8
         i += 1
 
-    finished_compute(&base_key[0], &transcript_hash[0], &verify_data[0])
+    finished_compute(@base_key[0], @transcript_hash[0], @verify_data[0])
 
     # verify_data should not be all zeros
     var all_zero: i32 = 1
@@ -590,10 +590,10 @@ fn test_finished_verify_success() -> i32
         i += 1
 
     # Compute expected verify_data
-    finished_compute(&base_key[0], &transcript_hash[0], &verify_data[0])
+    finished_compute(@base_key[0], @transcript_hash[0], @verify_data[0])
 
     # Verify should succeed
-    let result: i32 = finished_verify(&base_key[0], &transcript_hash[0], &verify_data[0])
+    let result: i32 = finished_verify(@base_key[0], @transcript_hash[0], @verify_data[0])
 
     if result != 1
         return 1
@@ -614,7 +614,7 @@ fn test_finished_verify_failure() -> i32
         i += 1
 
     # Verify should fail
-    let result: i32 = finished_verify(&base_key[0], &transcript_hash[0], &verify_data[0])
+    let result: i32 = finished_verify(@base_key[0], @transcript_hash[0], @verify_data[0])
 
     if result != 0
         return 1
@@ -630,7 +630,7 @@ fn test_finished_serialize() -> i32
         i += 1
 
     var out: [64]u8
-    let len: i64 = finished_serialize(&verify_data[0], &out[0])
+    let len: i64 = finished_serialize(@verify_data[0], @out[0])
 
     if len != 36
         return 1
@@ -662,7 +662,7 @@ fn test_handshake_header_parse() -> i32
     data[3] = 0x00  # Length = 256
 
     var hdr: HandshakeHeader
-    let result: i32 = handshake_header_parse(&data[0], 4, &hdr)
+    let result: i32 = handshake_header_parse(@data[0], 4, @hdr)
 
     if result != 0
         return 1
@@ -682,19 +682,19 @@ fn test_handshake_header_parse() -> i32
 [[test]]
 fn test_client_hello_transcript() -> i32
     var ch: ClientHello
-    client_hello_init(&ch)
+    client_hello_init(@ch)
 
     var buf: [512]u8
-    let len: i64 = client_hello_serialize(&ch, &buf[0], 512)
+    let len: i64 = client_hello_serialize(@ch, @buf[0], 512)
 
     # Add to transcript
     var t: Transcript
-    transcript_init(&t)
-    transcript_update(&t, &buf[0], len)
+    transcript_init(@t)
+    transcript_update(@t, @buf[0], len)
 
     # Get hash
     var hash: [32]u8
-    transcript_hash(&t, &hash[0])
+    transcript_hash(@t, @hash[0])
 
     # Should have non-zero hash
     var all_zero: i32 = 1

--- a/projects/cryptosec/test/test_tls13_kdf.ritz
+++ b/projects/cryptosec/test/test_tls13_kdf.ritz
@@ -91,7 +91,7 @@ fn print_hex_bytes(data: *u8, len: i32)
         let b: u8 = data[i]
         buf[0] = hex_chars[(b >> 4) as i64]
         buf[1] = hex_chars[(b & 0x0f) as i64]
-        sys_write(1, &buf[0], 2)
+        sys_write(1, @buf[0], 2)
         i += 1
     println(c"")
 
@@ -118,10 +118,10 @@ fn test_hkdf_expand_label_basic() -> i32
         i += 1
 
     var output: [32]u8
-    hkdf_expand_label(&secret[0], c"derived", 7, null, 0, &output[0], 32)
+    hkdf_expand_label(@secret[0], c"derived", 7, null, 0, @output[0], 32)
 
     # Output should not be all zeros
-    if mem_is_zero(&output[0], 32) == 1
+    if mem_is_zero(@output[0], 32) == 1
         return 1
     0
 
@@ -137,9 +137,9 @@ fn test_hkdf_expand_label_with_context() -> i32
         i += 1
 
     var output: [32]u8
-    hkdf_expand_label(&secret[0], c"c hs traffic", 12, &context[0], 32, &output[0], 32)
+    hkdf_expand_label(@secret[0], c"c hs traffic", 12, @context[0], 32, @output[0], 32)
 
-    if mem_is_zero(&output[0], 32) == 1
+    if mem_is_zero(@output[0], 32) == 1
         return 1
     0
 
@@ -155,10 +155,10 @@ fn test_hkdf_expand_label_deterministic() -> i32
     var out1: [32]u8
     var out2: [32]u8
 
-    hkdf_expand_label(&secret[0], c"key", 3, null, 0, &out1[0], 32)
-    hkdf_expand_label(&secret[0], c"key", 3, null, 0, &out2[0], 32)
+    hkdf_expand_label(@secret[0], c"key", 3, null, 0, @out1[0], 32)
+    hkdf_expand_label(@secret[0], c"key", 3, null, 0, @out2[0], 32)
 
-    if mem_eq(&out1[0], &out2[0], 32) != 1
+    if mem_eq(@out1[0], @out2[0], 32) != 1
         return 1
     0
 
@@ -174,10 +174,10 @@ fn test_hkdf_expand_label_different_labels() -> i32
     var out1: [32]u8
     var out2: [32]u8
 
-    hkdf_expand_label(&secret[0], c"key", 3, null, 0, &out1[0], 32)
-    hkdf_expand_label(&secret[0], c"iv", 2, null, 0, &out2[0], 32)
+    hkdf_expand_label(@secret[0], c"key", 3, null, 0, @out1[0], 32)
+    hkdf_expand_label(@secret[0], c"iv", 2, null, 0, @out2[0], 32)
 
-    if mem_eq(&out1[0], &out2[0], 32) == 1
+    if mem_eq(@out1[0], @out2[0], 32) == 1
         return 1  # Should be different
     0
 
@@ -196,9 +196,9 @@ fn test_derive_secret_basic() -> i32
 
     var output: [32]u8
     # Empty messages -> hash of empty string
-    derive_secret(&secret[0], c"derived", 7, null, 0, &output[0])
+    derive_secret(@secret[0], c"derived", 7, null, 0, @output[0])
 
-    if mem_is_zero(&output[0], 32) == 1
+    if mem_is_zero(@output[0], 32) == 1
         return 1
     0
 
@@ -217,9 +217,9 @@ fn test_derive_secret_with_messages() -> i32
         i += 1
 
     var output: [32]u8
-    derive_secret(&secret[0], c"c hs traffic", 12, &messages[0], 64, &output[0])
+    derive_secret(@secret[0], c"c hs traffic", 12, @messages[0], 64, @output[0])
 
-    if mem_is_zero(&output[0], 32) == 1
+    if mem_is_zero(@output[0], 32) == 1
         return 1
     0
 
@@ -235,11 +235,11 @@ fn test_rfc8448_early_secret() -> i32
     # Without PSK, early_secret = HKDF-Extract(0, 0)
     # expected early_secret: 33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a
     var early_secret: [32]u8
-    tls13_early_secret(null, 0, &early_secret[0])
+    tls13_early_secret(null, 0, @early_secret[0])
 
     let expected: *u8 = c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a"
-    if bytes_eq_hex(&early_secret[0], expected, 32) != 1
-        # print_hex(c"got early_secret", &early_secret[0], 32)
+    if bytes_eq_hex(@early_secret[0], expected, 32) != 1
+        # print_hex(c"got early_secret", @early_secret[0], 32)
         return 1
     0
 
@@ -248,15 +248,15 @@ fn test_rfc8448_derived_secret_from_early() -> i32
     # derived = Derive-Secret(early_secret, "derived", "")
     # From early_secret, derive intermediate secret for handshake
     var early_secret: [32]u8
-    fill_from_hex(&early_secret[0], c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a", 32)
+    fill_from_hex(@early_secret[0], c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a", 32)
 
     var derived: [32]u8
-    derive_secret(&early_secret[0], c"derived", 7, null, 0, &derived[0])
+    derive_secret(@early_secret[0], c"derived", 7, null, 0, @derived[0])
 
     # RFC 8448: derived secret = 6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba
     let expected: *u8 = c"6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba"
-    if bytes_eq_hex(&derived[0], expected, 32) != 1
-        # print_hex(c"got derived", &derived[0], 32)
+    if bytes_eq_hex(@derived[0], expected, 32) != 1
+        # print_hex(c"got derived", @derived[0], 32)
         return 1
     0
 
@@ -267,18 +267,18 @@ fn test_rfc8448_handshake_secret() -> i32
     # 8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d
 
     var derived: [32]u8
-    fill_from_hex(&derived[0], c"6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba", 32)
+    fill_from_hex(@derived[0], c"6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba", 32)
 
     var shared_secret: [32]u8
-    fill_from_hex(&shared_secret[0], c"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
+    fill_from_hex(@shared_secret[0], c"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
 
     var handshake_secret: [32]u8
-    tls13_handshake_secret(&derived[0], &shared_secret[0], 32, &handshake_secret[0])
+    tls13_handshake_secret(@derived[0], @shared_secret[0], 32, @handshake_secret[0])
 
     # RFC 8448: handshake_secret = 1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac
     let expected: *u8 = c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"
-    if bytes_eq_hex(&handshake_secret[0], expected, 32) != 1
-        # print_hex(c"got handshake_secret", &handshake_secret[0], 32)
+    if bytes_eq_hex(@handshake_secret[0], expected, 32) != 1
+        # print_hex(c"got handshake_secret", @handshake_secret[0], 32)
         return 1
     0
 
@@ -289,19 +289,19 @@ fn test_rfc8448_client_handshake_traffic_secret() -> i32
     # 860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8
 
     var hs_secret: [32]u8
-    fill_from_hex(&hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
+    fill_from_hex(@hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
 
     var transcript_hash: [32]u8
-    fill_from_hex(&transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
+    fill_from_hex(@transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
 
     var c_hs_traffic: [32]u8
     # Use transcript hash directly as context (it's already hashed)
-    hkdf_expand_label(&hs_secret[0], c"c hs traffic", 12, &transcript_hash[0], 32, &c_hs_traffic[0], 32)
+    hkdf_expand_label(@hs_secret[0], c"c hs traffic", 12, @transcript_hash[0], 32, @c_hs_traffic[0], 32)
 
     # RFC 8448: b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21
     let expected: *u8 = c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"
-    if bytes_eq_hex(&c_hs_traffic[0], expected, 32) != 1
-        # print_hex(c"got c_hs_traffic", &c_hs_traffic[0], 32)
+    if bytes_eq_hex(@c_hs_traffic[0], expected, 32) != 1
+        # print_hex(c"got c_hs_traffic", @c_hs_traffic[0], 32)
         return 1
     0
 
@@ -310,18 +310,18 @@ fn test_rfc8448_server_handshake_traffic_secret() -> i32
     # s_hs_traffic = Derive-Secret(handshake_secret, "s hs traffic", ClientHello...ServerHello)
 
     var hs_secret: [32]u8
-    fill_from_hex(&hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
+    fill_from_hex(@hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
 
     var transcript_hash: [32]u8
-    fill_from_hex(&transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
+    fill_from_hex(@transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
 
     var s_hs_traffic: [32]u8
-    hkdf_expand_label(&hs_secret[0], c"s hs traffic", 12, &transcript_hash[0], 32, &s_hs_traffic[0], 32)
+    hkdf_expand_label(@hs_secret[0], c"s hs traffic", 12, @transcript_hash[0], 32, @s_hs_traffic[0], 32)
 
     # RFC 8448: b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38
     let expected: *u8 = c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"
-    if bytes_eq_hex(&s_hs_traffic[0], expected, 32) != 1
-        # print_hex(c"got s_hs_traffic", &s_hs_traffic[0], 32)
+    if bytes_eq_hex(@s_hs_traffic[0], expected, 32) != 1
+        # print_hex(c"got s_hs_traffic", @s_hs_traffic[0], 32)
         return 1
     0
 
@@ -332,13 +332,13 @@ fn test_rfc8448_traffic_key_derivation() -> i32
     # iv = HKDF-Expand-Label(Secret, "iv", "", iv_length)
 
     var c_hs_traffic: [32]u8
-    fill_from_hex(&c_hs_traffic[0], c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21", 32)
+    fill_from_hex(@c_hs_traffic[0], c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21", 32)
 
     var key: [16]u8  # AES-128 key length
     var iv: [12]u8   # GCM IV length
 
-    hkdf_expand_label(&c_hs_traffic[0], c"key", 3, null, 0, &key[0], 16)
-    hkdf_expand_label(&c_hs_traffic[0], c"iv", 2, null, 0, &iv[0], 12)
+    hkdf_expand_label(@c_hs_traffic[0], c"key", 3, null, 0, @key[0], 16)
+    hkdf_expand_label(@c_hs_traffic[0], c"iv", 2, null, 0, @iv[0], 12)
 
     # RFC 8448:
     # client_handshake_key: dbfaa693d1762c5b666af5d950258d01
@@ -347,12 +347,12 @@ fn test_rfc8448_traffic_key_derivation() -> i32
     let expected_key: *u8 = c"dbfaa693d1762c5b666af5d950258d01"
     let expected_iv: *u8 = c"5bd3c71b836e0b76bb73265f"
 
-    if bytes_eq_hex(&key[0], expected_key, 16) != 1
-        # print_hex(c"got key", &key[0], 16)
+    if bytes_eq_hex(@key[0], expected_key, 16) != 1
+        # print_hex(c"got key", @key[0], 16)
         return 1
 
-    if bytes_eq_hex(&iv[0], expected_iv, 12) != 1
-        # print_hex(c"got iv", &iv[0], 12)
+    if bytes_eq_hex(@iv[0], expected_iv, 12) != 1
+        # print_hex(c"got iv", @iv[0], 12)
         return 2
     0
 
@@ -361,13 +361,13 @@ fn test_rfc8448_server_traffic_key_derivation() -> i32
     # From server_handshake_traffic_secret, derive key and IV
 
     var s_hs_traffic: [32]u8
-    fill_from_hex(&s_hs_traffic[0], c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38", 32)
+    fill_from_hex(@s_hs_traffic[0], c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38", 32)
 
     var key: [16]u8
     var iv: [12]u8
 
-    hkdf_expand_label(&s_hs_traffic[0], c"key", 3, null, 0, &key[0], 16)
-    hkdf_expand_label(&s_hs_traffic[0], c"iv", 2, null, 0, &iv[0], 12)
+    hkdf_expand_label(@s_hs_traffic[0], c"key", 3, null, 0, @key[0], 16)
+    hkdf_expand_label(@s_hs_traffic[0], c"iv", 2, null, 0, @iv[0], 12)
 
     # RFC 8448:
     # server_handshake_key: 3fce516009c21727d0f2e4e86ee403bc
@@ -376,12 +376,12 @@ fn test_rfc8448_server_traffic_key_derivation() -> i32
     let expected_key: *u8 = c"3fce516009c21727d0f2e4e86ee403bc"
     let expected_iv: *u8 = c"5d313eb2671276ee13000b30"
 
-    if bytes_eq_hex(&key[0], expected_key, 16) != 1
-        # print_hex(c"got key", &key[0], 16)
+    if bytes_eq_hex(@key[0], expected_key, 16) != 1
+        # print_hex(c"got key", @key[0], 16)
         return 1
 
-    if bytes_eq_hex(&iv[0], expected_iv, 12) != 1
-        # print_hex(c"got iv", &iv[0], 12)
+    if bytes_eq_hex(@iv[0], expected_iv, 12) != 1
+        # print_hex(c"got iv", @iv[0], 12)
         return 2
     0
 
@@ -391,18 +391,18 @@ fn test_rfc8448_master_secret() -> i32
     # derived_from_hs = Derive-Secret(handshake_secret, "derived", "")
 
     var hs_secret: [32]u8
-    fill_from_hex(&hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
+    fill_from_hex(@hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
 
     var derived: [32]u8
-    derive_secret(&hs_secret[0], c"derived", 7, null, 0, &derived[0])
+    derive_secret(@hs_secret[0], c"derived", 7, null, 0, @derived[0])
 
     var master_secret: [32]u8
-    tls13_master_secret(&derived[0], &master_secret[0])
+    tls13_master_secret(@derived[0], @master_secret[0])
 
     # RFC 8448: master_secret = 18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919
     let expected: *u8 = c"18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"
-    if bytes_eq_hex(&master_secret[0], expected, 32) != 1
-        # print_hex(c"got master_secret", &master_secret[0], 32)
+    if bytes_eq_hex(@master_secret[0], expected, 32) != 1
+        # print_hex(c"got master_secret", @master_secret[0], 32)
         return 1
     0
 
@@ -415,39 +415,39 @@ fn test_tls13_key_schedule_full() -> i32
     # Test the full TLS13KeySchedule struct workflow
 
     var ks: TLS13KeySchedule
-    tls13_key_schedule_init(&ks)
+    tls13_key_schedule_init(@ks)
 
     # Verify early secret
     let expected_early: *u8 = c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a"
-    if bytes_eq_hex(&ks.early_secret[0], expected_early, 32) != 1
-        # print_hex(c"early_secret mismatch", &ks.early_secret[0], 32)
+    if bytes_eq_hex(@ks.early_secret[0], expected_early, 32) != 1
+        # print_hex(c"early_secret mismatch", @ks.early_secret[0], 32)
         return 1
 
     # Advance to handshake with shared secret
     var shared_secret: [32]u8
-    fill_from_hex(&shared_secret[0], c"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
+    fill_from_hex(@shared_secret[0], c"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
 
     var transcript_hash: [32]u8
-    fill_from_hex(&transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
+    fill_from_hex(@transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
 
-    tls13_key_schedule_derive_handshake(&ks, &shared_secret[0], 32, &transcript_hash[0])
+    tls13_key_schedule_derive_handshake(@ks, @shared_secret[0], 32, @transcript_hash[0])
 
     # Verify handshake secret
     let expected_hs: *u8 = c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"
-    if bytes_eq_hex(&ks.handshake_secret[0], expected_hs, 32) != 1
-        # print_hex(c"handshake_secret mismatch", &ks.handshake_secret[0], 32)
+    if bytes_eq_hex(@ks.handshake_secret[0], expected_hs, 32) != 1
+        # print_hex(c"handshake_secret mismatch", @ks.handshake_secret[0], 32)
         return 2
 
     # Verify client handshake traffic secret
     let expected_c_hs: *u8 = c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"
-    if bytes_eq_hex(&ks.client_handshake_traffic_secret[0], expected_c_hs, 32) != 1
-        # print_hex(c"c_hs_traffic mismatch", &ks.client_handshake_traffic_secret[0], 32)
+    if bytes_eq_hex(@ks.client_handshake_traffic_secret[0], expected_c_hs, 32) != 1
+        # print_hex(c"c_hs_traffic mismatch", @ks.client_handshake_traffic_secret[0], 32)
         return 3
 
     # Verify server handshake traffic secret
     let expected_s_hs: *u8 = c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"
-    if bytes_eq_hex(&ks.server_handshake_traffic_secret[0], expected_s_hs, 32) != 1
-        # print_hex(c"s_hs_traffic mismatch", &ks.server_handshake_traffic_secret[0], 32)
+    if bytes_eq_hex(@ks.server_handshake_traffic_secret[0], expected_s_hs, 32) != 1
+        # print_hex(c"s_hs_traffic mismatch", @ks.server_handshake_traffic_secret[0], 32)
         return 4
 
     0

--- a/projects/cryptosec/test/test_tls13_record.ritz
+++ b/projects/cryptosec/test/test_tls13_record.ritz
@@ -64,7 +64,7 @@ fn print_hex_bytes(data: *u8, len: i32)
         let b: u8 = data[i]
         buf[0] = hex_chars[(b >> 4) as i64]
         buf[1] = hex_chars[(b & 0x0f) as i64]
-        sys_write(1, &buf[0], 2)
+        sys_write(1, @buf[0], 2)
         i += 1
     println(c"")
 
@@ -78,22 +78,22 @@ fn test_tls13_nonce_construction() -> i32
     # sequence number is 64-bit, IV is 12 bytes
     # pad sequence number to 12 bytes (left-pad with zeros), then XOR
     var iv: [12]u8
-    fill_from_hex(&iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
 
     var nonce: [12]u8
-    tls13_compute_nonce(&iv[0], 0, &nonce[0])
+    tls13_compute_nonce(@iv[0], 0, @nonce[0])
 
     # With seq=0, nonce should equal IV
-    if mem_eq(&nonce[0], &iv[0], 12) != 1
+    if mem_eq(@nonce[0], @iv[0], 12) != 1
         return 1
 
     # With seq=1, last byte should be different
-    tls13_compute_nonce(&iv[0], 1, &nonce[0])
+    tls13_compute_nonce(@iv[0], 1, @nonce[0])
     if nonce[11] != (0x5f ^ 0x01)  # 0x5e
         return 2
 
     # With seq=256, second-to-last byte changes
-    tls13_compute_nonce(&iv[0], 256, &nonce[0])
+    tls13_compute_nonce(@iv[0], 256, @nonce[0])
     if nonce[10] != (0x26 ^ 0x01)  # 0x27
         return 3
     if nonce[11] != 0x5f  # back to original (256 & 0xff = 0)
@@ -113,7 +113,7 @@ fn test_tls13_aad_construction() -> i32
     # length = 2-byte big-endian
 
     var aad: [5]u8
-    tls13_build_aad(50, &aad[0])  # 50 bytes of encrypted content
+    tls13_build_aad(50, @aad[0])  # 50 bytes of encrypted content
 
     if aad[0] != 23  # content type
         return 1
@@ -131,7 +131,7 @@ fn test_tls13_aad_construction() -> i32
 fn test_tls13_aad_large_record() -> i32
     # Test with a larger record size (2^12 = 4096 bytes)
     var aad: [5]u8
-    tls13_build_aad(4096, &aad[0])
+    tls13_build_aad(4096, @aad[0])
 
     if aad[3] != 0x10  # 4096 >> 8 = 16 = 0x10
         return 1
@@ -154,14 +154,14 @@ fn test_tls13_inner_plaintext_build() -> i32
     content[4] = 111 # 'o'
 
     var inner: [16]u8  # content + type + padding
-    let inner_len: i32 = tls13_build_inner_plaintext(&content[0], 5, TLS_CONTENT_HANDSHAKE, &inner[0], 16)
+    let inner_len: i32 = tls13_build_inner_plaintext(@content[0], 5, TLS_CONTENT_HANDSHAKE, @inner[0], 16)
 
     # Should be at least content_len + 1 (for type)
     if inner_len < 6
         return 1
 
     # Content should be at start
-    if mem_eq(&inner[0], &content[0], 5) != 1
+    if mem_eq(@inner[0], @content[0], 5) != 1
         return 2
 
     # Content type should be after content
@@ -184,7 +184,7 @@ fn test_tls13_inner_plaintext_parse() -> i32
     inner[7] = 0
 
     var content_type: u8 = 0
-    let content_len: i32 = tls13_parse_inner_plaintext(&inner[0], 8, &content_type)
+    let content_len: i32 = tls13_parse_inner_plaintext(@inner[0], 8, @content_type)
 
     if content_len != 3
         return 1
@@ -201,8 +201,8 @@ fn test_tls13_record_encrypt_decrypt_roundtrip() -> i32
     # Encrypt and decrypt a simple message
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(&key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(&iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
 
     var plaintext: [5]u8
     plaintext[0] = 72   # 'H'
@@ -212,7 +212,7 @@ fn test_tls13_record_encrypt_decrypt_roundtrip() -> i32
     plaintext[4] = 111  # 'o'
 
     var record: [128]u8
-    let record_len: i32 = tls13_record_encrypt(&key[0], 16, &iv[0], 0, &plaintext[0], 5, TLS_CONTENT_APPLICATION, &record[0], 128)
+    let record_len: i32 = tls13_record_encrypt(@key[0], 16, @iv[0], 0, @plaintext[0], 5, TLS_CONTENT_APPLICATION, @record[0], 128)
 
     if record_len < 0
         return 1
@@ -220,13 +220,13 @@ fn test_tls13_record_encrypt_decrypt_roundtrip() -> i32
     # Now decrypt
     var decrypted: [128]u8
     var content_type: u8 = 0
-    let decrypted_len: i32 = tls13_record_decrypt(&key[0], 16, &iv[0], 0, &record[0], record_len, &decrypted[0], 128, &content_type)
+    let decrypted_len: i32 = tls13_record_decrypt(@key[0], 16, @iv[0], 0, @record[0], record_len, @decrypted[0], 128, @content_type)
 
     if decrypted_len != 5
         return 2
     if content_type != TLS_CONTENT_APPLICATION
         return 3
-    if mem_eq(&decrypted[0], &plaintext[0], 5) != 1
+    if mem_eq(@decrypted[0], @plaintext[0], 5) != 1
         return 4
     0
 
@@ -235,8 +235,8 @@ fn test_tls13_record_sequence_number_increment() -> i32
     # Verify that different sequence numbers produce different ciphertext
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(&key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(&iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
 
     var plaintext: [4]u8
     plaintext[0] = 116  # 't'
@@ -247,14 +247,14 @@ fn test_tls13_record_sequence_number_increment() -> i32
     var record1: [64]u8
     var record2: [64]u8
 
-    let len1: i32 = tls13_record_encrypt(&key[0], 16, &iv[0], 0, &plaintext[0], 4, TLS_CONTENT_APPLICATION, &record1[0], 64)
-    let len2: i32 = tls13_record_encrypt(&key[0], 16, &iv[0], 1, &plaintext[0], 4, TLS_CONTENT_APPLICATION, &record2[0], 64)
+    let len1: i32 = tls13_record_encrypt(@key[0], 16, @iv[0], 0, @plaintext[0], 4, TLS_CONTENT_APPLICATION, @record1[0], 64)
+    let len2: i32 = tls13_record_encrypt(@key[0], 16, @iv[0], 1, @plaintext[0], 4, TLS_CONTENT_APPLICATION, @record2[0], 64)
 
     if len1 != len2
         return 1
 
     # Records should be different due to different nonces
-    if mem_eq(&record1[0], &record2[0], len1) == 1
+    if mem_eq(@record1[0], @record2[0], len1) == 1
         return 2
 
     # But both should decrypt correctly with their respective sequence numbers
@@ -263,14 +263,14 @@ fn test_tls13_record_sequence_number_increment() -> i32
     var ct1: u8 = 0
     var ct2: u8 = 0
 
-    let dlen1: i32 = tls13_record_decrypt(&key[0], 16, &iv[0], 0, &record1[0], len1, &dec1[0], 64, &ct1)
-    let dlen2: i32 = tls13_record_decrypt(&key[0], 16, &iv[0], 1, &record2[0], len2, &dec2[0], 64, &ct2)
+    let dlen1: i32 = tls13_record_decrypt(@key[0], 16, @iv[0], 0, @record1[0], len1, @dec1[0], 64, @ct1)
+    let dlen2: i32 = tls13_record_decrypt(@key[0], 16, @iv[0], 1, @record2[0], len2, @dec2[0], 64, @ct2)
 
     if dlen1 != 4 || dlen2 != 4
         return 3
-    if mem_eq(&dec1[0], &plaintext[0], 4) != 1
+    if mem_eq(@dec1[0], @plaintext[0], 4) != 1
         return 4
-    if mem_eq(&dec2[0], &plaintext[0], 4) != 1
+    if mem_eq(@dec2[0], @plaintext[0], 4) != 1
         return 5
     0
 
@@ -279,8 +279,8 @@ fn test_tls13_record_tamper_detection() -> i32
     # Verify that tampering with ciphertext causes decryption to fail
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(&key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(&iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
 
     var plaintext: [4]u8
     plaintext[0] = 65  # 'A'
@@ -289,7 +289,7 @@ fn test_tls13_record_tamper_detection() -> i32
     plaintext[3] = 68  # 'D'
 
     var record: [64]u8
-    let record_len: i32 = tls13_record_encrypt(&key[0], 16, &iv[0], 0, &plaintext[0], 4, TLS_CONTENT_APPLICATION, &record[0], 64)
+    let record_len: i32 = tls13_record_encrypt(@key[0], 16, @iv[0], 0, @plaintext[0], 4, TLS_CONTENT_APPLICATION, @record[0], 64)
 
     # Tamper with ciphertext (after 5-byte header)
     record[10] = record[10] ^ 0xff
@@ -297,7 +297,7 @@ fn test_tls13_record_tamper_detection() -> i32
     # Decryption should fail
     var decrypted: [64]u8
     var ct: u8 = 0
-    let dec_len: i32 = tls13_record_decrypt(&key[0], 16, &iv[0], 0, &record[0], record_len, &decrypted[0], 64, &ct)
+    let dec_len: i32 = tls13_record_decrypt(@key[0], 16, @iv[0], 0, @record[0], record_len, @decrypted[0], 64, @ct)
 
     if dec_len >= 0
         return 1  # Should have failed
@@ -316,8 +316,8 @@ fn test_rfc8448_client_handshake_record_decrypt() -> i32
     # client_handshake_iv: 5bd3c71b836e0b76bb73265f
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(&key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(&iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
 
     # The encrypted Finished message (from RFC 8448)
     # This includes the TLS record header
@@ -339,20 +339,20 @@ fn test_rfc8448_client_handshake_record_decrypt() -> i32
         i += 1
 
     var record: [128]u8
-    let record_len: i32 = tls13_record_encrypt(&key[0], 16, &iv[0], 0, &finished_msg[0], 36, TLS_CONTENT_HANDSHAKE, &record[0], 128)
+    let record_len: i32 = tls13_record_encrypt(@key[0], 16, @iv[0], 0, @finished_msg[0], 36, TLS_CONTENT_HANDSHAKE, @record[0], 128)
 
     if record_len < 0
         return 1
 
     var decrypted: [128]u8
     var ct: u8 = 0
-    let dec_len: i32 = tls13_record_decrypt(&key[0], 16, &iv[0], 0, &record[0], record_len, &decrypted[0], 128, &ct)
+    let dec_len: i32 = tls13_record_decrypt(@key[0], 16, @iv[0], 0, @record[0], record_len, @decrypted[0], 128, @ct)
 
     if dec_len != 36
         return 2
     if ct != TLS_CONTENT_HANDSHAKE
         return 3
-    if mem_eq(&decrypted[0], &finished_msg[0], 36) != 1
+    if mem_eq(@decrypted[0], @finished_msg[0], 36) != 1
         return 4
     0
 
@@ -361,21 +361,21 @@ fn test_tls13_record_empty_padding() -> i32
     # Test minimal padding (just content type byte)
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(&key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
-    fill_from_hex(&iv[0], c"5d313eb2671276ee13000b30", 12)
+    fill_from_hex(@key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
+    fill_from_hex(@iv[0], c"5d313eb2671276ee13000b30", 12)
 
     var plaintext: [1]u8
     plaintext[0] = 42
 
     var record: [64]u8
-    let record_len: i32 = tls13_record_encrypt(&key[0], 16, &iv[0], 0, &plaintext[0], 1, TLS_CONTENT_APPLICATION, &record[0], 64)
+    let record_len: i32 = tls13_record_encrypt(@key[0], 16, @iv[0], 0, @plaintext[0], 1, TLS_CONTENT_APPLICATION, @record[0], 64)
 
     if record_len < 0
         return 1
 
     var decrypted: [64]u8
     var ct: u8 = 0
-    let dec_len: i32 = tls13_record_decrypt(&key[0], 16, &iv[0], 0, &record[0], record_len, &decrypted[0], 64, &ct)
+    let dec_len: i32 = tls13_record_decrypt(@key[0], 16, @iv[0], 0, @record[0], record_len, @decrypted[0], 64, @ct)
 
     if dec_len != 1
         return 2
@@ -390,7 +390,7 @@ fn test_tls13_record_empty_padding() -> i32
 [[test]]
 fn test_tls_record_state_init() -> i32
     var state: TlsRecordState
-    tls_record_state_init(&state)
+    tls_record_state_init(@state)
 
     if state.client_seq != 0
         return 1
@@ -403,44 +403,44 @@ fn test_tls_record_state_init() -> i32
 [[test]]
 fn test_tls_record_state_set_keys() -> i32
     var state: TlsRecordState
-    tls_record_state_init(&state)
+    tls_record_state_init(@state)
 
     var client_key: [16]u8
     var client_iv: [12]u8
     var server_key: [16]u8
     var server_iv: [12]u8
 
-    fill_from_hex(&client_key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(&client_iv[0], c"5bd3c71b836e0b76bb73265f", 12)
-    fill_from_hex(&server_key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
-    fill_from_hex(&server_iv[0], c"5d313eb2671276ee13000b30", 12)
+    fill_from_hex(@client_key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@client_iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@server_key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
+    fill_from_hex(@server_iv[0], c"5d313eb2671276ee13000b30", 12)
 
-    tls_record_state_set_keys(&state, &client_key[0], &client_iv[0], &server_key[0], &server_iv[0], 16)
+    tls_record_state_set_keys(@state, @client_key[0], @client_iv[0], @server_key[0], @server_iv[0], 16)
 
     if state.key_len != 16
         return 1
-    if mem_eq(&state.client_key[0], &client_key[0], 16) != 1
+    if mem_eq(@state.client_key[0], @client_key[0], 16) != 1
         return 2
-    if mem_eq(&state.client_iv[0], &client_iv[0], 12) != 1
+    if mem_eq(@state.client_iv[0], @client_iv[0], 12) != 1
         return 3
     0
 
 [[test]]
 fn test_tls_record_state_encrypt_decrypt() -> i32
     var state: TlsRecordState
-    tls_record_state_init(&state)
+    tls_record_state_init(@state)
 
     var client_key: [16]u8
     var client_iv: [12]u8
     var server_key: [16]u8
     var server_iv: [12]u8
 
-    fill_from_hex(&client_key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(&client_iv[0], c"5bd3c71b836e0b76bb73265f", 12)
-    fill_from_hex(&server_key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
-    fill_from_hex(&server_iv[0], c"5d313eb2671276ee13000b30", 12)
+    fill_from_hex(@client_key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@client_iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@server_key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
+    fill_from_hex(@server_iv[0], c"5d313eb2671276ee13000b30", 12)
 
-    tls_record_state_set_keys(&state, &client_key[0], &client_iv[0], &server_key[0], &server_iv[0], 16)
+    tls_record_state_set_keys(@state, @client_key[0], @client_iv[0], @server_key[0], @server_iv[0], 16)
 
     var plaintext: [8]u8
     plaintext[0] = 104  # 'h'
@@ -454,7 +454,7 @@ fn test_tls_record_state_encrypt_decrypt() -> i32
 
     # Client encrypts
     var record: [64]u8
-    let record_len: i32 = tls_record_state_client_encrypt(&state, &plaintext[0], 8, TLS_CONTENT_APPLICATION, &record[0], 64)
+    let record_len: i32 = tls_record_state_client_encrypt(@state, @plaintext[0], 8, TLS_CONTENT_APPLICATION, @record[0], 64)
 
     if record_len < 0
         return 1
@@ -468,10 +468,10 @@ fn test_tls_record_state_encrypt_decrypt() -> i32
     var ct: u8 = 0
     # Note: for proper test, we'd need to track server's view of client seq
     # For now, decrypt with explicit seq=0
-    let dec_len: i32 = tls13_record_decrypt(&client_key[0], 16, &client_iv[0], 0, &record[0], record_len, &decrypted[0], 64, &ct)
+    let dec_len: i32 = tls13_record_decrypt(@client_key[0], 16, @client_iv[0], 0, @record[0], record_len, @decrypted[0], 64, @ct)
 
     if dec_len != 8
         return 3
-    if mem_eq(&decrypted[0], &plaintext[0], 8) != 1
+    if mem_eq(@decrypted[0], @plaintext[0], 8) != 1
         return 4
     0

--- a/projects/cryptosec/test/test_x25519.ritz
+++ b/projects/cryptosec/test/test_x25519.ritz
@@ -50,7 +50,7 @@ fn test_x25519_rfc7748_1() -> i32
     # Input u-coordinate (basepoint for keygen, or peer's public key)
     var u: [32]u8
     u[0] = 0x09  # basepoint
-    mem_zero(&u[1], 31)
+    mem_zero(@u[1], 31)
 
     # Expected output
     var expected: [32]u8
@@ -88,9 +88,9 @@ fn test_x25519_rfc7748_1() -> i32
     expected[31] = 0x6a
 
     var result: [32]u8
-    x25519(&result[0], &k[0], &u[0])
+    x25519(@result[0], @k[0], @u[0])
 
-    if mem_eq(&result[0], &expected[0], 32) == 0
+    if mem_eq(@result[0], @expected[0], 32) == 0
         return 1
     return 0
 
@@ -135,7 +135,7 @@ fn test_x25519_rfc7748_2() -> i32
     # Basepoint
     var u: [32]u8
     u[0] = 0x09
-    mem_zero(&u[1], 31)
+    mem_zero(@u[1], 31)
 
     # Expected output
     var expected: [32]u8
@@ -173,9 +173,9 @@ fn test_x25519_rfc7748_2() -> i32
     expected[31] = 0x4f
 
     var result: [32]u8
-    x25519(&result[0], &k[0], &u[0])
+    x25519(@result[0], @k[0], @u[0])
 
-    if mem_eq(&result[0], &expected[0], 32) == 0
+    if mem_eq(@result[0], @expected[0], 32) == 0
         return 1
     return 0
 
@@ -288,9 +288,9 @@ fn test_x25519_shared_secret() -> i32
     expected[31] = 0x42
 
     var result: [32]u8
-    x25519(&result[0], &k_alice[0], &pk_bob[0])
+    x25519(@result[0], @k_alice[0], @pk_bob[0])
 
-    if mem_eq(&result[0], &expected[0], 32) == 0
+    if mem_eq(@result[0], @expected[0], 32) == 0
         return 1
     return 0
 
@@ -370,26 +370,26 @@ fn test_x25519_key_agreement() -> i32
     # Basepoint
     var basepoint: [32]u8
     basepoint[0] = 0x09
-    mem_zero(&basepoint[1], 31)
+    mem_zero(@basepoint[1], 31)
 
     # Alice computes her public key
     var pk_alice: [32]u8
-    x25519(&pk_alice[0], &k_alice[0], &basepoint[0])
+    x25519(@pk_alice[0], @k_alice[0], @basepoint[0])
 
     # Bob computes his public key
     var pk_bob: [32]u8
-    x25519(&pk_bob[0], &k_bob[0], &basepoint[0])
+    x25519(@pk_bob[0], @k_bob[0], @basepoint[0])
 
     # Alice computes shared secret using Bob's public key
     var ss_alice: [32]u8
-    x25519(&ss_alice[0], &k_alice[0], &pk_bob[0])
+    x25519(@ss_alice[0], @k_alice[0], @pk_bob[0])
 
     # Bob computes shared secret using Alice's public key
     var ss_bob: [32]u8
-    x25519(&ss_bob[0], &k_bob[0], &pk_alice[0])
+    x25519(@ss_bob[0], @k_bob[0], @pk_alice[0])
 
     # Both should be equal!
-    if mem_eq(&ss_alice[0], &ss_bob[0], 32) == 0
+    if mem_eq(@ss_alice[0], @ss_bob[0], 32) == 0
         return 1
     return 0
 
@@ -467,9 +467,9 @@ fn test_x25519_keypair() -> i32
     expected_pk[31] = 0x6a
 
     var pubkey: [32]u8
-    x25519_pubkey(&pubkey[0], &privkey[0])
+    x25519_pubkey(@pubkey[0], @privkey[0])
 
-    if mem_eq(&pubkey[0], &expected_pk[0], 32) == 0
+    if mem_eq(@pubkey[0], @expected_pk[0], 32) == 0
         return 1
     return 0
 
@@ -485,7 +485,7 @@ fn test_x25519_clamp() -> i32
         scalar[i] = 0x00
         i += 1
 
-    x25519_clamp(&scalar[0])
+    x25519_clamp(@scalar[0])
 
     # Check clamping was applied
     if scalar[0] != 0xf8

--- a/projects/cryptosec/test/test_x509.ritz
+++ b/projects/cryptosec/test/test_x509.ritz
@@ -33,14 +33,14 @@ fn test_utc_time_parsing() -> i32
     data[14] = 0x5a # 'Z'
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 15)
+    der_parser_init(@parser, @data[0], 15)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var timestamp: i64 = 0
-    if x509_parse_utc_time(&elem, &timestamp) != 0
+    if x509_parse_utc_time(@elem, @timestamp) != 0
         return 2
 
     # 2023-01-01 12:00:00 UTC = 1672574400
@@ -79,14 +79,14 @@ fn test_generalized_time_parsing() -> i32
     data[16] = 0x5a # 'Z'
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 17)
+    der_parser_init(@parser, @data[0], 17)
 
     var elem: DerElement
-    if der_parse_element(&parser, &elem) != 0
+    if der_parse_element(@parser, @elem) != 0
         return 1
 
     var timestamp: i64 = 0
-    if x509_parse_generalized_time(&elem, &timestamp) != 0
+    if x509_parse_generalized_time(@elem, @timestamp) != 0
         return 2
 
     # 2023-06-15 14:30:00 UTC
@@ -132,12 +132,12 @@ fn test_name_equals_same() -> i32
     der_bytes[0] = 0x30
     der_bytes[1] = 0x08
 
-    name1.der_data = &der_bytes[0]
+    name1.der_data = @der_bytes[0]
     name1.der_len = 10
-    name2.der_data = &der_bytes[0]
+    name2.der_data = @der_bytes[0]
     name2.der_len = 10
 
-    if x509_name_equals(&name1, &name2) != 1
+    if x509_name_equals(@name1, @name2) != 1
         return 1
 
     return 0
@@ -149,12 +149,12 @@ fn test_name_equals_different_len() -> i32
 
     var der_bytes: [10]u8
 
-    name1.der_data = &der_bytes[0]
+    name1.der_data = @der_bytes[0]
     name1.der_len = 10
-    name2.der_data = &der_bytes[0]
+    name2.der_data = @der_bytes[0]
     name2.der_len = 8
 
-    if x509_name_equals(&name1, &name2) != 0
+    if x509_name_equals(@name1, @name2) != 0
         return 1
 
     return 0
@@ -209,10 +209,10 @@ fn test_validity_sequence() -> i32
     data[31] = 0x5a  # 'Z'
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 32)
+    der_parser_init(@parser, @data[0], 32)
 
     var validity: X509Validity
-    if x509_parse_validity(&parser, &validity) != 0
+    if x509_parse_validity(@parser, @validity) != 0
         return 1
 
     # 2023-01-01 00:00:00 = 1672531200
@@ -250,9 +250,9 @@ fn test_sig_algorithm_sha256_rsa() -> i32
     data[14] = 0x00
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 15)
+    der_parser_init(@parser, @data[0], 15)
 
-    let alg: u8 = x509_parse_sig_algorithm(&parser)
+    let alg: u8 = x509_parse_sig_algorithm(@parser)
     if alg != SIG_ALG_SHA256_RSA
         return 1
 
@@ -271,9 +271,9 @@ fn test_sig_algorithm_ed25519() -> i32
     data[6] = 0x70  # .112
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 7)
+    der_parser_init(@parser, @data[0], 7)
 
-    let alg: u8 = x509_parse_sig_algorithm(&parser)
+    let alg: u8 = x509_parse_sig_algorithm(@parser)
     if alg != SIG_ALG_ED25519
         return 1
 
@@ -318,10 +318,10 @@ fn test_pubkey_rsa() -> i32
     data[23] = 0xef
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 24)
+    der_parser_init(@parser, @data[0], 24)
 
     var pubkey: X509PublicKey
-    if x509_parse_public_key(&parser, &pubkey) != 0
+    if x509_parse_public_key(@parser, @pubkey) != 0
         return 1
 
     if pubkey.algorithm != PUBKEY_TYPE_RSA
@@ -382,10 +382,10 @@ fn test_pubkey_ec_p256() -> i32
     data[26] = 0xab  # 1 data byte
 
     var parser: DerParser
-    der_parser_init(&parser, &data[0], 27)
+    der_parser_init(@parser, @data[0], 27)
 
     var pubkey: X509PublicKey
-    if x509_parse_public_key(&parser, &pubkey) != 0
+    if x509_parse_public_key(@parser, @pubkey) != 0
         return 1
 
     if pubkey.algorithm != PUBKEY_TYPE_EC
@@ -407,7 +407,7 @@ fn test_validity_check_valid() -> i32
     cert.validity.not_after = 1704067200    # 2024-01-01
 
     let current: i64 = 1680000000  # ~March 2023
-    if x509_is_valid_time(&cert, current) != 1
+    if x509_is_valid_time(@cert, current) != 1
         return 1
 
     return 0
@@ -419,7 +419,7 @@ fn test_validity_check_expired() -> i32
     cert.validity.not_after = 1704067200    # 2024-01-01
 
     let current: i64 = 1710000000  # ~March 2024
-    if x509_is_valid_time(&cert, current) != 0
+    if x509_is_valid_time(@cert, current) != 0
         return 1  # Should be invalid (expired)
 
     return 0
@@ -431,7 +431,7 @@ fn test_validity_check_not_yet_valid() -> i32
     cert.validity.not_after = 1704067200    # 2024-01-01
 
     let current: i64 = 1640000000  # ~Dec 2021
-    if x509_is_valid_time(&cert, current) != 0
+    if x509_is_valid_time(@cert, current) != 0
         return 1  # Should be invalid (not yet valid)
 
     return 0
@@ -446,12 +446,12 @@ fn test_self_signed_detection() -> i32
     var der_bytes: [20]u8
 
     # Same issuer and subject DER
-    cert.issuer.der_data = &der_bytes[0]
+    cert.issuer.der_data = @der_bytes[0]
     cert.issuer.der_len = 20
-    cert.subject.der_data = &der_bytes[0]
+    cert.subject.der_data = @der_bytes[0]
     cert.subject.der_len = 20
 
-    if x509_is_self_signed(&cert) != 1
+    if x509_is_self_signed(@cert) != 1
         return 1
 
     return 0
@@ -466,12 +466,12 @@ fn test_not_self_signed() -> i32
     issuer_der[0] = 0x30
     subject_der[0] = 0x31
 
-    cert.issuer.der_data = &issuer_der[0]
+    cert.issuer.der_data = @issuer_der[0]
     cert.issuer.der_len = 20
-    cert.subject.der_data = &subject_der[0]
+    cert.subject.der_data = @subject_der[0]
     cert.subject.der_len = 20
 
-    if x509_is_self_signed(&cert) != 0
+    if x509_is_self_signed(@cert) != 0
         return 1
 
     return 0

--- a/projects/cryptosec/test/test_x509_verify.ritz
+++ b/projects/cryptosec/test/test_x509_verify.ritz
@@ -23,7 +23,7 @@ fn test_x509_verify_self_signed_rsa()
     # proper error codes for invalid inputs
 
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     cert.sig_algorithm = SIG_ALG_SHA256_RSA
     cert.tbs_data = null
@@ -35,34 +35,34 @@ fn test_x509_verify_self_signed_rsa()
     issuer_key.key_len = 0
 
     # Should fail with null/empty data
-    let result: i32 = x509_verify_signature(&cert, &issuer_key)
+    let result: i32 = x509_verify_signature(@cert, @issuer_key)
     assert result == 0
 
 [[test]]
 fn test_x509_verify_algorithm_mismatch()
     # Test that algorithm mismatch is detected
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     cert.sig_algorithm = SIG_ALG_SHA256_RSA
 
     var issuer_key: X509PublicKey
     issuer_key.algorithm = PUBKEY_TYPE_EC  # Mismatch: cert expects RSA
 
-    let result: i32 = x509_verify_signature(&cert, &issuer_key)
+    let result: i32 = x509_verify_signature(@cert, @issuer_key)
     assert result == 0  # Should fail due to algorithm mismatch
 
 [[test]]
 fn test_x509_verify_unknown_algorithm()
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     cert.sig_algorithm = SIG_ALG_UNKNOWN
 
     var issuer_key: X509PublicKey
     issuer_key.algorithm = PUBKEY_TYPE_RSA
 
-    let result: i32 = x509_verify_signature(&cert, &issuer_key)
+    let result: i32 = x509_verify_signature(@cert, @issuer_key)
     assert result == 0  # Should fail for unknown algorithm
 
 # ============================================================================
@@ -78,7 +78,7 @@ fn test_x509_chain_empty()
     chain[2] = null
     chain[3] = null
 
-    let result: i32 = x509_verify_chain(&chain[0], 0, null, 0)
+    let result: i32 = x509_verify_chain(@chain[0], 0, null, 0)
     assert result == 0
 
 [[test]]
@@ -87,19 +87,19 @@ fn test_x509_chain_single_self_signed()
     # Should pass if it's in the trust store
 
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     # Make it "self-signed" by having issuer == subject
-    cert.issuer.der_data = &cert.subject.common_name[0]
+    cert.issuer.der_data = @cert.subject.common_name[0]
     cert.issuer.der_len = 10
-    cert.subject.der_data = &cert.subject.common_name[0]
+    cert.subject.der_data = @cert.subject.common_name[0]
     cert.subject.der_len = 10
 
     cert.is_ca = 1
 
     # We can't fully test without a real certificate, but we can test
     # the structure. For now, verify the function exists.
-    assert x509_is_self_signed(&cert) == 1
+    assert x509_is_self_signed(@cert) == 1
 
 # ============================================================================
 # Hostname Verification Tests
@@ -122,7 +122,7 @@ fn test_hostname_match_exact()
 
     let hostname: *u8 = c"example.com"
 
-    let result: i32 = x509_hostname_match(&cn[0], 11, hostname, 11)
+    let result: i32 = x509_hostname_match(@cn[0], 11, hostname, 11)
     assert result == 1
 
 [[test]]
@@ -142,7 +142,7 @@ fn test_hostname_match_case_insensitive()
 
     let hostname: *u8 = c"example.com"
 
-    let result: i32 = x509_hostname_match(&cn[0], 11, hostname, 11)
+    let result: i32 = x509_hostname_match(@cn[0], 11, hostname, 11)
     assert result == 1
 
 [[test]]
@@ -165,7 +165,7 @@ fn test_hostname_wildcard_simple()
 
     let hostname: *u8 = c"www.example.com"
 
-    let result: i32 = x509_hostname_match(&cn[0], 13, hostname, 15)
+    let result: i32 = x509_hostname_match(@cn[0], 13, hostname, 15)
     assert result == 1
 
 [[test]]
@@ -188,7 +188,7 @@ fn test_hostname_wildcard_no_match_root()
 
     let hostname: *u8 = c"example.com"
 
-    let result: i32 = x509_hostname_match(&cn[0], 13, hostname, 11)
+    let result: i32 = x509_hostname_match(@cn[0], 13, hostname, 11)
     assert result == 0
 
 [[test]]
@@ -204,7 +204,7 @@ fn test_hostname_mismatch()
 
     let hostname: *u8 = c"bar.com"
 
-    let result: i32 = x509_hostname_match(&cn[0], 7, hostname, 7)
+    let result: i32 = x509_hostname_match(@cn[0], 7, hostname, 7)
     assert result == 0
 
 # ============================================================================
@@ -214,7 +214,7 @@ fn test_hostname_mismatch()
 [[test]]
 fn test_validity_time_valid()
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     # notBefore: 2020-01-01 00:00:00 UTC = 1577836800
     # notAfter: 2030-01-01 00:00:00 UTC = 1893456000
@@ -224,13 +224,13 @@ fn test_validity_time_valid()
     # Current time: 2025-06-15 = approximately 1750000000
     let current_time: i64 = 1750000000
 
-    let result: i32 = x509_is_valid_time(&cert, current_time)
+    let result: i32 = x509_is_valid_time(@cert, current_time)
     assert result == 1
 
 [[test]]
 fn test_validity_time_expired()
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     # notBefore: 2020-01-01
     # notAfter: 2024-01-01 = 1704067200
@@ -240,13 +240,13 @@ fn test_validity_time_expired()
     # Current time: 2025-06-15
     let current_time: i64 = 1750000000
 
-    let result: i32 = x509_is_valid_time(&cert, current_time)
+    let result: i32 = x509_is_valid_time(@cert, current_time)
     assert result == 0
 
 [[test]]
 fn test_validity_time_not_yet_valid()
     var cert: X509Certificate
-    mem_zero(&cert as *u8, 1200)
+    mem_zero(@cert as *u8, 1200)
 
     # notBefore: 2026-01-01 = 1767225600
     # notAfter: 2030-01-01
@@ -256,5 +256,5 @@ fn test_validity_time_not_yet_valid()
     # Current time: 2025-06-15
     let current_time: i64 = 1750000000
 
-    let result: i32 = x509_is_valid_time(&cert, current_time)
+    let result: i32 = x509_is_valid_time(@cert, current_time)
     assert result == 0

--- a/rz
+++ b/rz
@@ -66,9 +66,10 @@ def run_build(project_name, extra_args=None):
         print(f"Error: Project '{project_name}' not found", file=sys.stderr)
         return 1
 
-    # Set up environment
+    # Set up environment - include both ritz (for ritzlib) and project dir (for lib.* imports)
     env = os.environ.copy()
-    env["RITZ_PATH"] = str(PROJECTS_DIR / "ritz")
+    ritz_path = f"{project_dir}:{PROJECTS_DIR / 'ritz'}"
+    env["RITZ_PATH"] = ritz_path
 
     cmd = [sys.executable, str(RITZ_BUILD), "build", str(project_dir)]
     if extra_args:
@@ -85,9 +86,10 @@ def run_test(project_name, extra_args=None):
         print(f"Error: Project '{project_name}' not found", file=sys.stderr)
         return 1
 
-    # Set up environment
+    # Set up environment - include both ritz (for ritzlib) and project dir (for lib.* imports)
     env = os.environ.copy()
-    env["RITZ_PATH"] = str(PROJECTS_DIR / "ritz")
+    ritz_path = f"{project_dir}:{PROJECTS_DIR / 'ritz'}"
+    env["RITZ_PATH"] = ritz_path
 
     cmd = [sys.executable, str(RITZ_BUILD), "test", str(project_dir)]
     if extra_args:


### PR DESCRIPTION
## Summary
- Migrate all cryptosec lib/ and test/ files from legacy `&x` to `@x` reference syntax
- Fix `rz` script to include project directory in RITZ_PATH (needed for `import lib.*` resolution)

## Test plan
- [x] Verified syntax migration complete (no remaining `&x` patterns)
- [x] Verified no missing files compared to archive
- [x] Individual test files compile and pass (sha256, aes_gcm, chacha20, etc.)
- [ ] Full test suite (investigating hangs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)