### PR TITLE
RFC: Implement String API Migration - Phase 1 (cryptosec)

### DIFF
--- a/projects/cryptosec/lib/hkdf.ritz
+++ b/projects/cryptosec/lib/hkdf.ritz
@@ -9,6 +9,7 @@
 #              where T(i) = HMAC-Hash(PRK, T(i-1) || info || i)
 
 import ritzlib.sys
+import ritzlib.strview
 
 import hmac
 import mem
@@ -130,3 +131,18 @@ pub fn hkdf_sha256(salt: *u8, salt_len: u64, ikm: *u8, ikm_len: u64, info: *u8, 
     # Zero PRK
     mem_zero(@prk[0], 32)
 
+# ============================================================================
+# Idiomatic StrView API
+# ============================================================================
+
+# HKDF-Extract with StrView inputs (idiomatic Ritz API)
+pub fn hkdf_extract_str(salt: @StrView, ikm: @StrView, prk: *u8)
+    hkdf_extract(salt.ptr, salt.len as u64, ikm.ptr, ikm.len as u64, prk)
+
+# HKDF-Expand with StrView inputs (idiomatic Ritz API)
+pub fn hkdf_expand_str(prk: @StrView, info: @StrView, okm: *u8, okm_len: u64)
+    hkdf_expand(prk.ptr, info.ptr, info.len as u64, okm, okm_len)
+
+# Combined HKDF with StrView inputs (idiomatic Ritz API)
+pub fn hkdf_sha256_str(salt: @StrView, ikm: @StrView, info: @StrView, okm: *u8, okm_len: u64)
+    hkdf_sha256(salt.ptr, salt.len as u64, ikm.ptr, ikm.len as u64, info.ptr, info.len as u64, okm, okm_len)

--- a/projects/cryptosec/lib/hmac.ritz
+++ b/projects/cryptosec/lib/hmac.ritz
@@ -10,6 +10,7 @@
 #   opad = 0x5c repeated block_size times
 
 import ritzlib.sys
+import ritzlib.strview
 
 import sha256
 import sha512
@@ -248,3 +249,19 @@ pub fn hmac_sha384(key: *u8, key_len: u64, data: *u8, data_len: u64, out: *u8)
     mem_zero(@ipad_block[0], 128)
     mem_zero(@opad_block[0], 128)
     mem_zero(@inner_hash[0], 48)
+
+# ============================================================================
+# Idiomatic StrView API
+# ============================================================================
+
+# HMAC-SHA-256 with StrView inputs (idiomatic Ritz API)
+pub fn hmac_sha256_str(key: @StrView, data: @StrView, out: *u8)
+    hmac_sha256(key.ptr, key.len as u64, data.ptr, data.len as u64, out)
+
+# HMAC-SHA-512 with StrView inputs (idiomatic Ritz API)
+pub fn hmac_sha512_str(key: @StrView, data: @StrView, out: *u8)
+    hmac_sha512(key.ptr, key.len as u64, data.ptr, data.len as u64, out)
+
+# HMAC-SHA-384 with StrView inputs (idiomatic Ritz API)
+pub fn hmac_sha384_str(key: @StrView, data: @StrView, out: *u8)
+    hmac_sha384(key.ptr, key.len as u64, data.ptr, data.len as u64, out)

--- a/projects/cryptosec/lib/sha256.ritz
+++ b/projects/cryptosec/lib/sha256.ritz
@@ -13,6 +13,7 @@
 # that support it (runtime detection via CPUID).
 
 import ritzlib.sys
+import ritzlib.strview
 import cryptosec.cpuid
 
 # ============================================================================
@@ -688,9 +689,21 @@ pub fn sha256_final(ctx: *Sha256, out: *u8)
     out[30] = (ctx.h7 >> 8) as u8
     out[31] = ctx.h7 as u8
 
-# One-shot hash function
+# One-shot hash function (low-level, for FFI/byte buffers)
 pub fn sha256(data: *u8, len: u64, out: *u8)
     var ctx: Sha256
     sha256_init(@ctx)
     sha256_update(@ctx, data, len)
     sha256_final(@ctx, out)
+
+# ============================================================================
+# Idiomatic StrView API
+# ============================================================================
+
+# One-shot hash function with StrView input (idiomatic Ritz API)
+pub fn sha256_str(data: @StrView, out: *u8)
+    sha256(data.ptr, data.len as u64, out)
+
+# Update context with StrView data (idiomatic wrapper)
+pub fn sha256_update_str(ctx: *Sha256, data: @StrView)
+    sha256_update(ctx, data.ptr, data.len as u64)

--- a/projects/cryptosec/lib/sha512.ritz
+++ b/projects/cryptosec/lib/sha512.ritz
@@ -15,6 +15,7 @@
 # - sha384(data, len, out): One-shot convenience function (48-byte output)
 
 import ritzlib.sys
+import ritzlib.strview
 
 # ============================================================================
 # Constants
@@ -722,3 +723,23 @@ pub fn sha384(data: *u8, len: u64, out: *u8)
     sha384_init(@ctx)
     sha384_update(@ctx, data, len)
     sha384_final(@ctx, out)
+
+# ============================================================================
+# Idiomatic StrView API
+# ============================================================================
+
+# One-shot SHA-512 with StrView input (idiomatic Ritz API)
+pub fn sha512_str(data: @StrView, out: *u8)
+    sha512(data.ptr, data.len as u64, out)
+
+# One-shot SHA-384 with StrView input (idiomatic Ritz API)
+pub fn sha384_str(data: @StrView, out: *u8)
+    sha384(data.ptr, data.len as u64, out)
+
+# Update SHA-512 context with StrView data (idiomatic wrapper)
+pub fn sha512_update_str(ctx: *Sha512, data: @StrView)
+    sha512_update(ctx, data.ptr, data.len as u64)
+
+# Update SHA-384 context with StrView data (idiomatic wrapper)
+pub fn sha384_update_str(ctx: *Sha384, data: @StrView)
+    sha384_update(ctx, data.ptr, data.len as u64)

--- a/projects/cryptosec/lib/tls13_handshake.ritz
+++ b/projects/cryptosec/lib/tls13_handshake.ritz
@@ -728,7 +728,7 @@ pub fn certificate_verify_verify(cv: *CertificateVerify, transcript_hash: *u8, p
     pos = 64
 
     # Context string "TLS 1.3, server CertificateVerify"
-    let ctx: *u8 = c"TLS 1.3, server CertificateVerify"
+    let ctx: *u8 = "TLS 1.3, server CertificateVerify".as_ptr()
     i = 0
     while i < 33
         content[pos] = ctx[i]
@@ -768,7 +768,7 @@ pub fn finished_compute(base_key: *u8, transcript_hash: *u8, out: *u8)
     var finished_key: [32]u8
 
     # Derive finished key
-    hkdf_expand_label(base_key, c"finished", 8, null, 0, @finished_key[0], 32)
+    hkdf_expand_label(base_key, "finished", 8, null, 0, @finished_key[0], 32)
 
     # Compute HMAC
     hmac_sha256(@finished_key[0], 32, transcript_hash, 32, out)

--- a/projects/cryptosec/lib/tls13_kdf.ritz
+++ b/projects/cryptosec/lib/tls13_kdf.ritz
@@ -187,8 +187,8 @@ pub fn tls13_master_secret(derived: *u8, out: *u8)
 # iv = HKDF-Expand-Label(Secret, "iv", "", iv_length)
 
 pub fn tls13_derive_traffic_keys(traffic_secret: *u8, key: *u8, key_len: i32, iv: *u8, iv_len: i32)
-    hkdf_expand_label(traffic_secret, c"key", 3, null, 0, key, key_len)
-    hkdf_expand_label(traffic_secret, c"iv", 2, null, 0, iv, iv_len)
+    hkdf_expand_label(traffic_secret, "key", 3, null, 0, key, key_len)
+    hkdf_expand_label(traffic_secret, "iv", 2, null, 0, iv, iv_len)
 
 # ============================================================================
 # Key Schedule State Structure
@@ -230,14 +230,14 @@ pub fn tls13_key_schedule_init(ks: *TLS13KeySchedule)
 pub fn tls13_key_schedule_derive_handshake(ks: *TLS13KeySchedule, shared_secret: *u8, shared_len: i32, transcript_hash: *u8)
     # Derive intermediate secret
     var derived: [32]u8
-    derive_secret(@ks.early_secret[0], c"derived", 7, null, 0, @derived[0])
+    derive_secret(@ks.early_secret[0], "derived", 7, null, 0, @derived[0])
 
     # Compute handshake secret
     tls13_handshake_secret(@derived[0], shared_secret, shared_len, @ks.handshake_secret[0])
 
     # Derive client/server handshake traffic secrets
-    hkdf_expand_label(@ks.handshake_secret[0], c"c hs traffic", 12, transcript_hash, 32, @ks.client_handshake_traffic_secret[0], 32)
-    hkdf_expand_label(@ks.handshake_secret[0], c"s hs traffic", 12, transcript_hash, 32, @ks.server_handshake_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.handshake_secret[0], "c hs traffic", 12, transcript_hash, 32, @ks.client_handshake_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.handshake_secret[0], "s hs traffic", 12, transcript_hash, 32, @ks.server_handshake_traffic_secret[0], 32)
 
     mem_zero(@derived[0], 32)
     ks.state = 2
@@ -247,14 +247,14 @@ pub fn tls13_key_schedule_derive_handshake(ks: *TLS13KeySchedule, shared_secret:
 pub fn tls13_key_schedule_derive_application(ks: *TLS13KeySchedule, transcript_hash: *u8)
     # Derive intermediate secret from handshake
     var derived: [32]u8
-    derive_secret(@ks.handshake_secret[0], c"derived", 7, null, 0, @derived[0])
+    derive_secret(@ks.handshake_secret[0], "derived", 7, null, 0, @derived[0])
 
     # Compute master secret
     tls13_master_secret(@derived[0], @ks.master_secret[0])
 
     # Derive application traffic secrets
-    hkdf_expand_label(@ks.master_secret[0], c"c ap traffic", 12, transcript_hash, 32, @ks.client_application_traffic_secret[0], 32)
-    hkdf_expand_label(@ks.master_secret[0], c"s ap traffic", 12, transcript_hash, 32, @ks.server_application_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.master_secret[0], "c ap traffic", 12, transcript_hash, 32, @ks.client_application_traffic_secret[0], 32)
+    hkdf_expand_label(@ks.master_secret[0], "s ap traffic", 12, transcript_hash, 32, @ks.server_application_traffic_secret[0], 32)
 
     mem_zero(@derived[0], 32)
     ks.state = 3

--- a/projects/cryptosec/test/test_aes.ritz
+++ b/projects/cryptosec/test/test_aes.ritz
@@ -45,9 +45,9 @@ fn test_aes128_encrypt_fips197() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
-    hex_to_bytes(c"3243f6a8885a308d313198a2e0370734", @pt[0], 16)
-    hex_to_bytes(c"3925841d02dc09fbdc118597196a0b32", @expected[0], 16)
+    hex_to_bytes("2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes("3243f6a8885a308d313198a2e0370734", @pt[0], 16)
+    hex_to_bytes("3925841d02dc09fbdc118597196a0b32", @expected[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])
@@ -65,9 +65,9 @@ fn test_aes128_decrypt_fips197() -> i32
     var pt: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
-    hex_to_bytes(c"3925841d02dc09fbdc118597196a0b32", @ct[0], 16)
-    hex_to_bytes(c"3243f6a8885a308d313198a2e0370734", @expected[0], 16)
+    hex_to_bytes("2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes("3925841d02dc09fbdc118597196a0b32", @ct[0], 16)
+    hex_to_bytes("3243f6a8885a308d313198a2e0370734", @expected[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])
@@ -84,8 +84,8 @@ fn test_aes128_roundtrip() -> i32
     var ct: [16]u8
     var rt: [16]u8
 
-    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f", @key[0], 16)
-    hex_to_bytes(c"00112233445566778899aabbccddeeff", @pt[0], 16)
+    hex_to_bytes("000102030405060708090a0b0c0d0e0f", @key[0], 16)
+    hex_to_bytes("00112233445566778899aabbccddeeff", @pt[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])
@@ -109,9 +109,9 @@ fn test_aes128_nist_ecb_vector1() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
-    hex_to_bytes(c"3ad77bb40d7a3660a89ecaf32466ef97", @expected[0], 16)
+    hex_to_bytes("2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes("6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
+    hex_to_bytes("3ad77bb40d7a3660a89ecaf32466ef97", @expected[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])
@@ -129,9 +129,9 @@ fn test_aes128_nist_ecb_vector2() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
-    hex_to_bytes(c"ae2d8a571e03ac9c9eb76fac45af8e51", @pt[0], 16)
-    hex_to_bytes(c"f5d3d58503b9699de785895a96fdbaaf", @expected[0], 16)
+    hex_to_bytes("2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes("ae2d8a571e03ac9c9eb76fac45af8e51", @pt[0], 16)
+    hex_to_bytes("f5d3d58503b9699de785895a96fdbaaf", @expected[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])
@@ -157,9 +157,9 @@ fn test_aes256_encrypt_fips197() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", @key[0], 32)
-    hex_to_bytes(c"00112233445566778899aabbccddeeff", @pt[0], 16)
-    hex_to_bytes(c"8ea2b7ca516745bfeafc49904b496089", @expected[0], 16)
+    hex_to_bytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", @key[0], 32)
+    hex_to_bytes("00112233445566778899aabbccddeeff", @pt[0], 16)
+    hex_to_bytes("8ea2b7ca516745bfeafc49904b496089", @expected[0], 16)
 
     var ctx: Aes256
     aes256_init(@ctx, @key[0])
@@ -177,9 +177,9 @@ fn test_aes256_decrypt_fips197() -> i32
     var pt: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", @key[0], 32)
-    hex_to_bytes(c"8ea2b7ca516745bfeafc49904b496089", @ct[0], 16)
-    hex_to_bytes(c"00112233445566778899aabbccddeeff", @expected[0], 16)
+    hex_to_bytes("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", @key[0], 32)
+    hex_to_bytes("8ea2b7ca516745bfeafc49904b496089", @ct[0], 16)
+    hex_to_bytes("00112233445566778899aabbccddeeff", @expected[0], 16)
 
     var ctx: Aes256
     aes256_init(@ctx, @key[0])
@@ -196,8 +196,8 @@ fn test_aes256_roundtrip() -> i32
     var ct: [16]u8
     var rt: [16]u8
 
-    hex_to_bytes(c"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", @key[0], 32)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
+    hex_to_bytes("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", @key[0], 32)
+    hex_to_bytes("6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
 
     var ctx: Aes256
     aes256_init(@ctx, @key[0])
@@ -220,9 +220,9 @@ fn test_aes256_nist_ecb_vector1() -> i32
     var ct: [16]u8
     var expected: [16]u8
 
-    hex_to_bytes(c"603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", @key[0], 32)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
-    hex_to_bytes(c"f3eed1bdb5d2a03c064b5a7e3db181f8", @expected[0], 16)
+    hex_to_bytes("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4", @key[0], 32)
+    hex_to_bytes("6bc1bee22e409f96e93d7e117393172a", @pt[0], 16)
+    hex_to_bytes("f3eed1bdb5d2a03c064b5a7e3db181f8", @expected[0], 16)
 
     var ctx: Aes256
     aes256_init(@ctx, @key[0])
@@ -252,7 +252,7 @@ fn test_aes128_zero_key_zero_pt() -> i32
     mem_zero(@key[0], 16)
     mem_zero(@pt[0], 16)
 
-    hex_to_bytes(c"66e94bd4ef8a2c3b884cfa59ca342b2e", @expected[0], 16)
+    hex_to_bytes("66e94bd4ef8a2c3b884cfa59ca342b2e", @expected[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])
@@ -278,7 +278,7 @@ fn test_aes256_zero_key_zero_pt() -> i32
     mem_zero(@key[0], 32)
     mem_zero(@pt[0], 16)
 
-    hex_to_bytes(c"dc95c078a2408989ad48a21492842087", @expected[0], 16)
+    hex_to_bytes("dc95c078a2408989ad48a21492842087", @expected[0], 16)
 
     var ctx: Aes256
     aes256_init(@ctx, @key[0])
@@ -303,9 +303,9 @@ fn test_aes128_multiple_blocks() -> i32
     var rt1: [16]u8
     var rt2: [16]u8
 
-    hex_to_bytes(c"2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
-    hex_to_bytes(c"6bc1bee22e409f96e93d7e117393172a", @pt1[0], 16)
-    hex_to_bytes(c"ae2d8a571e03ac9c9eb76fac45af8e51", @pt2[0], 16)
+    hex_to_bytes("2b7e151628aed2a6abf7158809cf4f3c", @key[0], 16)
+    hex_to_bytes("6bc1bee22e409f96e93d7e117393172a", @pt1[0], 16)
+    hex_to_bytes("ae2d8a571e03ac9c9eb76fac45af8e51", @pt2[0], 16)
 
     var ctx: Aes128
     aes128_init(@ctx, @key[0])

--- a/projects/cryptosec/test/test_ca_store.ritz
+++ b/projects/cryptosec/test/test_ca_store.ritz
@@ -20,7 +20,7 @@ import cryptosec.pem
 fn get_test_pem_data() -> *u8
     # Small self-signed RSA cert for testing
     # This is a real PEM certificate for test purposes
-    return c"-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPpHGMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl\nc3RDQTAeFw0yNTAxMDEwMDAwMDBaFw0yNjAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC5xr0WmjLNkTv2K3LBoEJB\nVH6qN8yBBm8xNzVsHZLmYm5k5mRVZ5BgKWbZqJpbQvRmVmVmZWZmZmZmZmZmZmZm\nAgMBAAGjUzBRMB0GA1UdDgQWBBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAfBgNVHSME\nGDAWgBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==\n-----END CERTIFICATE-----\n"
+    return "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPpHGMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl\nc3RDQTAeFw0yNTAxMDEwMDAwMDBaFw0yNjAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC5xr0WmjLNkTv2K3LBoEJB\nVH6qN8yBBm8xNzVsHZLmYm5k5mRVZ5BgKWbZqJpbQvRmVmVmZWZmZmZmZmZmZmZm\nAgMBAAGjUzBRMB0GA1UdDgQWBBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAfBgNVHSME\nGDAWgBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==\n-----END CERTIFICATE-----\n"
 
 fn get_test_pem_len() -> i64
     return 583
@@ -87,7 +87,7 @@ fn test_ca_store_get_empty() -> i32
 fn get_multi_cert_pem() -> *u8
     # Two minimal PEM certificates concatenated
     # These are simplified test certs - just header/footer structure
-    return c"-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPpHGMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl\nc3RDQTAeFw0yNTAxMDEwMDAwMDBaFw0yNjAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC5xr0WmjLNkTv2K3LBoEJB\nVH6qN8yBBm8xNzVsHZLmYm5k5mRVZ5BgKWbZqJpbQvRmVmVmZWZmZmZmZmZmZmZm\nAgMBAAGjUzBRMB0GA1UdDgQWBBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAfBgNVHSME\nGDAWgBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPpHGMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl\nc3RDQTAeFw0yNTAxMDEwMDAwMDBaFw0yNjAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC5xr0WmjLNkTv2K3LBoEJB\nVH6qN8yBBm8xNzVsHZLmYm5k5mRVZ5BgKWbZqJpbQvRmVmVmZWZmZmZmZmZmZmZm\nAgMBAAGjUzBRMB0GA1UdDgQWBBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAfBgNVHSME\nGDAWgBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==\n-----END CERTIFICATE-----\n"
+    return "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPpHGMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl\nc3RDQTAeFw0yNTAxMDEwMDAwMDBaFw0yNjAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC5xr0WmjLNkTv2K3LBoEJB\nVH6qN8yBBm8xNzVsHZLmYm5k5mRVZ5BgKWbZqJpbQvRmVmVmZWZmZmZmZmZmZmZm\nAgMBAAGjUzBRMB0GA1UdDgQWBBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAfBgNVHSME\nGDAWgBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPpHGMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBlRl\nc3RDQTAeFw0yNTAxMDEwMDAwMDBaFw0yNjAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBlRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC5xr0WmjLNkTv2K3LBoEJB\nVH6qN8yBBm8xNzVsHZLmYm5k5mRVZ5BgKWbZqJpbQvRmVmVmZWZmZmZmZmZmZmZm\nAgMBAAGjUzBRMB0GA1UdDgQWBBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAfBgNVHSME\nGDAWgBQQEBAQEBAQEBAQEBAQEBAQEBAQEDAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\nqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg==\n-----END CERTIFICATE-----\n"
 
 fn get_multi_cert_pem_len() -> i64
     return 1166  # 583 * 2
@@ -192,7 +192,7 @@ fn test_ca_store_load_empty_bundle() -> i32
     ca_store_init(@store)
 
     # Empty data should load 0 certs
-    let empty: *u8 = c""
+    let empty: *u8 = "".as_ptr()
     let loaded: i32 = ca_store_load_pem_bundle(@store, empty, 0)
 
     if loaded != 0
@@ -212,7 +212,7 @@ fn test_ca_store_load_garbage() -> i32
     ca_store_init(@store)
 
     # Non-PEM data should load 0 certs
-    let garbage: *u8 = c"This is not PEM data at all.\nJust random text.\n"
+    let garbage: *u8 = "This is not PEM data at all.\nJust random text.\n".as_ptr()
     let loaded: i32 = ca_store_load_pem_bundle(@store, garbage, 48)
 
     if loaded != 0
@@ -232,7 +232,7 @@ fn test_ca_store_load_partial_pem() -> i32
     ca_store_init(@store)
 
     # PEM with BEGIN but no END
-    let partial: *u8 = c"-----BEGIN CERTIFICATE-----\nSomeBase64Data\n"
+    let partial: *u8 = "-----BEGIN CERTIFICATE-----\nSomeBase64Data\n".as_ptr()
     let loaded: i32 = ca_store_load_pem_bundle(@store, partial, 45)
 
     # Should fail gracefully (load 0)
@@ -249,7 +249,7 @@ fn test_ca_store_load_non_cert_pem() -> i32
     ca_store_init(@store)
 
     # PEM with different type (RSA PRIVATE KEY)
-    let key_pem: *u8 = c"-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBAK==\n-----END RSA PRIVATE KEY-----\n"
+    let key_pem: *u8 = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBAK==\n-----END RSA PRIVATE KEY-----\n".as_ptr()
     let loaded: i32 = ca_store_load_pem_bundle(@store, key_pem, 73)
 
     # Should skip non-certificate entries
@@ -271,7 +271,7 @@ fn test_ca_store_load_nonexistent_file() -> i32
     ca_store_init(@store)
 
     # File that definitely doesn't exist
-    let path: *u8 = c"/nonexistent/path/to/certs.pem"
+    let path: *u8 = "/nonexistent/path/to/certs.pem".as_ptr()
     let loaded: i32 = ca_store_load_pem_file(@store, path, 30)
 
     if loaded != -1

--- a/projects/cryptosec/test/test_hkdf.ritz
+++ b/projects/cryptosec/test/test_hkdf.ritz
@@ -79,7 +79,7 @@ fn test_hkdf_sha256_rfc5869_test1() -> i32
     var okm: [42]u8
     hkdf_sha256(@salt[0], 13, @ikm[0], 22, @info[0], 10, @okm[0], 42)
 
-    let expected: *u8 = c"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+    let expected: *u8 = "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865".as_ptr()
     if bytes_eq_hex(@okm[0], expected, 42) != 1
         return 1
     0
@@ -113,7 +113,7 @@ fn test_hkdf_sha256_rfc5869_test2() -> i32
     var okm: [82]u8
     hkdf_sha256(@salt[0], 80, @ikm[0], 80, @info[0], 80, @okm[0], 82)
 
-    let expected: *u8 = c"b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87"
+    let expected: *u8 = "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87".as_ptr()
     if bytes_eq_hex(@okm[0], expected, 82) != 1
         return 1
     0
@@ -135,7 +135,7 @@ fn test_hkdf_sha256_rfc5869_test3() -> i32
     var okm: [42]u8
     hkdf_sha256(null, 0, @ikm[0], 22, null, 0, @okm[0], 42)
 
-    let expected: *u8 = c"8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"
+    let expected: *u8 = "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8".as_ptr()
     if bytes_eq_hex(@okm[0], expected, 42) != 1
         return 1
     0
@@ -162,7 +162,7 @@ fn test_hkdf_extract_basic() -> i32
     var prk: [32]u8
     hkdf_extract(@salt[0], 13, @ikm[0], 22, @prk[0])
 
-    let expected: *u8 = c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"
+    let expected: *u8 = "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5".as_ptr()
     if bytes_eq_hex(@prk[0], expected, 32) != 1
         return 1
     0
@@ -193,7 +193,7 @@ fn test_hkdf_expand_basic() -> i32
     # Test expand step with known PRK
     # PRK from test case 1
     var prk: [32]u8
-    fill_from_hex(@prk[0], c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
+    fill_from_hex(@prk[0], "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
 
     var info: [10]u8
     var i: i32 = 0
@@ -204,7 +204,7 @@ fn test_hkdf_expand_basic() -> i32
     var okm: [42]u8
     hkdf_expand(@prk[0], @info[0], 10, @okm[0], 42)
 
-    let expected: *u8 = c"3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"
+    let expected: *u8 = "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865".as_ptr()
     if bytes_eq_hex(@okm[0], expected, 42) != 1
         return 1
     0
@@ -213,7 +213,7 @@ fn test_hkdf_expand_basic() -> i32
 fn test_hkdf_expand_no_info() -> i32
     # Expand with zero-length info
     var prk: [32]u8
-    fill_from_hex(@prk[0], c"077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
+    fill_from_hex(@prk[0], "077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5", 32)
 
     var okm: [32]u8
     hkdf_expand(@prk[0], null, 0, @okm[0], 32)
@@ -236,8 +236,8 @@ fn test_hkdf_deterministic() -> i32
         ikm[i] = (i + 1) as u8
         i += 1
 
-    let salt: *u8 = c"salt"
-    let info: *u8 = c"info"
+    let salt: *u8 = "salt".as_ptr()
+    let info: *u8 = "info".as_ptr()
 
     var okm1: [32]u8
     var okm2: [32]u8
@@ -258,9 +258,9 @@ fn test_hkdf_different_info_different_output() -> i32
         ikm[i] = (i + 1) as u8
         i += 1
 
-    let salt: *u8 = c"salt"
-    let info1: *u8 = c"info1"
-    let info2: *u8 = c"info2"
+    let salt: *u8 = "salt".as_ptr()
+    let info1: *u8 = "info1".as_ptr()
+    let info2: *u8 = "info2".as_ptr()
 
     var okm1: [32]u8
     var okm2: [32]u8

--- a/projects/cryptosec/test/test_hmac.ritz
+++ b/projects/cryptosec/test/test_hmac.ritz
@@ -54,12 +54,12 @@ fn test_hmac_sha256_rfc4231_test1() -> i32
         key[i] = 0x0b
         i += 1
 
-    let data: *u8 = c"Hi There"
+    let data: *u8 = "Hi There".as_ptr()
     var mac: [32]u8
 
     hmac_sha256(@key[0], 20, data, 8, @mac[0])
 
-    let expected: *u8 = c"b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+    let expected: *u8 = "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7".as_ptr()
     if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
@@ -71,13 +71,13 @@ fn test_hmac_sha256_rfc4231_test2() -> i32
     # Data = "what do ya want for nothing?" (28 bytes)
     # HMAC-SHA-256 = 5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843
 
-    let key: *u8 = c"Jefe"
-    let data: *u8 = c"what do ya want for nothing?"
+    let key: *u8 = "Jefe".as_ptr()
+    let data: *u8 = "what do ya want for nothing?".as_ptr()
     var mac: [32]u8
 
     hmac_sha256(key, 4, data, 28, @mac[0])
 
-    let expected: *u8 = c"5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+    let expected: *u8 = "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843".as_ptr()
     if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
@@ -104,7 +104,7 @@ fn test_hmac_sha256_rfc4231_test3() -> i32
     var mac: [32]u8
     hmac_sha256(@key[0], 20, @data[0], 50, @mac[0])
 
-    let expected: *u8 = c"773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe"
+    let expected: *u8 = "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe".as_ptr()
     if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
@@ -131,7 +131,7 @@ fn test_hmac_sha256_rfc4231_test4() -> i32
     var mac: [32]u8
     hmac_sha256(@key[0], 25, @data[0], 50, @mac[0])
 
-    let expected: *u8 = c"82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b"
+    let expected: *u8 = "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b".as_ptr()
     if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
@@ -149,12 +149,12 @@ fn test_hmac_sha256_rfc4231_test6() -> i32
         key[i] = 0xaa
         i += 1
 
-    let data: *u8 = c"Test Using Larger Than Block-Size Key - Hash Key First"
+    let data: *u8 = "Test Using Larger Than Block-Size Key - Hash Key First".as_ptr()
     var mac: [32]u8
 
     hmac_sha256(@key[0], 131, data, 54, @mac[0])
 
-    let expected: *u8 = c"60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54"
+    let expected: *u8 = "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54".as_ptr()
     if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
@@ -172,12 +172,12 @@ fn test_hmac_sha256_rfc4231_test7() -> i32
         key[i] = 0xaa
         i += 1
 
-    let data: *u8 = c"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm."
+    let data: *u8 = "This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.".as_ptr()
     var mac: [32]u8
 
     hmac_sha256(@key[0], 131, data, 152, @mac[0])
 
-    let expected: *u8 = c"9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2"
+    let expected: *u8 = "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2".as_ptr()
     if hash_eq_hex(@mac[0], expected, 32) != 1
         return 1
     0
@@ -196,7 +196,7 @@ fn test_hmac_sha256_empty_data() -> i32
         i += 1
 
     var mac: [32]u8
-    hmac_sha256(@key[0], 16, c"", 0, @mac[0])
+    hmac_sha256(@key[0], 16, "".as_ptr(), 0, @mac[0])
 
     # Just verify it produces output (not all zeros)
     if mem_is_zero(@mac[0], 32) == 1
@@ -206,8 +206,8 @@ fn test_hmac_sha256_empty_data() -> i32
 [[test]]
 fn test_hmac_sha256_deterministic() -> i32
     # Same inputs should produce same output
-    let key: *u8 = c"secret"
-    let data: *u8 = c"message"
+    let key: *u8 = "secret".as_ptr()
+    let data: *u8 = "message".as_ptr()
 
     var mac1: [32]u8
     var mac2: [32]u8
@@ -222,9 +222,9 @@ fn test_hmac_sha256_deterministic() -> i32
 [[test]]
 fn test_hmac_sha256_different_keys() -> i32
     # Different keys should produce different MACs
-    let key1: *u8 = c"key1"
-    let key2: *u8 = c"key2"
-    let data: *u8 = c"message"
+    let key1: *u8 = "key1".as_ptr()
+    let key2: *u8 = "key2".as_ptr()
+    let data: *u8 = "message".as_ptr()
 
     var mac1: [32]u8
     var mac2: [32]u8
@@ -239,9 +239,9 @@ fn test_hmac_sha256_different_keys() -> i32
 [[test]]
 fn test_hmac_sha256_different_data() -> i32
     # Different data should produce different MACs
-    let key: *u8 = c"secret"
-    let data1: *u8 = c"message1"
-    let data2: *u8 = c"message2"
+    let key: *u8 = "secret".as_ptr()
+    let data1: *u8 = "message1".as_ptr()
+    let data2: *u8 = "message2".as_ptr()
 
     var mac1: [32]u8
     var mac2: [32]u8
@@ -270,12 +270,12 @@ fn test_hmac_sha512_rfc4231_test1() -> i32
         key[i] = 0x0b
         i += 1
 
-    let data: *u8 = c"Hi There"
+    let data: *u8 = "Hi There".as_ptr()
     var mac: [64]u8
 
     hmac_sha512(@key[0], 20, data, 8, @mac[0])
 
-    let expected: *u8 = c"87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"
+    let expected: *u8 = "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cdedaa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854".as_ptr()
     if hash_eq_hex(@mac[0], expected, 64) != 1
         return 1
     0
@@ -288,21 +288,21 @@ fn test_hmac_sha512_rfc4231_test2() -> i32
     # HMAC-SHA-512 = 164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea250554
     #                9758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737
 
-    let key: *u8 = c"Jefe"
-    let data: *u8 = c"what do ya want for nothing?"
+    let key: *u8 = "Jefe".as_ptr()
+    let data: *u8 = "what do ya want for nothing?".as_ptr()
     var mac: [64]u8
 
     hmac_sha512(key, 4, data, 28, @mac[0])
 
-    let expected: *u8 = c"164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"
+    let expected: *u8 = "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea2505549758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737".as_ptr()
     if hash_eq_hex(@mac[0], expected, 64) != 1
         return 1
     0
 
 [[test]]
 fn test_hmac_sha512_deterministic() -> i32
-    let key: *u8 = c"secret"
-    let data: *u8 = c"message"
+    let key: *u8 = "secret".as_ptr()
+    let data: *u8 = "message".as_ptr()
 
     var mac1: [64]u8
     var mac2: [64]u8
@@ -331,12 +331,12 @@ fn test_hmac_sha384_rfc4231_test1() -> i32
         key[i] = 0x0b
         i += 1
 
-    let data: *u8 = c"Hi There"
+    let data: *u8 = "Hi There".as_ptr()
     var mac: [48]u8
 
     hmac_sha384(@key[0], 20, data, 8, @mac[0])
 
-    let expected: *u8 = c"afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6"
+    let expected: *u8 = "afd03944d84895626b0825f4ab46907f15f9dadbe4101ec682aa034c7cebc59cfaea9ea9076ede7f4af152e8b2fa9cb6".as_ptr()
     if hash_eq_hex(@mac[0], expected, 48) != 1
         return 1
     0
@@ -349,21 +349,21 @@ fn test_hmac_sha384_rfc4231_test2() -> i32
     # HMAC-SHA-384 = af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e
     #                8e2240ca5e69e2c78b3239ecfab21649
 
-    let key: *u8 = c"Jefe"
-    let data: *u8 = c"what do ya want for nothing?"
+    let key: *u8 = "Jefe".as_ptr()
+    let data: *u8 = "what do ya want for nothing?".as_ptr()
     var mac: [48]u8
 
     hmac_sha384(key, 4, data, 28, @mac[0])
 
-    let expected: *u8 = c"af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649"
+    let expected: *u8 = "af45d2e376484031617f78d2b58a6b1b9c7ef464f5a01b47e42ec3736322445e8e2240ca5e69e2c78b3239ecfab21649".as_ptr()
     if hash_eq_hex(@mac[0], expected, 48) != 1
         return 1
     0
 
 [[test]]
 fn test_hmac_sha384_deterministic() -> i32
-    let key: *u8 = c"secret"
-    let data: *u8 = c"message"
+    let key: *u8 = "secret".as_ptr()
+    let data: *u8 = "message".as_ptr()
 
     var mac1: [48]u8
     var mac2: [48]u8

--- a/projects/cryptosec/test/test_pem.ritz
+++ b/projects/cryptosec/test/test_pem.ritz
@@ -16,7 +16,7 @@ import cryptosec.pem
 fn test_base64_decode_empty() -> i32
     # Empty input -> empty output
     var out: [16]u8
-    let len: i64 = base64_decode(c"", 0, @out[0], 16)
+    let len: i64 = base64_decode("", 0, @out[0], 16)
     if len != 0
         return 1
     return 0
@@ -25,7 +25,7 @@ fn test_base64_decode_empty() -> i32
 fn test_base64_decode_simple() -> i32
     # "TWFu" -> "Man" (classic base64 example)
     var out: [16]u8
-    let len: i64 = base64_decode(c"TWFu", 4, @out[0], 16)
+    let len: i64 = base64_decode("TWFu", 4, @out[0], 16)
     if len != 3
         return 1
     if out[0] != 77  # 'M'
@@ -40,7 +40,7 @@ fn test_base64_decode_simple() -> i32
 fn test_base64_decode_padding_1() -> i32
     # "TWE=" -> "Ma" (1 padding byte)
     var out: [16]u8
-    let len: i64 = base64_decode(c"TWE=", 4, @out[0], 16)
+    let len: i64 = base64_decode("TWE=", 4, @out[0], 16)
     if len != 2
         return 1
     if out[0] != 77  # 'M'
@@ -53,7 +53,7 @@ fn test_base64_decode_padding_1() -> i32
 fn test_base64_decode_padding_2() -> i32
     # "TQ==" -> "M" (2 padding bytes)
     var out: [16]u8
-    let len: i64 = base64_decode(c"TQ==", 4, @out[0], 16)
+    let len: i64 = base64_decode("TQ==", 4, @out[0], 16)
     if len != 1
         return 1
     if out[0] != 77  # 'M'
@@ -95,7 +95,7 @@ fn test_base64_decode_with_newlines() -> i32
 fn test_base64_decode_buffer_too_small() -> i32
     # Output buffer too small should return error
     var out: [2]u8
-    let len: i64 = base64_decode(c"TWFu", 4, @out[0], 2)  # needs 3 bytes
+    let len: i64 = base64_decode("TWFu", 4, @out[0], 2)  # needs 3 bytes
     if len != -1
         return 1
     return 0
@@ -104,7 +104,7 @@ fn test_base64_decode_buffer_too_small() -> i32
 fn test_base64_decode_hello_world() -> i32
     # "SGVsbG8gV29ybGQ=" -> "Hello World"
     var out: [16]u8
-    let len: i64 = base64_decode(c"SGVsbG8gV29ybGQ=", 16, @out[0], 16)
+    let len: i64 = base64_decode("SGVsbG8gV29ybGQ=", 16, @out[0], 16)
     if len != 11
         return 1
     if out[0] != 'H'
@@ -207,17 +207,17 @@ fn test_base64_roundtrip() -> i32
 [[test]]
 fn test_base64_decoded_length() -> i32
     # "TWFu" (no padding) -> 3 bytes
-    let len1: i64 = base64_decoded_length(c"TWFu", 4)
+    let len1: i64 = base64_decoded_length("TWFu", 4)
     if len1 != 3
         return 1
 
     # "TWE=" (1 padding) -> 2 bytes
-    let len2: i64 = base64_decoded_length(c"TWE=", 4)
+    let len2: i64 = base64_decoded_length("TWE=", 4)
     if len2 != 2
         return 2
 
     # "TQ==" (2 padding) -> 1 byte
-    let len3: i64 = base64_decoded_length(c"TQ==", 4)
+    let len3: i64 = base64_decoded_length("TQ==", 4)
     if len3 != 1
         return 3
 
@@ -231,7 +231,7 @@ fn test_base64_decoded_length() -> i32
 fn test_pem_parse_simple() -> i32
     # "-----BEGIN TEST-----\nVGVzdA==\n-----END TEST-----\n"
     # Base64 of "Test" is "VGVzdA=="
-    let pem: *u8 = c"-----BEGIN TEST-----\nVGVzdA==\n-----END TEST-----\n"
+    let pem: *u8 = "-----BEGIN TEST-----\nVGVzdA==\n-----END TEST-----\n".as_ptr()
     var entry: PemEntry
     var der_buf: [64]u8
 
@@ -268,7 +268,7 @@ fn test_pem_parse_simple() -> i32
 [[test]]
 fn test_pem_parse_certificate_type() -> i32
     # "CERTIFICATE" type extraction
-    let pem: *u8 = c"-----BEGIN CERTIFICATE-----\nVGVzdA==\n-----END CERTIFICATE-----\n"
+    let pem: *u8 = "-----BEGIN CERTIFICATE-----\nVGVzdA==\n-----END CERTIFICATE-----\n".as_ptr()
     var entry: PemEntry
     var der_buf: [64]u8
 
@@ -290,7 +290,7 @@ fn test_pem_parse_certificate_type() -> i32
 [[test]]
 fn test_pem_iterator() -> i32
     # Two PEM entries back-to-back
-    let pem: *u8 = c"-----BEGIN A-----\nYQ==\n-----END A-----\n-----BEGIN B-----\nYg==\n-----END B-----\n"
+    let pem: *u8 = "-----BEGIN A-----\nYQ==\n-----END A-----\n-----BEGIN B-----\nYg==\n-----END B-----\n".as_ptr()
 
     var iter: PemIterator
     pem_iterator_init(@iter, pem, 82)
@@ -326,7 +326,7 @@ fn test_pem_iterator() -> i32
 [[test]]
 fn test_pem_count_certificates() -> i32
     # Two CERTIFICATE entries
-    let pem: *u8 = c"-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nYg==\n-----END CERTIFICATE-----\n"
+    let pem: *u8 = "-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nYg==\n-----END CERTIFICATE-----\n".as_ptr()
 
     let count: i32 = pem_count_certificates(pem, 124)
     if count != 2
@@ -337,7 +337,7 @@ fn test_pem_count_certificates() -> i32
 [[test]]
 fn test_pem_parse_no_entry() -> i32
     # No PEM data
-    let pem: *u8 = c"This is not PEM data\n"
+    let pem: *u8 = "This is not PEM data\n".as_ptr()
     var entry: PemEntry
     var der_buf: [64]u8
 
@@ -350,7 +350,7 @@ fn test_pem_parse_no_entry() -> i32
 [[test]]
 fn test_pem_parse_missing_end() -> i32
     # BEGIN without END
-    let pem: *u8 = c"-----BEGIN TEST-----\nVGVzdA==\n"
+    let pem: *u8 = "-----BEGIN TEST-----\nVGVzdA==\n".as_ptr()
     var entry: PemEntry
     var der_buf: [64]u8
 
@@ -367,7 +367,7 @@ fn test_pem_parse_with_crlf() -> i32
     var i: i32 = 0
 
     # "-----BEGIN T-----\r\nYQ==\r\n-----END T-----\r\n"
-    let header: *u8 = c"-----BEGIN T-----"
+    let header: *u8 = "-----BEGIN T-----".as_ptr()
     while i < 17
         pem[i] = header[i]
         i += 1
@@ -388,7 +388,7 @@ fn test_pem_parse_with_crlf() -> i32
     pem[i] = 10  # \n
     i += 1
 
-    let footer: *u8 = c"-----END T-----"
+    let footer: *u8 = "-----END T-----".as_ptr()
     var j: i32 = 0
     while j < 15
         pem[i] = footer[j]
@@ -417,7 +417,7 @@ fn test_pem_parse_with_crlf() -> i32
 [[test]]
 fn test_pem_empty_content() -> i32
     # PEM with empty base64 content
-    let pem: *u8 = c"-----BEGIN EMPTY-----\n-----END EMPTY-----\n"
+    let pem: *u8 = "-----BEGIN EMPTY-----\n-----END EMPTY-----\n".as_ptr()
     var entry: PemEntry
     var der_buf: [64]u8
 
@@ -432,16 +432,16 @@ fn test_pem_empty_content() -> i32
 
 [[test]]
 fn test_pem_type_is() -> i32
-    let pem: *u8 = c"-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n"
+    let pem: *u8 = "-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n".as_ptr()
     var entry: PemEntry
     var der_buf: [64]u8
 
     pem_parse_entry(pem, 57, @entry, @der_buf[0], 64)
 
-    if pem_type_is(@entry, c"CERTIFICATE", 11) != 1
+    if pem_type_is(@entry, "CERTIFICATE", 11) != 1
         return 1
 
-    if pem_type_is(@entry, c"KEY", 3) != 0
+    if pem_type_is(@entry, "KEY", 3) != 0
         return 2
 
     return 0

--- a/projects/cryptosec/test/test_sha256.ritz
+++ b/projects/cryptosec/test/test_sha256.ritz
@@ -51,10 +51,10 @@ fn hash_eq_hex(hash: *u8, hex: *u8) -> i32
 fn test_sha256_empty() -> i32
     # SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     var hash: [32]u8
-    let msg: *u8 = c""
+    let msg: *u8 = "".as_ptr()
     sha256(msg, 0, @hash[0])
 
-    let expected: *u8 = c"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    let expected: *u8 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -63,10 +63,10 @@ fn test_sha256_empty() -> i32
 fn test_sha256_abc() -> i32
     # SHA-256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
     var hash: [32]u8
-    let msg: *u8 = c"abc"
+    let msg: *u8 = "abc".as_ptr()
     sha256(msg, 3, @hash[0])
 
-    let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    let expected: *u8 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -76,10 +76,10 @@ fn test_sha256_448_bits() -> i32
     # SHA-256("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
     # = 248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1
     var hash: [32]u8
-    let msg: *u8 = c"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    let msg: *u8 = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_ptr()
     sha256(msg, 56, @hash[0])
 
-    let expected: *u8 = c"248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+    let expected: *u8 = "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -89,10 +89,10 @@ fn test_sha256_896_bits() -> i32
     # SHA-256("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")
     # = cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1
     var hash: [32]u8
-    let msg: *u8 = c"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+    let msg: *u8 = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu".as_ptr()
     sha256(msg, 112, @hash[0])
 
-    let expected: *u8 = c"cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1"
+    let expected: *u8 = "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -105,10 +105,10 @@ fn test_sha256_896_bits() -> i32
 fn test_sha256_single_a() -> i32
     # SHA-256("a") = ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb
     var hash: [32]u8
-    let msg: *u8 = c"a"
+    let msg: *u8 = "a".as_ptr()
     sha256(msg, 1, @hash[0])
 
-    let expected: *u8 = c"ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
+    let expected: *u8 = "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -121,7 +121,7 @@ fn test_sha256_single_zero_byte() -> i32
     var hash: [32]u8
     sha256(@msg[0], 1, @hash[0])
 
-    let expected: *u8 = c"6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"
+    let expected: *u8 = "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -135,10 +135,10 @@ fn test_sha256_55_bytes() -> i32
     # 55 bytes - fits in one block with padding (55 + 1 + 8 = 64)
     # SHA-256("0123456789012345678901234567890123456789012345678901234")
     var hash: [32]u8
-    let msg: *u8 = c"0123456789012345678901234567890123456789012345678901234"
+    let msg: *u8 = "0123456789012345678901234567890123456789012345678901234".as_ptr()
     sha256(msg, 55, @hash[0])
 
-    let expected: *u8 = c"f34d5a0f80c0cbf84c8c0b90218c22637abd199965249da736a20143c8c9c9d9"
+    let expected: *u8 = "f34d5a0f80c0cbf84c8c0b90218c22637abd199965249da736a20143c8c9c9d9".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -148,10 +148,10 @@ fn test_sha256_56_bytes() -> i32
     # 56 bytes - requires two blocks (56 + 1 > 56, need length at end)
     # SHA-256("01234567890123456789012345678901234567890123456789012345")
     var hash: [32]u8
-    let msg: *u8 = c"01234567890123456789012345678901234567890123456789012345"
+    let msg: *u8 = "01234567890123456789012345678901234567890123456789012345".as_ptr()
     sha256(msg, 56, @hash[0])
 
-    let expected: *u8 = c"83aa034bda83e458a0dc9cbce0d4e354716aa0ff770ed37ac0ed2b292052e4af"
+    let expected: *u8 = "83aa034bda83e458a0dc9cbce0d4e354716aa0ff770ed37ac0ed2b292052e4af".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -161,10 +161,10 @@ fn test_sha256_64_bytes() -> i32
     # Exactly one block (64 bytes) - padding goes into second block
     # SHA-256("0123456789012345678901234567890123456789012345678901234567890123")
     var hash: [32]u8
-    let msg: *u8 = c"0123456789012345678901234567890123456789012345678901234567890123"
+    let msg: *u8 = "0123456789012345678901234567890123456789012345678901234567890123".as_ptr()
     sha256(msg, 64, @hash[0])
 
-    let expected: *u8 = c"9674d9e078535b7cec43284387a6ee39956188e735a85452b0050b55341cda56"
+    let expected: *u8 = "9674d9e078535b7cec43284387a6ee39956188e735a85452b0050b55341cda56".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -181,7 +181,7 @@ fn test_sha256_128_bytes() -> i32
     sha256(@msg[0], 128, @hash[0])
 
     # SHA-256("a" * 128)
-    let expected: *u8 = c"6836cf13bac400e9105071cd6af47084dfacad4e5e302c94bfed24e013afb73e"
+    let expected: *u8 = "6836cf13bac400e9105071cd6af47084dfacad4e5e302c94bfed24e013afb73e".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -195,11 +195,11 @@ fn test_sha256_streaming_single_update() -> i32
     # Same as one-shot for "abc"
     var ctx: Sha256
     sha256_init(@ctx)
-    sha256_update(@ctx, c"abc", 3)
+    sha256_update(@ctx, "abc".as_ptr(), 3)
     var hash: [32]u8
     sha256_final(@ctx, @hash[0])
 
-    let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    let expected: *u8 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -209,13 +209,13 @@ fn test_sha256_streaming_multiple_updates() -> i32
     # Hash "abc" as three separate updates
     var ctx: Sha256
     sha256_init(@ctx)
-    sha256_update(@ctx, c"a", 1)
-    sha256_update(@ctx, c"b", 1)
-    sha256_update(@ctx, c"c", 1)
+    sha256_update(@ctx, "a".as_ptr(), 1)
+    sha256_update(@ctx, "b".as_ptr(), 1)
+    sha256_update(@ctx, "c".as_ptr(), 1)
     var hash: [32]u8
     sha256_final(@ctx, @hash[0])
 
-    let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    let expected: *u8 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -226,16 +226,16 @@ fn test_sha256_streaming_cross_block() -> i32
     var ctx: Sha256
     sha256_init(@ctx)
     # First update: 60 bytes (fills most of first block)
-    let part1: *u8 = c"012345678901234567890123456789012345678901234567890123456789"
+    let part1: *u8 = "012345678901234567890123456789012345678901234567890123456789".as_ptr()
     sha256_update(@ctx, part1, 60)
     # Second update: 10 bytes (crosses into second block)
-    let part2: *u8 = c"0123456789"
+    let part2: *u8 = "0123456789".as_ptr()
     sha256_update(@ctx, part2, 10)
     var hash: [32]u8
     sha256_final(@ctx, @hash[0])
 
     # SHA-256("0123456789" * 7) = 70 chars total
-    let expected: *u8 = c"57445fa40b08c60cdcba7ca39c756de614d11482e3f15a925f548688c19e58f4"
+    let expected: *u8 = "57445fa40b08c60cdcba7ca39c756de614d11482e3f15a925f548688c19e58f4".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -245,13 +245,13 @@ fn test_sha256_streaming_empty_updates() -> i32
     # Empty updates should be handled gracefully
     var ctx: Sha256
     sha256_init(@ctx)
-    sha256_update(@ctx, c"", 0)
-    sha256_update(@ctx, c"abc", 3)
-    sha256_update(@ctx, c"", 0)
+    sha256_update(@ctx, "".as_ptr(), 0)
+    sha256_update(@ctx, "abc".as_ptr(), 3)
+    sha256_update(@ctx, "".as_ptr(), 0)
     var hash: [32]u8
     sha256_final(@ctx, @hash[0])
 
-    let expected: *u8 = c"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    let expected: *u8 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".as_ptr()
     if hash_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -300,7 +300,7 @@ fn test_sha256_deterministic() -> i32
     # Same input should always produce same output
     var hash1: [32]u8
     var hash2: [32]u8
-    let msg: *u8 = c"test message"
+    let msg: *u8 = "test message".as_ptr()
 
     sha256(msg, 12, @hash1[0])
     sha256(msg, 12, @hash2[0])
@@ -315,8 +315,8 @@ fn test_sha256_different_inputs_different_outputs() -> i32
     var hash1: [32]u8
     var hash2: [32]u8
 
-    sha256(c"hello", 5, @hash1[0])
-    sha256(c"world", 5, @hash2[0])
+    sha256("hello".as_ptr(), 5, @hash1[0])
+    sha256("world".as_ptr(), 5, @hash2[0])
 
     if mem_eq(@hash1[0], @hash2[0], 32) == 1
         return 1  # Should be different!

--- a/projects/cryptosec/test/test_sha512.ritz
+++ b/projects/cryptosec/test/test_sha512.ritz
@@ -55,9 +55,9 @@ fn hash384_eq_hex(hash: *u8, hex: *u8) -> i32
 fn test_sha512_empty() -> i32
     # SHA-512("")
     var hash: [64]u8
-    let msg: *u8 = c""
+    let msg: *u8 = "".as_ptr()
     sha512(msg, 0, @hash[0])
-    let expected: *u8 = c"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+    let expected: *u8 = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e".as_ptr()
     if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -66,9 +66,9 @@ fn test_sha512_empty() -> i32
 fn test_sha512_abc() -> i32
     # SHA-512("abc")
     var hash: [64]u8
-    let msg: *u8 = c"abc"
+    let msg: *u8 = "abc".as_ptr()
     sha512(msg, 3, @hash[0])
-    let expected: *u8 = c"ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+    let expected: *u8 = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f".as_ptr()
     if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -77,9 +77,9 @@ fn test_sha512_abc() -> i32
 fn test_sha512_448_bits() -> i32
     # SHA-512("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
     var hash: [64]u8
-    let msg: *u8 = c"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    let msg: *u8 = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_ptr()
     sha512(msg, 56, @hash[0])
-    let expected: *u8 = c"204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445"
+    let expected: *u8 = "204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c33596fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445".as_ptr()
     if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -88,9 +88,9 @@ fn test_sha512_448_bits() -> i32
 fn test_sha512_896_bits() -> i32
     # SHA-512("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")
     var hash: [64]u8
-    let msg: *u8 = c"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"
+    let msg: *u8 = "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu".as_ptr()
     sha512(msg, 112, @hash[0])
-    let expected: *u8 = c"8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909"
+    let expected: *u8 = "8e959b75dae313da8cf4f72814fc143f8f7779c6eb9f7fa17299aeadb6889018501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909".as_ptr()
     if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -99,9 +99,9 @@ fn test_sha512_896_bits() -> i32
 fn test_sha512_incremental() -> i32
     # Test streaming API: hash "abc" in parts
     var hash: [64]u8
-    let a: *u8 = c"a"
-    let b: *u8 = c"b"
-    let c: *u8 = c"c"
+    let a: *u8 = "a".as_ptr()
+    let b: *u8 = "b".as_ptr()
+    let c: *u8 = "c".as_ptr()
 
     var ctx: Sha512 = sha512_new()
     sha512_init(@ctx)
@@ -110,7 +110,7 @@ fn test_sha512_incremental() -> i32
     sha512_update(@ctx, c, 1)
     sha512_final(@ctx, @hash[0])
 
-    let expected: *u8 = c"ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"
+    let expected: *u8 = "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f".as_ptr()
     if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -119,9 +119,9 @@ fn test_sha512_incremental() -> i32
 fn test_sha512_single_byte() -> i32
     # SHA-512("a")
     var hash: [64]u8
-    let msg: *u8 = c"a"
+    let msg: *u8 = "a".as_ptr()
     sha512(msg, 1, @hash[0])
-    let expected: *u8 = c"1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75"
+    let expected: *u8 = "1f40fc92da241694750979ee6cf582f2d5d7d28e18335de05abc54d0560e0f5302860c652bf08d560252aa5e74210546f369fbbbce8c12cfc7957b2652fe9a75".as_ptr()
     if hash512_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -134,9 +134,9 @@ fn test_sha512_single_byte() -> i32
 fn test_sha384_empty() -> i32
     # SHA-384("")
     var hash: [48]u8
-    let msg: *u8 = c""
+    let msg: *u8 = "".as_ptr()
     sha384(msg, 0, @hash[0])
-    let expected: *u8 = c"38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+    let expected: *u8 = "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b".as_ptr()
     if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -145,9 +145,9 @@ fn test_sha384_empty() -> i32
 fn test_sha384_abc() -> i32
     # SHA-384("abc")
     var hash: [48]u8
-    let msg: *u8 = c"abc"
+    let msg: *u8 = "abc".as_ptr()
     sha384(msg, 3, @hash[0])
-    let expected: *u8 = c"cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
+    let expected: *u8 = "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7".as_ptr()
     if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -156,9 +156,9 @@ fn test_sha384_abc() -> i32
 fn test_sha384_448_bits() -> i32
     # SHA-384("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")
     var hash: [48]u8
-    let msg: *u8 = c"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+    let msg: *u8 = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_ptr()
     sha384(msg, 56, @hash[0])
-    let expected: *u8 = c"3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b"
+    let expected: *u8 = "3391fdddfc8dc7393707a65b1b4709397cf8b1d162af05abfe8f450de5f36bc6b0455a8520bc4e6f5fe95b1fe3c8452b".as_ptr()
     if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -167,9 +167,9 @@ fn test_sha384_448_bits() -> i32
 fn test_sha384_incremental() -> i32
     # Test streaming API: hash "abc" in parts
     var hash: [48]u8
-    let a: *u8 = c"a"
-    let b: *u8 = c"b"
-    let c: *u8 = c"c"
+    let a: *u8 = "a".as_ptr()
+    let b: *u8 = "b".as_ptr()
+    let c: *u8 = "c".as_ptr()
 
     var ctx: Sha384 = sha384_new()
     sha384_init(@ctx)
@@ -178,7 +178,7 @@ fn test_sha384_incremental() -> i32
     sha384_update(@ctx, c, 1)
     sha384_final(@ctx, @hash[0])
 
-    let expected: *u8 = c"cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7"
+    let expected: *u8 = "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7".as_ptr()
     if hash384_eq_hex(@hash[0], expected) != 1
         return 1
     0
@@ -192,7 +192,7 @@ fn test_sha512_deterministic() -> i32
     # Same input should always produce same output
     var hash1: [64]u8
     var hash2: [64]u8
-    let msg: *u8 = c"hello"
+    let msg: *u8 = "hello".as_ptr()
     sha512(msg, 5, @hash1[0])
     sha512(msg, 5, @hash2[0])
     if mem_eq(@hash1[0], @hash2[0], 64) != 1
@@ -203,7 +203,7 @@ fn test_sha512_deterministic() -> i32
 fn test_sha384_deterministic() -> i32
     var hash1: [48]u8
     var hash2: [48]u8
-    let msg: *u8 = c"hello"
+    let msg: *u8 = "hello".as_ptr()
     sha384(msg, 5, @hash1[0])
     sha384(msg, 5, @hash2[0])
     if mem_eq(@hash1[0], @hash2[0], 48) != 1
@@ -214,8 +214,8 @@ fn test_sha384_deterministic() -> i32
 fn test_sha512_different_inputs() -> i32
     var hash1: [64]u8
     var hash2: [64]u8
-    let msg1: *u8 = c"abc"
-    let msg2: *u8 = c"abd"
+    let msg1: *u8 = "abc".as_ptr()
+    let msg2: *u8 = "abd".as_ptr()
     sha512(msg1, 3, @hash1[0])
     sha512(msg2, 3, @hash2[0])
     # Different inputs should produce different outputs

--- a/projects/cryptosec/test/test_tls13_client.ritz
+++ b/projects/cryptosec/test/test_tls13_client.ritz
@@ -31,7 +31,7 @@ fn test_config_set_hostname() -> i32
     var cfg: TlsConfig
     tls_config_init(@cfg)
 
-    tls_config_set_hostname(@cfg, c"example.com", 11)
+    tls_config_set_hostname(@cfg, "example.com", 11)
 
     if cfg.hostname_len != 11
         return 1
@@ -49,7 +49,7 @@ fn test_config_set_hostname() -> i32
 fn test_client_init() -> i32
     var cfg: TlsConfig
     tls_config_init(@cfg)
-    tls_config_set_hostname(@cfg, c"test.local", 10)
+    tls_config_set_hostname(@cfg, "test.local", 10)
 
     var client: TlsClient
     tls_client_init(@client, @cfg)
@@ -70,7 +70,7 @@ fn test_client_init() -> i32
 fn test_client_start() -> i32
     var cfg: TlsConfig
     tls_config_init(@cfg)
-    tls_config_set_hostname(@cfg, c"example.com", 11)
+    tls_config_set_hostname(@cfg, "example.com", 11)
 
     var client: TlsClient
     tls_client_init(@client, @cfg)

--- a/projects/cryptosec/test/test_tls13_handshake.ritz
+++ b/projects/cryptosec/test/test_tls13_handshake.ritz
@@ -29,7 +29,7 @@ fn test_transcript_update_and_hash() -> i32
     transcript_init(@t)
 
     # Hash "abc"
-    transcript_update(@t, c"abc", 3)
+    transcript_update(@t, "abc", 3)
 
     var hash: [32]u8
     transcript_hash(@t, @hash[0])
@@ -52,8 +52,8 @@ fn test_transcript_incremental() -> i32
     transcript_init(@t)
 
     # Hash in parts
-    transcript_update(@t, c"a", 1)
-    transcript_update(@t, c"bc", 2)
+    transcript_update(@t, "a", 1)
+    transcript_update(@t, "bc", 2)
 
     var hash: [32]u8
     transcript_hash(@t, @hash[0])
@@ -71,13 +71,13 @@ fn test_transcript_multiple_hashes() -> i32
     var t: Transcript
     transcript_init(@t)
 
-    transcript_update(@t, c"hello", 5)
+    transcript_update(@t, "hello", 5)
 
     var hash1: [32]u8
     transcript_hash(@t, @hash1[0])
 
     # Update more
-    transcript_update(@t, c"world", 5)
+    transcript_update(@t, "world", 5)
 
     var hash2: [32]u8
     transcript_hash(@t, @hash2[0])
@@ -130,7 +130,7 @@ fn test_client_hello_set_hostname() -> i32
     var ch: ClientHello
     client_hello_init(@ch)
 
-    client_hello_set_hostname(@ch, c"example.com", 11)
+    client_hello_set_hostname(@ch, "example.com", 11)
 
     if ch.hostname_len != 11
         return 1
@@ -146,7 +146,7 @@ fn test_client_hello_set_hostname() -> i32
 fn test_client_hello_serialize() -> i32
     var ch: ClientHello
     client_hello_init(@ch)
-    client_hello_set_hostname(@ch, c"test.local", 10)
+    client_hello_set_hostname(@ch, "test.local", 10)
 
     var buf: [512]u8
     let len: i64 = client_hello_serialize(@ch, @buf[0], 512)

--- a/projects/cryptosec/test/test_tls13_kdf.ritz
+++ b/projects/cryptosec/test/test_tls13_kdf.ritz
@@ -85,7 +85,7 @@ fn fill_from_hex(out: *u8, hex: *u8, len: i32)
 
 fn print_hex_bytes(data: *u8, len: i32)
     var i: i32 = 0
-    let hex_chars: *u8 = c"0123456789abcdef"
+    let hex_chars: *u8 = "0123456789abcdef".as_ptr()
     var buf: [2]u8
     while i < len
         let b: u8 = data[i]
@@ -93,7 +93,7 @@ fn print_hex_bytes(data: *u8, len: i32)
         buf[1] = hex_chars[(b & 0x0f) as i64]
         sys_write(1, @buf[0], 2)
         i += 1
-    println(c"")
+    println("")
 
 # ============================================================================
 # HKDF-Expand-Label tests (RFC 8446 Section 7.1)
@@ -118,7 +118,7 @@ fn test_hkdf_expand_label_basic() -> i32
         i += 1
 
     var output: [32]u8
-    hkdf_expand_label(@secret[0], c"derived", 7, null, 0, @output[0], 32)
+    hkdf_expand_label(@secret[0], "derived", 7, null, 0, @output[0], 32)
 
     # Output should not be all zeros
     if mem_is_zero(@output[0], 32) == 1
@@ -137,7 +137,7 @@ fn test_hkdf_expand_label_with_context() -> i32
         i += 1
 
     var output: [32]u8
-    hkdf_expand_label(@secret[0], c"c hs traffic", 12, @context[0], 32, @output[0], 32)
+    hkdf_expand_label(@secret[0], "c hs traffic", 12, @context[0], 32, @output[0], 32)
 
     if mem_is_zero(@output[0], 32) == 1
         return 1
@@ -155,8 +155,8 @@ fn test_hkdf_expand_label_deterministic() -> i32
     var out1: [32]u8
     var out2: [32]u8
 
-    hkdf_expand_label(@secret[0], c"key", 3, null, 0, @out1[0], 32)
-    hkdf_expand_label(@secret[0], c"key", 3, null, 0, @out2[0], 32)
+    hkdf_expand_label(@secret[0], "key", 3, null, 0, @out1[0], 32)
+    hkdf_expand_label(@secret[0], "key", 3, null, 0, @out2[0], 32)
 
     if mem_eq(@out1[0], @out2[0], 32) != 1
         return 1
@@ -174,8 +174,8 @@ fn test_hkdf_expand_label_different_labels() -> i32
     var out1: [32]u8
     var out2: [32]u8
 
-    hkdf_expand_label(@secret[0], c"key", 3, null, 0, @out1[0], 32)
-    hkdf_expand_label(@secret[0], c"iv", 2, null, 0, @out2[0], 32)
+    hkdf_expand_label(@secret[0], "key", 3, null, 0, @out1[0], 32)
+    hkdf_expand_label(@secret[0], "iv", 2, null, 0, @out2[0], 32)
 
     if mem_eq(@out1[0], @out2[0], 32) == 1
         return 1  # Should be different
@@ -196,7 +196,7 @@ fn test_derive_secret_basic() -> i32
 
     var output: [32]u8
     # Empty messages -> hash of empty string
-    derive_secret(@secret[0], c"derived", 7, null, 0, @output[0])
+    derive_secret(@secret[0], "derived", 7, null, 0, @output[0])
 
     if mem_is_zero(@output[0], 32) == 1
         return 1
@@ -217,7 +217,7 @@ fn test_derive_secret_with_messages() -> i32
         i += 1
 
     var output: [32]u8
-    derive_secret(@secret[0], c"c hs traffic", 12, @messages[0], 64, @output[0])
+    derive_secret(@secret[0], "c hs traffic", 12, @messages[0], 64, @output[0])
 
     if mem_is_zero(@output[0], 32) == 1
         return 1
@@ -237,9 +237,9 @@ fn test_rfc8448_early_secret() -> i32
     var early_secret: [32]u8
     tls13_early_secret(null, 0, @early_secret[0])
 
-    let expected: *u8 = c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a"
+    let expected: *u8 = "33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a".as_ptr()
     if bytes_eq_hex(@early_secret[0], expected, 32) != 1
-        # print_hex(c"got early_secret", @early_secret[0], 32)
+        # print_hex("got early_secret", @early_secret[0], 32)
         return 1
     0
 
@@ -248,15 +248,15 @@ fn test_rfc8448_derived_secret_from_early() -> i32
     # derived = Derive-Secret(early_secret, "derived", "")
     # From early_secret, derive intermediate secret for handshake
     var early_secret: [32]u8
-    fill_from_hex(@early_secret[0], c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a", 32)
+    fill_from_hex(@early_secret[0], "33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a", 32)
 
     var derived: [32]u8
-    derive_secret(@early_secret[0], c"derived", 7, null, 0, @derived[0])
+    derive_secret(@early_secret[0], "derived", 7, null, 0, @derived[0])
 
     # RFC 8448: derived secret = 6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba
-    let expected: *u8 = c"6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba"
+    let expected: *u8 = "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba".as_ptr()
     if bytes_eq_hex(@derived[0], expected, 32) != 1
-        # print_hex(c"got derived", @derived[0], 32)
+        # print_hex("got derived", @derived[0], 32)
         return 1
     0
 
@@ -267,18 +267,18 @@ fn test_rfc8448_handshake_secret() -> i32
     # 8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d
 
     var derived: [32]u8
-    fill_from_hex(@derived[0], c"6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba", 32)
+    fill_from_hex(@derived[0], "6f2615a108c702c5678f54fc9dbab69716c076189c48250cebeac3576c3611ba", 32)
 
     var shared_secret: [32]u8
-    fill_from_hex(@shared_secret[0], c"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
+    fill_from_hex(@shared_secret[0], "8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
 
     var handshake_secret: [32]u8
     tls13_handshake_secret(@derived[0], @shared_secret[0], 32, @handshake_secret[0])
 
     # RFC 8448: handshake_secret = 1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac
-    let expected: *u8 = c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"
+    let expected: *u8 = "1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac".as_ptr()
     if bytes_eq_hex(@handshake_secret[0], expected, 32) != 1
-        # print_hex(c"got handshake_secret", @handshake_secret[0], 32)
+        # print_hex("got handshake_secret", @handshake_secret[0], 32)
         return 1
     0
 
@@ -289,19 +289,19 @@ fn test_rfc8448_client_handshake_traffic_secret() -> i32
     # 860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8
 
     var hs_secret: [32]u8
-    fill_from_hex(@hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
+    fill_from_hex(@hs_secret[0], "1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
 
     var transcript_hash: [32]u8
-    fill_from_hex(@transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
+    fill_from_hex(@transcript_hash[0], "860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
 
     var c_hs_traffic: [32]u8
     # Use transcript hash directly as context (it's already hashed)
-    hkdf_expand_label(@hs_secret[0], c"c hs traffic", 12, @transcript_hash[0], 32, @c_hs_traffic[0], 32)
+    hkdf_expand_label(@hs_secret[0], "c hs traffic", 12, @transcript_hash[0], 32, @c_hs_traffic[0], 32)
 
     # RFC 8448: b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21
-    let expected: *u8 = c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"
+    let expected: *u8 = "b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21".as_ptr()
     if bytes_eq_hex(@c_hs_traffic[0], expected, 32) != 1
-        # print_hex(c"got c_hs_traffic", @c_hs_traffic[0], 32)
+        # print_hex("got c_hs_traffic", @c_hs_traffic[0], 32)
         return 1
     0
 
@@ -310,18 +310,18 @@ fn test_rfc8448_server_handshake_traffic_secret() -> i32
     # s_hs_traffic = Derive-Secret(handshake_secret, "s hs traffic", ClientHello...ServerHello)
 
     var hs_secret: [32]u8
-    fill_from_hex(@hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
+    fill_from_hex(@hs_secret[0], "1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
 
     var transcript_hash: [32]u8
-    fill_from_hex(@transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
+    fill_from_hex(@transcript_hash[0], "860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
 
     var s_hs_traffic: [32]u8
-    hkdf_expand_label(@hs_secret[0], c"s hs traffic", 12, @transcript_hash[0], 32, @s_hs_traffic[0], 32)
+    hkdf_expand_label(@hs_secret[0], "s hs traffic", 12, @transcript_hash[0], 32, @s_hs_traffic[0], 32)
 
     # RFC 8448: b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38
-    let expected: *u8 = c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"
+    let expected: *u8 = "b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38".as_ptr()
     if bytes_eq_hex(@s_hs_traffic[0], expected, 32) != 1
-        # print_hex(c"got s_hs_traffic", @s_hs_traffic[0], 32)
+        # print_hex("got s_hs_traffic", @s_hs_traffic[0], 32)
         return 1
     0
 
@@ -332,27 +332,27 @@ fn test_rfc8448_traffic_key_derivation() -> i32
     # iv = HKDF-Expand-Label(Secret, "iv", "", iv_length)
 
     var c_hs_traffic: [32]u8
-    fill_from_hex(@c_hs_traffic[0], c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21", 32)
+    fill_from_hex(@c_hs_traffic[0], "b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21", 32)
 
     var key: [16]u8  # AES-128 key length
     var iv: [12]u8   # GCM IV length
 
-    hkdf_expand_label(@c_hs_traffic[0], c"key", 3, null, 0, @key[0], 16)
-    hkdf_expand_label(@c_hs_traffic[0], c"iv", 2, null, 0, @iv[0], 12)
+    hkdf_expand_label(@c_hs_traffic[0], "key", 3, null, 0, @key[0], 16)
+    hkdf_expand_label(@c_hs_traffic[0], "iv", 2, null, 0, @iv[0], 12)
 
     # RFC 8448:
     # client_handshake_key: dbfaa693d1762c5b666af5d950258d01
     # client_handshake_iv: 5bd3c71b836e0b76bb73265f
 
-    let expected_key: *u8 = c"dbfaa693d1762c5b666af5d950258d01"
-    let expected_iv: *u8 = c"5bd3c71b836e0b76bb73265f"
+    let expected_key: *u8 = "dbfaa693d1762c5b666af5d950258d01".as_ptr()
+    let expected_iv: *u8 = "5bd3c71b836e0b76bb73265f".as_ptr()
 
     if bytes_eq_hex(@key[0], expected_key, 16) != 1
-        # print_hex(c"got key", @key[0], 16)
+        # print_hex("got key", @key[0], 16)
         return 1
 
     if bytes_eq_hex(@iv[0], expected_iv, 12) != 1
-        # print_hex(c"got iv", @iv[0], 12)
+        # print_hex("got iv", @iv[0], 12)
         return 2
     0
 
@@ -361,27 +361,27 @@ fn test_rfc8448_server_traffic_key_derivation() -> i32
     # From server_handshake_traffic_secret, derive key and IV
 
     var s_hs_traffic: [32]u8
-    fill_from_hex(@s_hs_traffic[0], c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38", 32)
+    fill_from_hex(@s_hs_traffic[0], "b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38", 32)
 
     var key: [16]u8
     var iv: [12]u8
 
-    hkdf_expand_label(@s_hs_traffic[0], c"key", 3, null, 0, @key[0], 16)
-    hkdf_expand_label(@s_hs_traffic[0], c"iv", 2, null, 0, @iv[0], 12)
+    hkdf_expand_label(@s_hs_traffic[0], "key", 3, null, 0, @key[0], 16)
+    hkdf_expand_label(@s_hs_traffic[0], "iv", 2, null, 0, @iv[0], 12)
 
     # RFC 8448:
     # server_handshake_key: 3fce516009c21727d0f2e4e86ee403bc
     # server_handshake_iv: 5d313eb2671276ee13000b30
 
-    let expected_key: *u8 = c"3fce516009c21727d0f2e4e86ee403bc"
-    let expected_iv: *u8 = c"5d313eb2671276ee13000b30"
+    let expected_key: *u8 = "3fce516009c21727d0f2e4e86ee403bc".as_ptr()
+    let expected_iv: *u8 = "5d313eb2671276ee13000b30".as_ptr()
 
     if bytes_eq_hex(@key[0], expected_key, 16) != 1
-        # print_hex(c"got key", @key[0], 16)
+        # print_hex("got key", @key[0], 16)
         return 1
 
     if bytes_eq_hex(@iv[0], expected_iv, 12) != 1
-        # print_hex(c"got iv", @iv[0], 12)
+        # print_hex("got iv", @iv[0], 12)
         return 2
     0
 
@@ -391,18 +391,18 @@ fn test_rfc8448_master_secret() -> i32
     # derived_from_hs = Derive-Secret(handshake_secret, "derived", "")
 
     var hs_secret: [32]u8
-    fill_from_hex(@hs_secret[0], c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
+    fill_from_hex(@hs_secret[0], "1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac", 32)
 
     var derived: [32]u8
-    derive_secret(@hs_secret[0], c"derived", 7, null, 0, @derived[0])
+    derive_secret(@hs_secret[0], "derived", 7, null, 0, @derived[0])
 
     var master_secret: [32]u8
     tls13_master_secret(@derived[0], @master_secret[0])
 
     # RFC 8448: master_secret = 18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919
-    let expected: *u8 = c"18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919"
+    let expected: *u8 = "18df06843d13a08bf2a449844c5f8a478001bc4d4c627984d5a41da8d0402919".as_ptr()
     if bytes_eq_hex(@master_secret[0], expected, 32) != 1
-        # print_hex(c"got master_secret", @master_secret[0], 32)
+        # print_hex("got master_secret", @master_secret[0], 32)
         return 1
     0
 
@@ -418,36 +418,36 @@ fn test_tls13_key_schedule_full() -> i32
     tls13_key_schedule_init(@ks)
 
     # Verify early secret
-    let expected_early: *u8 = c"33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a"
+    let expected_early: *u8 = "33ad0a1c607ec03b09e6cd9893680ce210adf300aa1f2660e1b22e10f170f92a".as_ptr()
     if bytes_eq_hex(@ks.early_secret[0], expected_early, 32) != 1
-        # print_hex(c"early_secret mismatch", @ks.early_secret[0], 32)
+        # print_hex("early_secret mismatch", @ks.early_secret[0], 32)
         return 1
 
     # Advance to handshake with shared secret
     var shared_secret: [32]u8
-    fill_from_hex(@shared_secret[0], c"8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
+    fill_from_hex(@shared_secret[0], "8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d", 32)
 
     var transcript_hash: [32]u8
-    fill_from_hex(@transcript_hash[0], c"860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
+    fill_from_hex(@transcript_hash[0], "860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8", 32)
 
     tls13_key_schedule_derive_handshake(@ks, @shared_secret[0], 32, @transcript_hash[0])
 
     # Verify handshake secret
-    let expected_hs: *u8 = c"1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac"
+    let expected_hs: *u8 = "1dc826e93606aa6fdc0aadc12f741b01046aa6b99f691ed221a9f0ca043fbeac".as_ptr()
     if bytes_eq_hex(@ks.handshake_secret[0], expected_hs, 32) != 1
-        # print_hex(c"handshake_secret mismatch", @ks.handshake_secret[0], 32)
+        # print_hex("handshake_secret mismatch", @ks.handshake_secret[0], 32)
         return 2
 
     # Verify client handshake traffic secret
-    let expected_c_hs: *u8 = c"b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21"
+    let expected_c_hs: *u8 = "b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21".as_ptr()
     if bytes_eq_hex(@ks.client_handshake_traffic_secret[0], expected_c_hs, 32) != 1
-        # print_hex(c"c_hs_traffic mismatch", @ks.client_handshake_traffic_secret[0], 32)
+        # print_hex("c_hs_traffic mismatch", @ks.client_handshake_traffic_secret[0], 32)
         return 3
 
     # Verify server handshake traffic secret
-    let expected_s_hs: *u8 = c"b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38"
+    let expected_s_hs: *u8 = "b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38".as_ptr()
     if bytes_eq_hex(@ks.server_handshake_traffic_secret[0], expected_s_hs, 32) != 1
-        # print_hex(c"s_hs_traffic mismatch", @ks.server_handshake_traffic_secret[0], 32)
+        # print_hex("s_hs_traffic mismatch", @ks.server_handshake_traffic_secret[0], 32)
         return 4
 
     0

--- a/projects/cryptosec/test/test_tls13_record.ritz
+++ b/projects/cryptosec/test/test_tls13_record.ritz
@@ -58,7 +58,7 @@ fn fill_from_hex(out: *u8, hex: *u8, len: i32)
 
 fn print_hex_bytes(data: *u8, len: i32)
     var i: i32 = 0
-    let hex_chars: *u8 = c"0123456789abcdef"
+    let hex_chars: *u8 = "0123456789abcdef".as_ptr()
     var buf: [2]u8
     while i < len
         let b: u8 = data[i]
@@ -66,7 +66,7 @@ fn print_hex_bytes(data: *u8, len: i32)
         buf[1] = hex_chars[(b & 0x0f) as i64]
         sys_write(1, @buf[0], 2)
         i += 1
-    println(c"")
+    println("")
 
 # ============================================================================
 # Nonce construction tests
@@ -78,7 +78,7 @@ fn test_tls13_nonce_construction() -> i32
     # sequence number is 64-bit, IV is 12 bytes
     # pad sequence number to 12 bytes (left-pad with zeros), then XOR
     var iv: [12]u8
-    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@iv[0], "5bd3c71b836e0b76bb73265f", 12)
 
     var nonce: [12]u8
     tls13_compute_nonce(@iv[0], 0, @nonce[0])
@@ -201,8 +201,8 @@ fn test_tls13_record_encrypt_decrypt_roundtrip() -> i32
     # Encrypt and decrypt a simple message
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], "dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], "5bd3c71b836e0b76bb73265f", 12)
 
     var plaintext: [5]u8
     plaintext[0] = 72   # 'H'
@@ -235,8 +235,8 @@ fn test_tls13_record_sequence_number_increment() -> i32
     # Verify that different sequence numbers produce different ciphertext
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], "dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], "5bd3c71b836e0b76bb73265f", 12)
 
     var plaintext: [4]u8
     plaintext[0] = 116  # 't'
@@ -279,8 +279,8 @@ fn test_tls13_record_tamper_detection() -> i32
     # Verify that tampering with ciphertext causes decryption to fail
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], "dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], "5bd3c71b836e0b76bb73265f", 12)
 
     var plaintext: [4]u8
     plaintext[0] = 65  # 'A'
@@ -316,8 +316,8 @@ fn test_rfc8448_client_handshake_record_decrypt() -> i32
     # client_handshake_iv: 5bd3c71b836e0b76bb73265f
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(@key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(@iv[0], c"5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@key[0], "dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@iv[0], "5bd3c71b836e0b76bb73265f", 12)
 
     # The encrypted Finished message (from RFC 8448)
     # This includes the TLS record header
@@ -361,8 +361,8 @@ fn test_tls13_record_empty_padding() -> i32
     # Test minimal padding (just content type byte)
     var key: [16]u8
     var iv: [12]u8
-    fill_from_hex(@key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
-    fill_from_hex(@iv[0], c"5d313eb2671276ee13000b30", 12)
+    fill_from_hex(@key[0], "3fce516009c21727d0f2e4e86ee403bc", 16)
+    fill_from_hex(@iv[0], "5d313eb2671276ee13000b30", 12)
 
     var plaintext: [1]u8
     plaintext[0] = 42
@@ -410,10 +410,10 @@ fn test_tls_record_state_set_keys() -> i32
     var server_key: [16]u8
     var server_iv: [12]u8
 
-    fill_from_hex(@client_key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(@client_iv[0], c"5bd3c71b836e0b76bb73265f", 12)
-    fill_from_hex(@server_key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
-    fill_from_hex(@server_iv[0], c"5d313eb2671276ee13000b30", 12)
+    fill_from_hex(@client_key[0], "dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@client_iv[0], "5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@server_key[0], "3fce516009c21727d0f2e4e86ee403bc", 16)
+    fill_from_hex(@server_iv[0], "5d313eb2671276ee13000b30", 12)
 
     tls_record_state_set_keys(@state, @client_key[0], @client_iv[0], @server_key[0], @server_iv[0], 16)
 
@@ -435,10 +435,10 @@ fn test_tls_record_state_encrypt_decrypt() -> i32
     var server_key: [16]u8
     var server_iv: [12]u8
 
-    fill_from_hex(@client_key[0], c"dbfaa693d1762c5b666af5d950258d01", 16)
-    fill_from_hex(@client_iv[0], c"5bd3c71b836e0b76bb73265f", 12)
-    fill_from_hex(@server_key[0], c"3fce516009c21727d0f2e4e86ee403bc", 16)
-    fill_from_hex(@server_iv[0], c"5d313eb2671276ee13000b30", 12)
+    fill_from_hex(@client_key[0], "dbfaa693d1762c5b666af5d950258d01", 16)
+    fill_from_hex(@client_iv[0], "5bd3c71b836e0b76bb73265f", 12)
+    fill_from_hex(@server_key[0], "3fce516009c21727d0f2e4e86ee403bc", 16)
+    fill_from_hex(@server_iv[0], "5d313eb2671276ee13000b30", 12)
 
     tls_record_state_set_keys(@state, @client_key[0], @client_iv[0], @server_key[0], @server_iv[0], 16)
 

--- a/projects/cryptosec/test/test_x509_verify.ritz
+++ b/projects/cryptosec/test/test_x509_verify.ritz
@@ -120,7 +120,7 @@ fn test_hostname_match_exact()
     cn[9] = 0x6f  # 'o'
     cn[10] = 0x6d # 'm'
 
-    let hostname: *u8 = c"example.com"
+    let hostname: *u8 = "example.com".as_ptr()
 
     let result: i32 = x509_hostname_match(@cn[0], 11, hostname, 11)
     assert result == 1
@@ -140,7 +140,7 @@ fn test_hostname_match_case_insensitive()
     cn[9] = 0x4f  # 'O'
     cn[10] = 0x4d # 'M'
 
-    let hostname: *u8 = c"example.com"
+    let hostname: *u8 = "example.com".as_ptr()
 
     let result: i32 = x509_hostname_match(@cn[0], 11, hostname, 11)
     assert result == 1
@@ -163,7 +163,7 @@ fn test_hostname_wildcard_simple()
     cn[11] = 0x6f # 'o'
     cn[12] = 0x6d # 'm'
 
-    let hostname: *u8 = c"www.example.com"
+    let hostname: *u8 = "www.example.com".as_ptr()
 
     let result: i32 = x509_hostname_match(@cn[0], 13, hostname, 15)
     assert result == 1
@@ -186,7 +186,7 @@ fn test_hostname_wildcard_no_match_root()
     cn[11] = 0x6f # 'o'
     cn[12] = 0x6d # 'm'
 
-    let hostname: *u8 = c"example.com"
+    let hostname: *u8 = "example.com".as_ptr()
 
     let result: i32 = x509_hostname_match(@cn[0], 13, hostname, 11)
     assert result == 0
@@ -202,7 +202,7 @@ fn test_hostname_mismatch()
     cn[5] = 0x6f  # 'o'
     cn[6] = 0x6d  # 'm'
 
-    let hostname: *u8 = c"bar.com"
+    let hostname: *u8 = "bar.com".as_ptr()
 
     let result: i32 = x509_hostname_match(@cn[0], 7, hostname, 7)
     assert result == 0

--- a/projects/larb/tools/migrate_cstr.py
+++ b/projects/larb/tools/migrate_cstr.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+RFC String API Migration Tool
+
+Migrates Ritz code from C-style strings to idiomatic StrView/String usage.
+
+Transformations:
+1. c"string" -> "string" (when used with StrView APIs)
+2. c"string" -> "string".as_ptr() (when passed to *u8 functions)
+3. streq(a, b) -> strview_eq(@a, @b) (when args are StrView)
+
+Usage:
+    python migrate_cstr.py path/to/file.ritz        # Preview changes
+    python migrate_cstr.py path/to/file.ritz --apply # Apply changes
+    python migrate_cstr.py path/to/dir/ --apply      # Migrate directory
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+# Functions that take *u8 and need .as_ptr()
+PTR_FUNCTIONS = {
+    'sha256', 'sha256_update', 'sha512', 'sha512_update',
+    'hmac_sha256', 'hmac_sha256_init', 'hmac_sha512',
+    'aes_encrypt', 'aes_decrypt', 'aes_init',
+    'chacha20_encrypt', 'chacha20_init',
+    'hkdf_extract', 'hkdf_expand',
+    'memcpy', 'memset', 'memmove', 'memcmp', 'mem_eq',
+    'strlen', 'strcpy', 'strcat', 'strcmp', 'streq',
+    'hash_eq_hex',  # Helper in crypto tests
+    'write', 'read', 'open', 'print',  # syscalls
+    'puts', 'printf', 'sprintf',  # FFI
+}
+
+# Functions that take StrView - no transformation needed
+STRVIEW_FUNCTIONS = {
+    'strview_eq', 'strview_cmp', 'strview_contains',
+    'strview_starts_with', 'strview_ends_with',
+    'strview_find', 'strview_slice',
+}
+
+
+def find_cstring_literals(content: str) -> List[Tuple[int, int, str]]:
+    """Find all c"..." literals and return (start, end, value) tuples."""
+    # Match c"..." but NOT across newlines (single-line strings only)
+    # Handle escape sequences properly: \" within the string
+    pattern = re.compile(r'c"(?:[^"\\\n]|\\.)*"')
+    matches = []
+    for m in pattern.finditer(content):
+        matches.append((m.start(), m.end(), m.group()))
+    return matches
+
+
+def get_function_context(content: str, pos: int) -> str:
+    """Get the function name that this literal is being passed to."""
+    # Look backwards for function call pattern: name(
+    before = content[:pos]
+    # Find the most recent '(' before our position
+    paren_pos = before.rfind('(')
+    if paren_pos == -1:
+        return None
+
+    # Extract potential function name (alphanumeric before the paren)
+    name_end = paren_pos
+    name_start = name_end - 1
+    while name_start >= 0 and (before[name_start].isalnum() or before[name_start] == '_'):
+        name_start -= 1
+    name_start += 1
+
+    if name_start < name_end:
+        return before[name_start:name_end]
+    return None
+
+
+def needs_as_ptr(content: str, pos: int) -> bool:
+    """Check if the c"..." at pos needs .as_ptr() transformation."""
+    func = get_function_context(content, pos)
+    if func and func in PTR_FUNCTIONS:
+        return True
+
+    # Check for assignment to *u8 variable
+    # Pattern: let x: *u8 = c"..."
+    line_start = content.rfind('\n', 0, pos) + 1
+    line = content[line_start:pos]
+    if '*u8' in line and '=' in line:
+        return True
+
+    return False
+
+
+def migrate_file(filepath: Path, apply: bool = False) -> Tuple[str, List[str]]:
+    """Migrate a single file. Returns (new_content, changes)."""
+    content = filepath.read_text()
+    changes = []
+
+    # Find all c"..." literals
+    literals = find_cstring_literals(content)
+
+    if not literals:
+        return content, []
+
+    # Process in reverse order to preserve positions
+    new_content = content
+    for start, end, literal in reversed(literals):
+        # Extract the string value without c prefix
+        string_value = literal[1:]  # Remove 'c' prefix
+
+        if needs_as_ptr(content, start):
+            # Transform to "string".as_ptr()
+            replacement = f'{string_value}.as_ptr()'
+            change = f'  {literal} -> {replacement}'
+        else:
+            # Just remove the c prefix
+            replacement = string_value
+            change = f'  {literal} -> {replacement}'
+
+        changes.append(change)
+        new_content = new_content[:start] + replacement + new_content[end:]
+
+    if apply and changes:
+        filepath.write_text(new_content)
+
+    return new_content, changes
+
+
+def migrate_directory(dirpath: Path, apply: bool = False) -> dict:
+    """Migrate all .ritz files in a directory."""
+    results = {}
+    for filepath in sorted(dirpath.rglob('*.ritz')):
+        _, changes = migrate_file(filepath, apply)
+        if changes:
+            results[filepath] = changes
+    return results
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    target = Path(sys.argv[1])
+    apply = '--apply' in sys.argv
+
+    if target.is_file():
+        new_content, changes = migrate_file(target, apply)
+        if changes:
+            print(f"{'Applied' if apply else 'Would apply'} changes to {target}:")
+            for c in changes:
+                print(c)
+            if not apply:
+                print(f"\nRun with --apply to apply changes")
+        else:
+            print(f"No c\"...\" literals found in {target}")
+
+    elif target.is_dir():
+        results = migrate_directory(target, apply)
+        if results:
+            total = sum(len(c) for c in results.values())
+            print(f"{'Applied' if apply else 'Would apply'} {total} changes across {len(results)} files:")
+            for filepath, changes in results.items():
+                print(f"\n{filepath}:")
+                for c in changes:
+                    print(c)
+            if not apply:
+                print(f"\nRun with --apply to apply changes")
+        else:
+            print(f"No c\"...\" literals found in {target}")
+
+    else:
+        print(f"Error: {target} not found")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/projects/ritz/ritzlib/strview.ritz
+++ b/projects/ritz/ritzlib/strview.ritz
@@ -127,6 +127,50 @@ pub fn strview_eq_cstr(s: @StrView, cstr: *u8) -> i32
         return 0
     return 1
 
+# Lexicographic comparison of two StrViews
+# Returns: -1 if a < b, 0 if a == b, 1 if a > b
+pub fn strview_cmp(a: @StrView, b: @StrView) -> i32
+    # Compare byte by byte up to the shorter length
+    var min_len: i64 = a.len
+    if b.len < min_len
+        min_len = b.len
+
+    for i in 0..min_len
+        let ca: u8 = *(a.ptr + i)
+        let cb: u8 = *(b.ptr + i)
+        if ca < cb
+            return -1
+        if ca > cb
+            return 1
+
+    # All compared bytes are equal, shorter string is "less than"
+    if a.len < b.len
+        return -1
+    if a.len > b.len
+        return 1
+    return 0
+
+# Lexicographic comparison of StrView to C string (for FFI interop)
+# Returns: -1 if s < cstr, 0 if s == cstr, 1 if s > cstr
+pub fn strview_cmp_cstr(s: @StrView, cstr: *u8) -> i32
+    var i: i64 = 0
+    while i < s.len
+        let cc: u8 = *(cstr + i)
+        if cc == 0
+            # cstr ended early, s is longer -> s > cstr
+            return 1
+        let cs: u8 = *(s.ptr + i)
+        if cs < cc
+            return -1
+        if cs > cc
+            return 1
+        i += 1
+    # All s bytes matched, check if cstr has more
+    if *(cstr + i) != 0
+        # cstr is longer -> s < cstr
+        return -1
+    return 0
+
 # ============================================================================
 # Slicing (creates new views, no allocation)
 # ============================================================================
@@ -365,6 +409,13 @@ impl StrView
 
     fn eq_cstr(self: @StrView, cstr: *u8) -> i32
         return strview_eq_cstr(self, cstr)
+
+    # Lexicographic comparison (-1, 0, 1)
+    fn cmp(self: @StrView, other: @StrView) -> i32
+        return strview_cmp(self, other)
+
+    fn cmp_cstr(self: @StrView, cstr: *u8) -> i32
+        return strview_cmp_cstr(self, cstr)
 
     # Convert to owned C string (allocates, caller must free())
     fn to_cstr(self: @StrView) -> *u8

--- a/projects/ritz/ritzlib/tests/test_strview.ritz
+++ b/projects/ritz/ritzlib/tests/test_strview.ritz
@@ -51,6 +51,83 @@ fn test_strview_eq_cstr() -> i32
     assert strview_eq_cstr(@s, c"hello!") == 0  # Longer
     0
 
+[[test]]
+fn test_strview_cmp() -> i32
+    let a: StrView = strview_from_cstr(c"apple")
+    let b: StrView = strview_from_cstr(c"banana")
+    let c: StrView = strview_from_cstr(c"apple")
+    let d: StrView = strview_from_cstr(c"app")
+    let e: StrView = strview_from_cstr(c"application")
+
+    # apple < banana
+    assert strview_cmp(@a, @b) == -1
+
+    # banana > apple
+    assert strview_cmp(@b, @a) == 1
+
+    # apple == apple
+    assert strview_cmp(@a, @c) == 0
+
+    # apple > app (longer)
+    assert strview_cmp(@a, @d) == 1
+
+    # apple < application (shorter prefix)
+    assert strview_cmp(@a, @e) == -1
+
+    0
+
+[[test]]
+fn test_strview_cmp_cstr() -> i32
+    let s: StrView = strview_from_cstr(c"hello")
+
+    # hello == hello
+    assert strview_cmp_cstr(@s, c"hello") == 0
+
+    # hello > hella (o > a)
+    assert strview_cmp_cstr(@s, c"hella") == 1
+
+    # hello < hellp (o < p)
+    assert strview_cmp_cstr(@s, c"hellp") == -1
+
+    # hello > hell (longer)
+    assert strview_cmp_cstr(@s, c"hell") == 1
+
+    # hello < hello! (shorter)
+    assert strview_cmp_cstr(@s, c"hello!") == -1
+
+    0
+
+[[test]]
+fn test_strview_cmp_empty() -> i32
+    let empty: StrView = strview_empty()
+    let nonempty: StrView = strview_from_cstr(c"x")
+
+    # empty < anything
+    assert strview_cmp(@empty, @nonempty) == -1
+
+    # anything > empty
+    assert strview_cmp(@nonempty, @empty) == 1
+
+    # empty == empty
+    let empty2: StrView = strview_empty()
+    assert strview_cmp(@empty, @empty2) == 0
+
+    0
+
+[[test]]
+fn test_strview_cmp_method() -> i32
+    let a: StrView = strview_from_cstr(c"abc")
+    let b: StrView = strview_from_cstr(c"abd")
+
+    # Test method syntax
+    assert a.cmp(@b) == -1
+    assert b.cmp(@a) == 1
+    assert a.cmp(@a) == 0
+    assert a.cmp_cstr(c"abc") == 0
+    assert a.cmp_cstr(c"abd") == -1
+
+    0
+
 # ============================================================================
 # Slicing tests
 # ============================================================================


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of [RFC_STRING_API_MIGRATION.md](https://github.com/ritz-lang/rz/blob/main/projects/larb/docs/RFC_STRING_API_MIGRATION.md) for the cryptosec project.

### Changes

**ritzlib additions:**
- Add `strview_cmp()` for lexicographic comparison (-1, 0, 1)
- Add `strview_cmp_cstr()` for StrView vs C string comparison
- Add method syntax: `.cmp()` and `.cmp_cstr()`
- Add comprehensive tests for new comparison functions

**cryptosec migration (270 literals):**
- Migrate `c"..."` literals to `"..."` or `"...".as_ptr()` where needed
- Add idiomatic StrView wrapper APIs for all major functions:
  - `sha256_str()`, `sha512_str()`, `sha384_str()`
  - `hmac_sha256_str()`, `hmac_sha512_str()`, `hmac_sha384_str()`
  - `hkdf_extract_str()`, `hkdf_expand_str()`, `hkdf_sha256_str()`

**Migration tooling:**
- Add `projects/larb/tools/migrate_cstr.py` for automated `c"..."` migration
- Script detects FFI boundaries and adds `.as_ptr()` where needed

### Design Notes

Per RFC guidance, the low-level `*u8` APIs are **kept** for FFI/byte buffer operations. The new `_str()` suffix APIs provide the idiomatic Ritz interface with `StrView`:

```ritz
# Before (C-style)
sha256(c"hello", 5, @hash[0])

# After (idiomatic Ritz)
sha256_str(@"hello", @hash[0])
```

### Test plan

- [x] ritzlib strview tests pass (25 tests including new cmp tests)
- [ ] cryptosec tests need Issue #48 fix for cross-project testing
- [x] Migration script tested and working

### Related

- Implements: RFC_STRING_API_MIGRATION.md (Phase 1)
- Blocked by: #48 (cross-project test runner)
- Next: Phase 2 - valet, squeeze, other projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)