### PR TITLE
RERITZ-audit: Update tests and docs to approved syntax

### DIFF
--- a/projects/larb/docs/GRAMMAR_SPEC.md
+++ b/projects/larb/docs/GRAMMAR_SPEC.md
@@ -45,12 +45,12 @@ The following identifiers are reserved keywords:
 
 | | | | | |
 |---|---|---|---|---|
-| `as` | `assert` | `break` | `const` | `continue` |
-| `else` | `enum` | `extern` | `false` | `fn` |
-| `for` | `if` | `impl` | `import` | `in` |
-| `let` | `match` | `mut` | `null` | `pub` |
-| `return` | `struct` | `trait` | `true` | `type` |
-| `unsafe` | `var` | `while` | | |
+| `and` | `as` | `assert` | `break` | `const` |
+| `continue` | `else` | `enum` | `extern` | `false` |
+| `fn` | `for` | `if` | `impl` | `import` |
+| `in` | `let` | `match` | `not` | `null` |
+| `or` | `pub` | `return` | `struct` | `trait` |
+| `true` | `type` | `unsafe` | `var` | `while` |
 
 ### 1.4 Primitive Type Keywords
 
@@ -106,8 +106,8 @@ escape_seq  = '\' ( 'n' | 'r' | 't' | '\' | '"' | "'" | '0' | 'x' hex_digit hex_
 | `FAT_ARROW` | `=>` | Match arm |
 | `DOT_DOT` | `..` | Range |
 | `COLON_COLON` | `::` | Path separator |
-| `AND` | `&&` | Logical AND |
-| `OR` | `\|\|` | Logical OR |
+| `AND` | `and` | Logical AND (keyword) |
+| `OR` | `or` | Logical OR (keyword) |
 | `EQ` | `==` | Equality |
 | `NE` | `!=` | Inequality |
 | `LE` | `<=` | Less or equal |
@@ -118,7 +118,7 @@ escape_seq  = '\' ( 'n' | 'r' | 't' | '\' | '"' | "'" | '0' | 'x' hex_digit hex_
 | `MINUS_EQ` | `-=` | Subtract-assign |
 | `STAR_EQ` | `*=` | Multiply-assign |
 | `SLASH_EQ` | `/=` | Divide-assign |
-| `AMP_MUT` | `&mut` | Mutable reference |
+| `AT_AMP` | `@&` | Mutable reference |
 
 #### Single-character Operators
 
@@ -193,18 +193,24 @@ item = [ attrs ] fn_def
 ```ebnf
 attrs = attr { attr }
 
-attr = '@' IDENT [ NEWLINE ]
+attr = '[[' IDENT [ '(' attr_args ')' ] ']]' [ NEWLINE ]
+attr_args = IDENT { ',' IDENT }
 ```
 
 **Examples:**
 ```ritz
-@test
+[[test]]
 fn test_something()
     assert 1 == 1
 
-@inline
+[[inline]]
 fn fast_add(a: i32, b: i32) -> i32
     return a + b
+
+[[derive(Debug, Clone)]]
+struct Point
+    x: i32
+    y: i32
 ```
 
 ### 2.3 Functions
@@ -359,10 +365,9 @@ var buffer: [1024]u8
 ```ebnf
 type = primitive_type
      | type_name
-     | '*' type                    (* pointer *)
-     | '*' 'mut' type              (* mutable pointer *)
-     | '&' type                    (* reference *)
-     | '&mut' type                 (* mutable reference *)
+     | '*' type                    (* raw pointer - FFI/unsafe only *)
+     | '@' type                    (* immutable reference *)
+     | '@&' type                   (* mutable reference *)
      | '[' NUMBER ']' type         (* fixed array *)
      | '[' ']' type                (* slice *)
      | type '|' type               (* union type *)
@@ -380,10 +385,9 @@ primitive_type = 'i8' | 'i16' | 'i32' | 'i64'
 **Type Examples:**
 ```ritz
 i32                     # 32-bit signed integer
-*u8                     # pointer to byte
-*mut Node               # mutable pointer to Node
-&Point                  # reference to Point
-&mut i32                # mutable reference to i32
+*u8                     # raw pointer (FFI/unsafe only)
+@Point                  # immutable reference to Point
+@&i32                   # mutable reference to i32
 [16]u8                  # array of 16 bytes
 []i32                   # slice of i32
 Option<T>               # generic type
@@ -532,8 +536,8 @@ From lowest to highest precedence:
 
 | Level | Operators | Associativity | Description |
 |-------|-----------|---------------|-------------|
-| 1 | `\|\|` | Right | Logical OR |
-| 2 | `&&` | Right | Logical AND |
+| 1 | `or` | Right | Logical OR |
+| 2 | `and` | Right | Logical AND |
 | 3 | `==` `!=` `<` `<=` `>` `>=` | None | Comparison |
 | 4 | `\|` | Right | Bitwise OR |
 | 5 | `..` | None | Range |
@@ -543,7 +547,7 @@ From lowest to highest precedence:
 | 9 | `+` `-` | Right | Additive |
 | 10 | `*` `/` `%` | Right | Multiplicative |
 | 11 | `as` | Left | Type cast |
-| 12 | `-` `!` `~` `*` `&` `&mut` | Prefix | Unary |
+| 12 | `-` `not` `~` `*` `@` `@&` | Prefix | Unary |
 | 13 | `?` | Postfix | Try/propagate |
 | 14 | `()` `[]` `.` | Left | Postfix (call, index, field) |
 
@@ -552,8 +556,8 @@ From lowest to highest precedence:
 ```ebnf
 expr = or_expr
 
-or_expr = and_expr { '||' and_expr }
-and_expr = cmp_expr { '&&' cmp_expr }
+or_expr = and_expr { 'or' and_expr }
+and_expr = cmp_expr { 'and' cmp_expr }
 
 cmp_expr = bit_or_expr [ cmp_op bit_or_expr ]
 cmp_op = '==' | '!=' | '<' | '<=' | '>' | '>='
@@ -570,11 +574,11 @@ mul_expr = cast_expr { ( '*' | '/' | '%' ) cast_expr }
 cast_expr = unary_expr [ 'as' type ]
 
 unary_expr = '-' unary_expr
-           | '!' unary_expr
+           | 'not' unary_expr
            | '~' unary_expr
            | '*' unary_expr
-           | '&' unary_expr
-           | '&mut' unary_expr
+           | '@' unary_expr           (* address-of / immutable ref *)
+           | '@&' unary_expr          (* mutable reference *)
            | try_expr
 
 try_expr = postfix_expr [ '?' ]
@@ -626,8 +630,8 @@ block_expr = '{' stmts [ expr ] '}'
 1 + 2 * 3           # 7 (precedence)
 (1 + 2) * 3         # 9
 
-# Comparisons
-x == y && y > 0
+# Comparisons (using keyword operators)
+x == y and y > 0
 
 # Bitwise
 flags | MASK
@@ -640,10 +644,10 @@ count as i64
 
 # Unary
 -x
-!valid
+not valid
 *ptr
-&value
-&mut array[0]
+@value              # address-of / immutable reference
+@&array[0]          # mutable reference
 
 # Try operator
 file.read()?
@@ -737,10 +741,11 @@ type Result<T, E> = T | E
 
 | Syntax | Meaning | Can be null? | Arithmetic? |
 |--------|---------|--------------|-------------|
-| `&T` | Reference | No | No |
-| `&mut T` | Mutable reference | No | No |
-| `*T` | Pointer | Yes | Yes |
-| `*mut T` | Mutable pointer | Yes | Yes |
+| `@T` | Immutable reference | No | No |
+| `@&T` | Mutable reference | No | No |
+| `*T` | Raw pointer (FFI/unsafe only) | Yes | Yes |
+
+**Note:** Raw pointers (`*T`) are only for FFI and unsafe code. There is no `*mut` distinction - use `@&T` for mutable references in safe code.
 
 ---
 
@@ -754,7 +759,7 @@ item = [ attrs ] fn_def | struct_def | enum_def | const_def
 
 (* === Attributes === *)
 attrs = attr { attr } ;
-attr = '@' IDENT [ NEWLINE ] ;
+attr = '[[' IDENT [ '(' IDENT { ',' IDENT } ')' ] ']]' [ NEWLINE ] ;
 
 (* === Functions === *)
 fn_def = 'fn' IDENT [ generic_params ] '(' [ params ] ')' [ return_type ] block
@@ -792,7 +797,7 @@ global_var = 'var' IDENT ':' type [ '=' expr ] NEWLINE ;
 
 (* === Types === *)
 type = primitive_type | type_name
-     | '*' type | '*' 'mut' type | '&' type | '&mut' type
+     | '*' type | '@' type | '@&' type
      | '[' NUMBER ']' type | '[' ']' type
      | type '|' type | '(' type ')' ;
 type_name = IDENT [ '<' type { ',' type } '>' ] ;
@@ -824,8 +829,8 @@ expr_stmt = expr NEWLINE ;
 
 (* === Expressions === *)
 expr = or_expr ;
-or_expr = and_expr { '||' and_expr } ;
-and_expr = cmp_expr { '&&' cmp_expr } ;
+or_expr = and_expr { 'or' and_expr } ;
+and_expr = cmp_expr { 'and' cmp_expr } ;
 cmp_expr = bit_or_expr [ ( '==' | '!=' | '<' | '<=' | '>' | '>=' ) bit_or_expr ] ;
 bit_or_expr = range_expr { '|' range_expr } ;
 range_expr = bit_xor_expr [ '..' bit_xor_expr ] ;
@@ -835,7 +840,7 @@ shift_expr = add_expr { ( '<<' | '>>' ) add_expr } ;
 add_expr = mul_expr { ( '+' | '-' ) mul_expr } ;
 mul_expr = cast_expr { ( '*' | '/' | '%' ) cast_expr } ;
 cast_expr = unary_expr [ 'as' type ] ;
-unary_expr = ( '-' | '!' | '~' | '*' | '&' | '&mut' ) unary_expr | try_expr ;
+unary_expr = ( '-' | 'not' | '~' | '*' | '@' | '@&' ) unary_expr | try_expr ;
 try_expr = postfix_expr [ '?' ] ;
 postfix_expr = primary_expr { '(' [ expr { ',' expr } ] ')' | '[' expr ']' | '.' IDENT [ generic_args ] | '.' NUMBER } ;
 primary_expr = NUMBER | HEX_NUMBER | BIN_NUMBER | FLOAT | STRING | CSTRING | SPAN_STRING | CHAR

--- a/projects/ritz/examples/38_tee/src/main.ritz
+++ b/projects/ritz/examples/38_tee/src/main.ritz
@@ -53,19 +53,19 @@ fn write_all(fd: i32, buf: *u8, count: i64) -> i32
 fn main(argc: i32, argv: **u8) -> i32
     # Parse arguments
     var parser: ArgParser
-    args_init(&parser, "tee", "Copy standard input to each FILE, and also to standard output.")
-    args_flag(&parser, 'a', "append", "Append to the given FILEs, do not overwrite")
-    args_flag(&parser, 'h', "help", "Display this help and exit")
-    args_positional(&parser, "FILE", "Output file(s)", 0, 0 - 1)  # 0 to unlimited
+    args_init(@parser, "tee", "Copy standard input to each FILE, and also to standard output.")
+    args_flag(@parser, 'a', "append", "Append to the given FILEs, do not overwrite")
+    args_flag(@parser, 'h', "help", "Display this help and exit")
+    args_positional(@parser, "FILE", "Output file(s)", 0, 0 - 1)  # 0 to unlimited
 
-    if args_parse(&parser, argc, argv) != 0
+    if args_parse(@parser, argc, argv) != 0
         return 1
 
-    if args_get_flag(&parser, 'h') != 0
-        args_print_help(&parser)
+    if args_get_flag(@parser, 'h') != 0
+        args_print_help(@parser)
         return 0
 
-    let append_mode: i32 = args_get_flag(&parser, 'a')
+    let append_mode: i32 = args_get_flag(@parser, 'a')
 
     # Open output files
     var fds: [64]i32  # MAX_FILES
@@ -74,7 +74,7 @@ fn main(argc: i32, argv: **u8) -> i32
 
     var i: i32 = 0
     while i < parser.positional_count
-        let path: *u8 = args_get_positional(&parser, i)
+        let path: *u8 = args_get_positional(@parser, i)
 
         # Determine flags for open
         var flags: i32 = O_WRONLY | O_CREAT
@@ -100,7 +100,7 @@ fn main(argc: i32, argv: **u8) -> i32
         i = i + 1
 
     # Read from stdin, write to stdout and all files
-    var buf: *mut u8 = __builtin_alloca(BUF_SIZE)
+    var buf: *u8 = __builtin_alloca(BUF_SIZE)
 
     var done: i32 = 0
     while done == 0

--- a/projects/ritz/examples/tier1_basics/05_cat/src/main.ritz
+++ b/projects/ritz/examples/tier1_basics/05_cat/src/main.ritz
@@ -19,7 +19,7 @@ const BUF_SIZE: i64 = 4096
 
 # Cat a single file descriptor to stdout
 # Returns 0 on success, 1 on error
-fn cat_fd(fd: i32, buf: *mut u8) -> i32
+fn cat_fd(fd: i32, buf: *u8) -> i32
   var n: i64 = 1
 
   while n > 0
@@ -35,7 +35,7 @@ fn cat_fd(fd: i32, buf: *mut u8) -> i32
 
 fn main(argc: i32, argv: **u8) -> i32
   # Allocate buffer on stack
-  var buf: *mut u8 = __builtin_alloca(BUF_SIZE)
+  var buf: *u8 = __builtin_alloca(BUF_SIZE)
 
   # No args: read from stdin
   if argc == 1

--- a/projects/ritz/examples/tier4_applications/38_tee/src/main.ritz
+++ b/projects/ritz/examples/tier4_applications/38_tee/src/main.ritz
@@ -53,19 +53,19 @@ fn write_all(fd: i32, buf: *u8, count: i64) -> i32
 fn main(argc: i32, argv: **u8) -> i32
     # Parse arguments
     var parser: ArgParser
-    args_init(&parser, "tee", "Copy standard input to each FILE, and also to standard output.")
-    args_flag(&parser, 'a', "append", "Append to the given FILEs, do not overwrite")
-    args_flag(&parser, 'h', "help", "Display this help and exit")
-    args_positional(&parser, "FILE", "Output file(s)", 0, -1)  # 0 to unlimited
+    args_init(@parser, "tee", "Copy standard input to each FILE, and also to standard output.")
+    args_flag(@parser, 'a', "append", "Append to the given FILEs, do not overwrite")
+    args_flag(@parser, 'h', "help", "Display this help and exit")
+    args_positional(@parser, "FILE", "Output file(s)", 0, -1)  # 0 to unlimited
 
-    if args_parse(&parser, argc, argv) != 0
+    if args_parse(@parser, argc, argv) != 0
         return 1
 
-    if args_get_flag(&parser, 'h') != 0
-        args_print_help(&parser)
+    if args_get_flag(@parser, 'h') != 0
+        args_print_help(@parser)
         return 0
 
-    let append_mode: i32 = args_get_flag(&parser, 'a')
+    let append_mode: i32 = args_get_flag(@parser, 'a')
 
     # Open output files
     var fds: [64]i32  # MAX_FILES
@@ -73,7 +73,7 @@ fn main(argc: i32, argv: **u8) -> i32
     var exit_code: i32 = 0
 
     for i in 0..parser.positional_count
-        let path: *u8 = args_get_positional(&parser, i)
+        let path: *u8 = args_get_positional(@parser, i)
 
         # Determine flags for open
         var flags: i32 = O_WRONLY | O_CREAT
@@ -97,7 +97,7 @@ fn main(argc: i32, argv: **u8) -> i32
                 num_fds += 1
 
     # Read from stdin, write to stdout and all files
-    var buf: *mut u8 = __builtin_alloca(BUF_SIZE)
+    var buf: *u8 = __builtin_alloca(BUF_SIZE)
 
     var done: i32 = 0
     while done == 0

--- a/projects/ritz/test/dual_compiler/level3/02_struct_fn_param.ritz
+++ b/projects/ritz/test/dual_compiler/level3/02_struct_fn_param.ritz
@@ -12,4 +12,4 @@ fn main() -> i32
     var p: Point
     p.x = 20
     p.y = 22
-    sum_point(&p)
+    sum_point(@p)

--- a/projects/ritz/test/dual_compiler/level3/03_pointer_deref.ritz
+++ b/projects/ritz/test/dual_compiler/level3/03_pointer_deref.ritz
@@ -3,5 +3,5 @@
 
 fn main() -> i32
     var x: i32 = 42
-    var p: *i32 = &x
+    var p: *i32 = @x
     *p

--- a/projects/ritz/test/dual_compiler/level3/04_pointer_write.ritz
+++ b/projects/ritz/test/dual_compiler/level3/04_pointer_write.ritz
@@ -3,6 +3,6 @@
 
 fn main() -> i32
     var x: i32 = 0
-    var p: *i32 = &x
+    var p: *i32 = @x
     *p = 42
     x

--- a/projects/ritz/test/dual_compiler/level4/06_vec_import.ritz
+++ b/projects/ritz/test/dual_compiler/level4/06_vec_import.ritz
@@ -4,5 +4,5 @@ import ritzlib.memory
 
 fn main() -> i32
     var v: Vec<i32> = vec_new<i32>()
-    vec_push<i32>(&v, 42)
-    vec_get<i32>(&v, 0)
+    vec_push<i32>(@v, 42)
+    vec_get<i32>(@v, 0)

--- a/projects/ritz/test/features/test_dyn_trait.ritz
+++ b/projects/ritz/test/features/test_dyn_trait.ritz
@@ -35,8 +35,8 @@ fn main() -> i32
     var cat = Cat { lives: 9 }
     
     # Static dispatch (works today)
-    Dog_speak(&dog)
-    Cat_speak(&cat)
+    Dog_speak(@dog)
+    Cat_speak(@cat)
     
     prints("Static dispatch works!\n")
     0

--- a/projects/ritz/test/test_unsafe.ritz
+++ b/projects/ritz/test/test_unsafe.ritz
@@ -12,7 +12,7 @@ fn test_unsafe_block_basic() -> i32
     # Unsafe block allows raw pointer operations
     var x: i32 = 42
     unsafe
-        let ptr: *i32 = &x
+        let ptr: *i32 = @x
         let val: i32 = *ptr
         assert val == 42
     0
@@ -22,7 +22,7 @@ fn test_unsafe_block_write() -> i32
     # Unsafe block can write through pointers
     var x: i32 = 0
     unsafe
-        let ptr: *mut i32 = &x
+        let ptr: *i32 = @x
         *ptr = 99
     assert x == 99
     0
@@ -32,7 +32,7 @@ fn test_unsafe_nested() -> i32
     # Nested unsafe blocks (outer unsafe is sufficient)
     var x: i32 = 10
     unsafe
-        let ptr: *mut i32 = &x
+        let ptr: *i32 = @x
         unsafe
             *ptr = 20
         assert *ptr == 20
@@ -46,7 +46,7 @@ fn test_unsafe_with_control_flow() -> i32
     var arr: [3]i32 = [1, 2, 3]
 
     unsafe
-        let ptr: *i32 = &arr[0]
+        let ptr: *i32 = @arr[0]
         var i: i32 = 0
         while i < 3
             # Pointer arithmetic in unsafe
@@ -60,7 +60,7 @@ fn test_unsafe_with_control_flow() -> i32
 # Unsafe with functions
 # ============================================================================
 
-fn unsafe_helper(ptr: *mut i32)
+fn unsafe_helper(ptr: *i32)
     # This function body is implicitly safe
     # We can receive pointers as params, just can't deref without unsafe
     unsafe
@@ -69,6 +69,6 @@ fn unsafe_helper(ptr: *mut i32)
 [[test]]
 fn test_unsafe_in_function() -> i32
     var x: i32 = 0
-    unsafe_helper(&x)
+    unsafe_helper(@x)
     assert x == 123
     0


### PR DESCRIPTION
## Summary
Migrate tests and documentation to follow DESIGN_DECISIONS.md conventions.

### Syntax Changes
| Old | New | Description |
|-----|-----|-------------|
| `*mut T` | `*T` | Raw pointers have no mut distinction |
| `&x` | `@x` | Address-of operator |
| `@test` | `[[test]]` | Attributes use double brackets |
| `&&`/`||`/`!` | `and`/`or`/`not` | Logical operators are keywords |
| `&T`/`&mut T` | `@T`/`@&T` | Reference types |

### Files Updated
- **GRAMMAR_SPEC.md**: Complete overhaul to match DESIGN_DECISIONS.md
- **test_unsafe.ritz**: Remove `*mut`, fix pointer syntax
- **38_tee examples**: Remove `*mut`, `&parser` → `@parser`
- **dual_compiler tests**: `&x` → `@x` for address-of
- **test_dyn_trait.ritz**: `&dog` → `@dog`

### String Types (clarified)
- `StrView` = measured strings (ptr + len), not null-terminated
- `Span<u8>` = raw byte sequences
- `c"string"` = null-terminated C strings for FFI

## Test plan
- [x] All modified test files compile with ritz0
- [x] GRAMMAR_SPEC.md syntax matches DESIGN_DECISIONS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)