### PR TITLE
ritzlib: Fix Clang 20 segfault in async_tasks (Issue #50)

### DIFF
--- a/projects/ritz/ritzlib/async_tasks.ritz
+++ b/projects/ritz/ritzlib/async_tasks.ritz
@@ -541,7 +541,7 @@ pub fn task_server_poll_tasks(srv: *TaskServer)
 # Handle a new connection (shared by both modes)
 pub fn task_server_handle_accept(srv: *TaskServer, client_fd: i32, handler: fn(*Task) -> i32)
     # Check max connections limit
-    if srv.max_connections > 0 and srv.pool.active_count >= srv.max_connections
+    if srv.max_connections > 0 and (@srv.pool).active_count >= srv.max_connections
         # At connection limit, reject new connection
         sys_close(client_fd)
         return

--- a/projects/ritz/ritzlib/fs.ritz
+++ b/projects/ritz/ritzlib/fs.ritz
@@ -387,7 +387,7 @@ pub fn file_size_string(path: *String) -> Result<i64, i32>
 # Read entire file contents into a String.
 # Returns error code (0 = success, negative = error).
 # TODO: Migrate to Result<String, i32> now that struct-in-enum works.
-pub fn read_file_string(path: *String, out:& String) -> i32
+pub fn read_file_string(path: *String, out: @&String) -> i32
     let cstr: *u8 = string_as_ptr(path)
     let fd: i32 = sys_open(cstr, O_RDONLY)
     if fd < 0


### PR DESCRIPTION
## Summary

- Fix ownership syntax error in `fs.ritz` that was blocking builds
- Fix codegen inefficiency in `async_tasks.ritz` that triggered LLVM 20 crash

## Root Cause

The expression `srv.pool.active_count` was generating LLVM IR that loaded the **entire** `TaskPool` struct by value (~4.3MB: 256 tasks × 17KB each), just to extract a single i32 field.

This triggered a crash in LLVM 20's DAG combiner during instruction selection:
```
Running pass 'X86 DAG->DAG Instruction Selection' on function '@task_server_handle_accept'
```

Stack trace showed `SelectionDAG::ReplaceAllUsesWith` segfault.

## Changes

| File | Change |
|------|--------|
| `fs.ritz` | Fix borrow syntax: `out:& String` → `out: @&String` |
| `async_tasks.ritz` | Fix struct access: `srv.pool.active_count` → `(@srv.pool).active_count` |

## Test Plan

- [x] `./rz build valet` succeeds
- [x] Verified LLVM IR no longer loads TaskPool by value

## Notes

This is a workaround for an LLVM 20 bug. The compiler (ritz0) should ideally generate pointer-based field access for nested struct member access, but that's a separate enhancement.

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)