### PR TITLE
mausoleum: Monorepo fixes for cryptosec imports and build

### DIFF
--- a/projects/cryptosec/lib/ca_store.ritz
+++ b/projects/cryptosec/lib/ca_store.ritz
@@ -19,9 +19,9 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.mem
-import lib.pem
-import lib.x509
+import cryptosec.mem
+import cryptosec.pem
+import cryptosec.x509
 
 # ============================================================================
 # Constants

--- a/projects/cryptosec/lib/p256.ritz
+++ b/projects/cryptosec/lib/p256.ritz
@@ -15,10 +15,10 @@
 #   - SEC 2: Recommended Elliptic Curve Domain Parameters
 #   - RFC 6979: Deterministic ECDSA
 
-import lib.mem
-import lib.u128
-import lib.hmac
-import lib.sha256
+import cryptosec.mem
+import cryptosec.u128
+import cryptosec.hmac
+import cryptosec.sha256
 
 # ============================================================================
 # Field Element: FeP256 - Element of GF(p)

--- a/projects/cryptosec/lib/sha256.ritz
+++ b/projects/cryptosec/lib/sha256.ritz
@@ -13,7 +13,7 @@
 # that support it (runtime detection via CPUID).
 
 import ritzlib.sys
-import lib.cpuid
+import cryptosec.cpuid
 
 # ============================================================================
 # Constants

--- a/projects/cryptosec/test/test_aes.ritz
+++ b/projects/cryptosec/test/test_aes.ritz
@@ -1,8 +1,8 @@
 # AES Block Cipher Tests
 # NIST FIPS 197 test vectors
 
-import lib.aes
-import lib.mem
+import cryptosec.aes
+import cryptosec.mem
 import ritzlib.io
 
 # Convert a hex character to its value (0-15)

--- a/projects/cryptosec/test/test_aes_gcm.ritz
+++ b/projects/cryptosec/test/test_aes_gcm.ritz
@@ -1,9 +1,9 @@
 # AES-GCM tests
 # Test vectors from NIST SP 800-38D and RFC 5116
 
-import lib.aes_gcm
-import lib.mem
-import lib.cpuid
+import cryptosec.aes_gcm
+import cryptosec.mem
+import cryptosec.cpuid
 
 # Helper to check if two byte arrays are equal
 fn bytes_equal(a: *u8, b: *u8, len: i64) -> i32

--- a/projects/cryptosec/test/test_asn1.ritz
+++ b/projects/cryptosec/test/test_asn1.ritz
@@ -4,8 +4,8 @@
 
 import ritzlib.sys
 import ritzlib.io
-import lib.asn1
-import lib.mem
+import cryptosec.asn1
+import cryptosec.mem
 
 # ============================================================================
 # Tag Parsing Tests

--- a/projects/cryptosec/test/test_bigint.ritz
+++ b/projects/cryptosec/test/test_bigint.ritz
@@ -1,6 +1,6 @@
 # test/test_bigint.ritz - Tests for big integer arithmetic
 
-import lib.bigint
+import cryptosec.bigint
 
 # ============================================================================
 # Basic Operations Tests

--- a/projects/cryptosec/test/test_ca_store.ritz
+++ b/projects/cryptosec/test/test_ca_store.ritz
@@ -2,10 +2,10 @@
 #
 # Tests certificate store initialization, loading, and lookup.
 
-import lib.ca_store
-import lib.x509
-import lib.mem
-import lib.pem
+import cryptosec.ca_store
+import cryptosec.x509
+import cryptosec.mem
+import cryptosec.pem
 
 # ============================================================================
 # Test Data

--- a/projects/cryptosec/test/test_chacha20.ritz
+++ b/projects/cryptosec/test/test_chacha20.ritz
@@ -1,8 +1,8 @@
 # ChaCha20 tests
 # RFC 8439 test vectors
 
-import lib.chacha20
-import lib.mem
+import cryptosec.chacha20
+import cryptosec.mem
 
 # Helper to check if two byte arrays are equal
 fn bytes_equal(a: *u8, b: *u8, len: i64) -> i32

--- a/projects/cryptosec/test/test_chacha20_avx2.ritz
+++ b/projects/cryptosec/test/test_chacha20_avx2.ritz
@@ -1,9 +1,9 @@
 # ChaCha20 AVX2 tests
 # RFC 8439 test vectors - verifies AVX2 implementation matches scalar
 
-import lib.chacha20_avx2
-import lib.chacha20
-import lib.mem
+import cryptosec.chacha20_avx2
+import cryptosec.chacha20
+import cryptosec.mem
 
 # Helper to check if two byte arrays are equal
 fn bytes_equal(a: *u8, b: *u8, len: i64) -> i32

--- a/projects/cryptosec/test/test_chacha20_poly1305.ritz
+++ b/projects/cryptosec/test/test_chacha20_poly1305.ritz
@@ -1,8 +1,8 @@
 # ChaCha20-Poly1305 AEAD tests
 # RFC 8439 test vectors
 
-import lib.chacha20_poly1305
-import lib.mem
+import cryptosec.chacha20_poly1305
+import cryptosec.mem
 
 # Helper to check if two byte arrays are equal
 fn bytes_equal(a: *u8, b: *u8, len: i64) -> i32

--- a/projects/cryptosec/test/test_cpuid.ritz
+++ b/projects/cryptosec/test/test_cpuid.ritz
@@ -7,7 +7,7 @@
 # - AVX-512F (AVX-512 Foundation)
 # - PCLMULQDQ (carryless multiply)
 
-import lib.cpuid
+import cryptosec.cpuid
 
 # ============================================================================
 # Basic Detection Tests

--- a/projects/cryptosec/test/test_ed25519.ritz
+++ b/projects/cryptosec/test/test_ed25519.ritz
@@ -1,7 +1,7 @@
 # test/test_ed25519.ritz - Ed25519 tests (RFC 8032)
 
-import lib.ed25519
-import lib.mem
+import cryptosec.ed25519
+import cryptosec.mem
 
 # ============================================================================
 # RFC 8032 Test Vectors

--- a/projects/cryptosec/test/test_helpers.ritz
+++ b/projects/cryptosec/test/test_helpers.ritz
@@ -4,7 +4,7 @@
 # Import this instead of duplicating helpers in each test file.
 
 import ritzlib.sys
-import lib.mem
+import cryptosec.mem
 
 # ============================================================================
 # Hex Conversion Helpers

--- a/projects/cryptosec/test/test_hkdf.ritz
+++ b/projects/cryptosec/test/test_hkdf.ritz
@@ -6,8 +6,8 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.hkdf
-import lib.mem
+import cryptosec.hkdf
+import cryptosec.mem
 
 # ============================================================================
 # Helper: Compare output to expected hex

--- a/projects/cryptosec/test/test_hmac.ritz
+++ b/projects/cryptosec/test/test_hmac.ritz
@@ -8,8 +8,8 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.hmac
-import lib.mem
+import cryptosec.hmac
+import cryptosec.mem
 
 # ============================================================================
 # Helper: Compare hash output to expected hex

--- a/projects/cryptosec/test/test_mem.ritz
+++ b/projects/cryptosec/test/test_mem.ritz
@@ -10,7 +10,7 @@ import ritzlib.sys
 import ritzlib.io
 import ritzlib.memory
 
-import lib.mem
+import cryptosec.mem
 
 # ============================================================================
 # mem_zero tests

--- a/projects/cryptosec/test/test_p256.ritz
+++ b/projects/cryptosec/test/test_p256.ritz
@@ -3,8 +3,8 @@
 # Test vectors from NIST FIPS 186-4 and RFC 6979
 
 import ritzlib.sys
-import lib.p256
-import lib.mem
+import cryptosec.p256
+import cryptosec.mem
 
 # ============================================================================
 # Field Element Tests

--- a/projects/cryptosec/test/test_pem.ritz
+++ b/projects/cryptosec/test/test_pem.ritz
@@ -4,9 +4,9 @@
 
 import ritzlib.sys
 
-import lib.mem
-import lib.base64
-import lib.pem
+import cryptosec.mem
+import cryptosec.base64
+import cryptosec.pem
 
 # ============================================================================
 # Base64 Decoding Tests

--- a/projects/cryptosec/test/test_poly1305.ritz
+++ b/projects/cryptosec/test/test_poly1305.ritz
@@ -1,8 +1,8 @@
 # Poly1305 tests
 # RFC 8439 test vectors
 
-import lib.poly1305
-import lib.mem
+import cryptosec.poly1305
+import cryptosec.mem
 
 # Helper to check if two byte arrays are equal
 fn bytes_equal(a: *u8, b: *u8, len: i64) -> i32

--- a/projects/cryptosec/test/test_random.ritz
+++ b/projects/cryptosec/test/test_random.ritz
@@ -9,8 +9,8 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.random
-import lib.mem
+import cryptosec.random
+import cryptosec.mem
 
 # ============================================================================
 # Basic functionality tests

--- a/projects/cryptosec/test/test_rsa.ritz
+++ b/projects/cryptosec/test/test_rsa.ritz
@@ -1,8 +1,8 @@
 # test/test_rsa.ritz - Tests for RSA signature verification
 
-import lib.rsa
-import lib.bigint
-import lib.mem
+import cryptosec.rsa
+import cryptosec.bigint
+import cryptosec.mem
 
 # ============================================================================
 # RSA Public Key Parsing Tests

--- a/projects/cryptosec/test/test_sha256.ritz
+++ b/projects/cryptosec/test/test_sha256.ritz
@@ -8,8 +8,8 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.sha256
-import lib.mem
+import cryptosec.sha256
+import cryptosec.mem
 
 # ============================================================================
 # Helper: Compare hash output to expected hex

--- a/projects/cryptosec/test/test_sha512.ritz
+++ b/projects/cryptosec/test/test_sha512.ritz
@@ -4,8 +4,8 @@
 
 import ritzlib.sys
 import ritzlib.io
-import lib.sha512
-import lib.mem
+import cryptosec.sha512
+import cryptosec.mem
 
 # ============================================================================
 # Helper: Compare hash output to expected hex

--- a/projects/cryptosec/test/test_sha_ni.ritz
+++ b/projects/cryptosec/test/test_sha_ni.ritz
@@ -2,8 +2,8 @@
 #
 # Tests that the SHA-NI and AES-NI intrinsics are correctly wired up.
 
-import lib.cpuid
-import lib.mem
+import cryptosec.cpuid
+import cryptosec.mem
 
 # ============================================================================
 # SHA-NI Intrinsic Tests

--- a/projects/cryptosec/test/test_tls13_client.ritz
+++ b/projects/cryptosec/test/test_tls13_client.ritz
@@ -2,9 +2,9 @@
 
 import ritzlib.sys
 
-import lib.mem
-import lib.tls13_client
-import lib.tls13_handshake
+import cryptosec.mem
+import cryptosec.tls13_client
+import cryptosec.tls13_handshake
 
 # ============================================================================
 # Config Tests

--- a/projects/cryptosec/test/test_tls13_handshake.ritz
+++ b/projects/cryptosec/test/test_tls13_handshake.ritz
@@ -2,10 +2,10 @@
 
 import ritzlib.sys
 
-import lib.mem
-import lib.sha256
-import lib.tls13_handshake
-import lib.tls13_kdf
+import cryptosec.mem
+import cryptosec.sha256
+import cryptosec.tls13_handshake
+import cryptosec.tls13_kdf
 
 # ============================================================================
 # Transcript Hash Tests

--- a/projects/cryptosec/test/test_tls13_kdf.ritz
+++ b/projects/cryptosec/test/test_tls13_kdf.ritz
@@ -44,9 +44,9 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.tls13_kdf
-import lib.mem
-import lib.sha256
+import cryptosec.tls13_kdf
+import cryptosec.mem
+import cryptosec.sha256
 
 # ============================================================================
 # Helper: hex conversion

--- a/projects/cryptosec/test/test_tls13_record.ritz
+++ b/projects/cryptosec/test/test_tls13_record.ritz
@@ -16,10 +16,10 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.tls13_record
-import lib.tls13_kdf
-import lib.aes_gcm
-import lib.mem
+import cryptosec.tls13_record
+import cryptosec.tls13_kdf
+import cryptosec.aes_gcm
+import cryptosec.mem
 
 # ============================================================================
 # Helper: hex conversion

--- a/projects/cryptosec/test/test_u128.ritz
+++ b/projects/cryptosec/test/test_u128.ritz
@@ -9,7 +9,7 @@
 import ritzlib.sys
 import ritzlib.io
 
-import lib.u128
+import cryptosec.u128
 
 # ============================================================================
 # Construction and basic operations

--- a/projects/cryptosec/test/test_x25519.ritz
+++ b/projects/cryptosec/test/test_x25519.ritz
@@ -2,8 +2,8 @@
 #
 # Test vectors from RFC 7748 and related sources
 
-import lib.x25519
-import lib.mem
+import cryptosec.x25519
+import cryptosec.mem
 
 # ============================================================================
 # RFC 7748 Test Vectors

--- a/projects/cryptosec/test/test_x509.ritz
+++ b/projects/cryptosec/test/test_x509.ritz
@@ -4,9 +4,9 @@
 
 import ritzlib.sys
 import ritzlib.io
-import lib.asn1
-import lib.x509
-import lib.mem
+import cryptosec.asn1
+import cryptosec.x509
+import cryptosec.mem
 
 # ============================================================================
 # Time Parsing Tests

--- a/projects/cryptosec/test/test_x509_verify.ritz
+++ b/projects/cryptosec/test/test_x509_verify.ritz
@@ -1,10 +1,10 @@
 # test/test_x509_verify.ritz - Tests for X.509 certificate chain validation
 
-import lib.x509
-import lib.x509_verify
-import lib.asn1
-import lib.mem
-import lib.rsa
+import cryptosec.x509
+import cryptosec.x509_verify
+import cryptosec.asn1
+import cryptosec.mem
+import cryptosec.rsa
 
 # ============================================================================
 # Certificate Signature Verification Tests

--- a/projects/mausoleum/src/main.ritz
+++ b/projects/mausoleum/src/main.ritz
@@ -158,7 +158,7 @@ fn print_version()
     prints("Protocol: M7SP v1 (encrypted)\n")
     prints("Crypto: X25519 + ChaCha20-Poly1305\n")
 
-fn print_int(n: i32)
+fn print_i32(n: i32)
     if n == 0
         print_char(48)
         return
@@ -183,7 +183,7 @@ fn print_int(n: i32)
 fn cmd_serve(port: i32) -> i32
     prints("Starting Mausoleum server...\n")
     prints("  Port: ")
-    print_int(port)
+    print_i32(port)
     prints("\n")
     prints("  Encryption: X25519 + ChaCha20-Poly1305\n")
     prints("\n")
@@ -216,7 +216,7 @@ fn cmd_serve(port: i32) -> i32
     let bind_result: i32 = socket_bind_any(@sock, port)
     if bind_result < 0
         prints("Error: Failed to bind to port ")
-        print_int(port)
+        print_i32(port)
         prints("\n")
         socket_close(@sock)
         collection_destroy(@collection)
@@ -233,7 +233,7 @@ fn cmd_serve(port: i32) -> i32
         return 1
 
     prints("Server listening on 0.0.0.0:")
-    print_int(port)
+    print_i32(port)
     prints("\n")
     prints("Press Ctrl+C to stop.\n")
     prints("\n")
@@ -339,7 +339,7 @@ fn cmd_shell(host: *u8, port: i32) -> i32
     prints("Connecting to ")
     prints_cstr(host)
     prints(":")
-    print_int(port)
+    print_i32(port)
     prints(" (encrypted)...\n")
 
     # Create socket

--- a/projects/ritz/build.py
+++ b/projects/ritz/build.py
@@ -866,7 +866,8 @@ def compile_binary(name: str, src_path: Path, out_dir: Path, additional_sources:
 
         # Link: runtime.o + all .bc/.ll files -> binary
         # Build link command with profile-specific options
-        link_cmd = linker_cmd + [str(runtime_obj)] + [str(f) for f in link_files] + ["-o", str(bin_path), "-nostdlib"]
+        # Use -march=native to enable CPU features like SHA-NI, AVX2, etc.
+        link_cmd = linker_cmd + [str(runtime_obj)] + [str(f) for f in link_files] + ["-o", str(bin_path), "-nostdlib", "-march=native"]
 
         # Add optimization level
         opt_level = profile.get("opt_level", 0)


### PR DESCRIPTION
## Summary

- Fix cryptosec internal imports (`lib.*` → `cryptosec.*`) for monorepo compatibility
- Add `-march=native` to build.py linker for SHA-NI and other CPU intrinsics
- Fix mausoleum `print_int` symbol conflict with ritzlib

## Test plan

- [x] `./rz build mausoleum` succeeds
- [x] `./projects/mausoleum/build/debug/mausoleum version` runs correctly

## Related

- Depends on PR #45 (cryptosec RERITZ syntax migration) ✅ merged
- Part of monorepo migration (Issue #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)