### PR TITLE
Fix valet test failures and import resolution bugs

### DIFF
--- a/projects/ritz/ritz0/import_resolver.py
+++ b/projects/ritz/ritz0/import_resolver.py
@@ -196,6 +196,9 @@ class ImportResolver:
         For each directory in RITZ_PATH that has a ritz.toml, parse it and
         add the project as a dependency namespace. This allows imports like
         'squeeze.gzip' to resolve correctly when squeeze is in RITZ_PATH.
+
+        Also checks subdirectories of RITZ_PATH entries, so if RITZ_PATH
+        contains '/path/to/projects', we'll find '/path/to/projects/ritzunit'.
         """
         try:
             import tomllib
@@ -205,16 +208,15 @@ class ImportResolver:
             except ImportError:
                 return  # Can't parse TOML, skip auto-detection
 
-        for import_path in self.import_paths:
-            # Skip if already registered as a dependency
-            dep_name = import_path.name
+        def register_project(project_path: Path):
+            """Register a project from its path if it has ritz.toml."""
+            dep_name = project_path.name
             if dep_name in self.dependencies:
-                continue
+                return
 
-            # Check for ritz.toml
-            toml_path = import_path / "ritz.toml"
+            toml_path = project_path / "ritz.toml"
             if not toml_path.exists():
-                continue
+                return
 
             try:
                 with open(toml_path, "rb") as f:
@@ -234,11 +236,23 @@ class ImportResolver:
                 # Register as a dependency
                 self.dependencies[dep_name] = DependencyMapping(
                     name=dep_name,
-                    path=import_path,
+                    path=project_path,
                     sources=sources
                 )
             except Exception:
                 pass  # Skip on any error
+
+        for import_path in self.import_paths:
+            # First try the import_path itself
+            register_project(import_path)
+
+            # Also check subdirectories (for workspace-style RITZ_PATH entries)
+            # This handles the case where RITZ_PATH contains '/path/to/projects'
+            # and we want to find '/path/to/projects/ritzunit', etc.
+            if import_path.is_dir():
+                for subdir in import_path.iterdir():
+                    if subdir.is_dir():
+                        register_project(subdir)
 
     # ============================================================================
     # Export Map Building

--- a/projects/ritz/ritz0/test_runner.py
+++ b/projects/ritz/ritz0/test_runner.py
@@ -452,8 +452,7 @@ fn main() -> i32
 
         # Parse dependencies from ritz.toml if not provided
         if dependencies is None and project_root:
-            toml_path = project_root / "ritz.toml"
-            dependencies = parse_ritz_toml_dependencies(toml_path, project_root)
+            dependencies = parse_project_dependencies(project_root)
 
         try:
             source_files = collect_all_source_files(

--- a/projects/valet/tests/test_config.ritz
+++ b/projects/valet/tests/test_config.ritz
@@ -176,15 +176,100 @@ fn test_config_parse_json_preserves_defaults() -> i32
 # File Loading Tests
 # ============================================================================
 
+# Build a minimal valid config JSON for file loading test
+# {"server":{"port":8080},"limits":{"keepalive_requests":100}}
+fn build_test_config_json(buf: *u8) -> i64
+    # {"server":{"port":8080},"limits":{"keepalive_requests":100}}
+    buf[0] = 123   # {
+    buf[1] = 34    # "
+    buf[2] = 's'
+    buf[3] = 'e'
+    buf[4] = 'r'
+    buf[5] = 'v'
+    buf[6] = 'e'
+    buf[7] = 'r'
+    buf[8] = 34    # "
+    buf[9] = ':'
+    buf[10] = 123  # {
+    buf[11] = 34   # "
+    buf[12] = 'p'
+    buf[13] = 'o'
+    buf[14] = 'r'
+    buf[15] = 't'
+    buf[16] = 34   # "
+    buf[17] = ':'
+    buf[18] = '8'
+    buf[19] = '0'
+    buf[20] = '8'
+    buf[21] = '0'
+    buf[22] = 125  # }
+    buf[23] = ','
+    buf[24] = 34   # "
+    buf[25] = 'l'
+    buf[26] = 'i'
+    buf[27] = 'm'
+    buf[28] = 'i'
+    buf[29] = 't'
+    buf[30] = 's'
+    buf[31] = 34   # "
+    buf[32] = ':'
+    buf[33] = 123  # {
+    buf[34] = 34   # "
+    buf[35] = 'k'
+    buf[36] = 'e'
+    buf[37] = 'e'
+    buf[38] = 'p'
+    buf[39] = 'a'
+    buf[40] = 'l'
+    buf[41] = 'i'
+    buf[42] = 'v'
+    buf[43] = 'e'
+    buf[44] = '_'
+    buf[45] = 'r'
+    buf[46] = 'e'
+    buf[47] = 'q'
+    buf[48] = 'u'
+    buf[49] = 'e'
+    buf[50] = 's'
+    buf[51] = 't'
+    buf[52] = 's'
+    buf[53] = 34   # "
+    buf[54] = ':'
+    buf[55] = '1'
+    buf[56] = '0'
+    buf[57] = '0'
+    buf[58] = 125  # }
+    buf[59] = 125  # }
+    buf[60] = 0
+    return 60
+
 [[test]]
 fn test_config_load_from_file() -> i32
+    # Create a temp test file with known JSON content
+    var json_buf: [256]u8
+    let json_len: i64 = build_test_config_json(@json_buf[0])
+
+    # Write to temp file - O_WRONLY | O_CREAT | O_TRUNC = 577, mode 0644 = 420
+    let fd: i32 = sys_open3(c"/tmp/valet_test_config.json", 577, 420)
+    if fd < 0
+        return 10  # FAIL: could not create temp file
+    let written: i64 = sys_write(fd, @json_buf[0], json_len)
+    sys_close(fd)
+    if written != json_len
+        return 11  # FAIL: write error
+
+    # Now test config_load
     var cfg: ValetConfig
     config_default(@cfg)
 
-    let ret: i32 = config_load(@cfg, c"valet.json")
+    let ret: i32 = config_load(@cfg, c"/tmp/valet_test_config.json")
+
+    # Clean up temp file
+    sys_unlink(c"/tmp/valet_test_config.json")
+
     if ret != 0
         return 1  # FAIL: file load should succeed
-    # valet.json should have port 8080 and keepalive_requests 100
+    # Our test JSON has port 8080 and keepalive_requests 100
     if cfg.port != 8080
         return 2
     if cfg.keepalive_requests != 100


### PR DESCRIPTION
## Summary

Fixes 3 bugs that caused valet test failures:

1. **test_config_load_from_file** - Test was failing because it tried to load `valet.json` from the working directory, but tests run in a temp directory. Fixed by creating a temp test file with known JSON content.

2. **parse_ritz_toml_dependencies undefined** - `test_runner.py` called `parse_ritz_toml_dependencies` but the function is actually named `parse_project_dependencies`. This caused all TLS tests to fail.

3. **ritzunit not found** - The import resolver's `_auto_detect_dependencies_from_ritz_path` only checked direct RITZ_PATH entries, not subdirectories. When RITZ_PATH contains `/path/to/projects`, it now also checks `/path/to/projects/ritzunit`, etc.

## Test Results

All **99 valet tests** now pass ✅

## Test plan

- [x] `./rz test valet` - 99 passed, 0 failed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)