### PR TITLE
examples: Purist audit - var to let where possible

### DIFF
--- a/projects/ritz/examples/tier1_basics/05_cat/src/main.ritz
+++ b/projects/ritz/examples/tier1_basics/05_cat/src/main.ritz
@@ -35,7 +35,7 @@ fn cat_fd(fd: i32, buf: *u8) -> i32
 
 fn main(argc: i32, argv: **u8) -> i32
   # Allocate buffer on stack
-  var buf: *u8 = __builtin_alloca(BUF_SIZE)
+  let buf: *u8 = __builtin_alloca(BUF_SIZE)
 
   # No args: read from stdin
   if argc == 1
@@ -45,7 +45,7 @@ fn main(argc: i32, argv: **u8) -> i32
   var i: i32 = 1
   while i < argc
     let path = argv[i]
-    var fd: i32 = sys_open(path, O_RDONLY)
+    let fd: i32 = sys_open(path, O_RDONLY)
 
     if fd < 0
       return 1

--- a/projects/ritz/examples/tier1_basics/06_head/src/main.ritz
+++ b/projects/ritz/examples/tier1_basics/06_head/src/main.ritz
@@ -13,7 +13,7 @@ const BUFSIZE: i64 = 4096
 # Print first n lines from fd
 fn head_fd(fd: i32, n: i32, buf: *u8) -> i32
   var lines: i32 = 0
-  var start: i64 = 0
+  let start: i64 = 0  # NOTE: This appears to be dead code - start is never assigned
 
   while lines < n
     let bytes_read: i64 = sys_read(fd, buf, BUFSIZE)

--- a/projects/ritz/examples/tier1_basics/10_sleep/src/main.ritz
+++ b/projects/ritz/examples/tier1_basics/10_sleep/src/main.ritz
@@ -53,8 +53,8 @@ fn parse_duration(s: *u8, out_sec: *i64, out_nsec: *i64) -> i32
 
 # Call nanosleep syscall with proper struct
 fn do_sleep(sec: i64, nsec: i64) -> i32
-  # Create a mutable TimeSpec struct to get its address
-  var ts: TimeSpec = TimeSpec { tv_sec: sec, tv_nsec: nsec }
+  # Create TimeSpec struct to get its address
+  let ts: TimeSpec = TimeSpec { tv_sec: sec, tv_nsec: nsec }
 
   # Get pointer to struct and call nanosleep
   let result: i32 = sys_nanosleep(&ts as *i64, null)


### PR DESCRIPTION
## Summary

Apply strict Ritz style guidelines to tier1 examples - every `var` that could be `let` is a moral failing.

### Changes:
- **05_cat**: `buf` and `fd` are never reassigned, changed to `let`
- **06_head**: `start` is never assigned (dead code warning added), changed to `let`  
- **10_sleep**: `ts` struct is never reassigned, changed to `let`

### Context

Part of ongoing RERITZ-audit to ensure examples follow purist Ritz conventions:
- ✅ No `&&`/`||`/`!` - all use `and`/`or`/`not`
- ✅ No `c""` string literals in tier1 basics
- ✅ `var` → `let` where appropriate (this PR)

Raw pointer usage (`*u8`, `**u8`) remains for bootstrap - these examples demonstrate low-level Linux programming and will be updated once `Args` iterator type is implemented in ritzlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)