### PR TITLE
Integrate rzsh shell and create indium distribution stub

### DIFF
--- a/projects/harland/kernel/src/fs/initramfs.ritz
+++ b/projects/harland/kernel/src/fs/initramfs.ritz
@@ -39,6 +39,8 @@ extern fn echo_elf_start()
 extern fn echo_elf_end()
 extern fn wc_elf_start()
 extern fn wc_elf_end()
+extern fn rzsh_elf_start()
+extern fn rzsh_elf_end()
 
 # ============================================================================
 # Configuration
@@ -341,6 +343,11 @@ pub fn initramfs_load_embedded() -> i32
     let wc_data: *u8 = wc_elf_start as *u8
     let wc_size: u64 = (wc_elf_end as u64) - (wc_elf_start as u64)
     create_file(ns, c"/bin/wc", wc_data, wc_size)
+
+    # Create /bin/rzsh - Ritz Shell (interactive shell)
+    let rzsh_data: *u8 = rzsh_elf_start as *u8
+    let rzsh_size: u64 = (rzsh_elf_end as u64) - (rzsh_elf_start as u64)
+    create_file(ns, c"/bin/rzsh", rzsh_data, rzsh_size)
 
     # Create /var/log/boot.log
     var bootlog: [64]u8

--- a/projects/harland/kernel/user_elf.s
+++ b/projects/harland/kernel/user_elf.s
@@ -161,3 +161,18 @@ wc_elf_end:
 
 wc_elf_size:
     .quad wc_elf_end - wc_elf_start
+
+# ============================================================================
+# rzsh.elf - Ritz Shell (interactive shell for harland)
+# ============================================================================
+.global rzsh_elf_start
+.global rzsh_elf_end
+.global rzsh_elf_size
+
+.align 16
+rzsh_elf_start:
+    .incbin "build/debug/rzsh.elf"
+rzsh_elf_end:
+
+rzsh_elf_size:
+    .quad rzsh_elf_end - rzsh_elf_start

--- a/projects/harland/user/init.ritz
+++ b/projects/harland/user/init.ritz
@@ -186,6 +186,19 @@ pub fn main() -> i32
         print_str(c"  ALL TESTS PASSED\n")
         print_str(c"========================================\n")
         print_str(c"\n")
+
+        # Launch the shell
+        print_str(c"[init] Launching rzsh...\n")
+        let shell_pid: i64 = sys_spawn(c"/bin/rzsh")
+        if shell_pid > 0
+            # Wait for shell to exit
+            let shell_exit: i64 = sys_wait(shell_pid as i32)
+            print_str(c"[init] rzsh exited with code ")
+            print_num(shell_exit as i32)
+            print_str(c"\n")
+        else
+            print_str(c"[init] Failed to spawn rzsh\n")
+
         print_str(c"[init] Triggering ACPI poweroff...\n")
         sys_acpi_poweroff()
         # If poweroff fails, fall through to exit

--- a/projects/indium/README.md
+++ b/projects/indium/README.md
@@ -1,0 +1,69 @@
+# Indium
+
+**Indium** is the distribution built on the Harland microkernel.
+
+## Architecture
+
+The Ritz ecosystem separates the **kernel** from the **distribution**:
+
+- **Harland** — The microkernel. Just the kernel, nothing else.
+- **Indium** — The distribution. Builds the kernel, userspace, and creates bootable images.
+
+This separation allows:
+- Multiple distributions built on Harland
+- Clean testing of kernel vs userspace
+- Proper packaging and image creation
+
+## Current Status
+
+**Work in Progress** — Indium is being extracted from the harland project.
+
+Currently, harland contains embedded userspace programs (init, hello, true, false, etc.)
+and QEMU run scripts. These will migrate here.
+
+## Planned Structure
+
+```
+indium/
+├── build.py              # Main build script
+├── config/               # Distribution configuration
+│   └── default.toml      # Default config
+├── initramfs/            # Initramfs staging
+│   ├── bin/              # Userspace binaries
+│   ├── etc/              # Configuration files
+│   └── ...
+├── image/                # Image creation
+│   └── iso.py            # ISO image builder
+└── run/                  # QEMU run scripts
+    └── qemu.py           # QEMU launcher
+```
+
+## Build Process (Planned)
+
+```bash
+# Build everything
+./indium build
+
+# This will:
+# 1. Build harland kernel
+# 2. Build userspace (init, rzsh, utilities)
+# 3. Create initramfs TAR archive
+# 4. Create bootable ISO
+# 5. (Optional) Create disk image
+
+# Run in QEMU
+./indium run
+```
+
+## Migration Plan
+
+1. [x] Create indium project stub
+2. [ ] Move QEMU scripts from harland/boot/ to indium/run/
+3. [ ] Move initramfs creation from kernel to indium
+4. [ ] Remove embedded ELFs from kernel (use disk/TAR instead)
+5. [ ] Create proper build orchestration
+6. [ ] Support multiple configurations (test, release, etc.)
+
+## Why "Indium"?
+
+Indium is a soft, malleable metal. Like the distribution that wraps around the hard kernel.


### PR DESCRIPTION
## Summary

- **harland**: Embed rzsh.elf binary and launch it from init after tests pass
- **indium**: Create distribution project stub documenting architecture separation

## Details

### rzsh Integration
- Embedded rzsh.elf in kernel image via `user_elf.s`
- Added `/bin/rzsh` to initramfs
- Modified init to spawn rzsh after Tier 1 tests pass
- Shell provides interactive environment for userspace development

### indium Distribution Project
- Created `projects/indium/README.md` documenting architecture
- Harland = kernel only
- Indium = distribution (builds kernel, userspace, creates images)
- Planned migration path for proper separation

## Test Plan

- [x] All Tier 1 tests pass (7/7)
- [x] rzsh launches successfully after tests
- [x] Shell displays banner and prompt
- [x] Test times out as expected (shell waits for input)

## Notes

Currently rzsh.elf must be manually copied to `projects/harland/build/debug/` before building. This is temporary until the indium distribution handles the build orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)