### PR TITLE
rzsh: Add raw mode terminal input with line editing and history

### DIFF
--- a/projects/ritz/ritzlib/sys.ritz
+++ b/projects/ritz/ritzlib/sys.ritz
@@ -860,3 +860,195 @@ pub fn sys_gettimeofday(tv: *Timeval, tz: *u8) -> i32
 [[target_os = "linux"]]
 pub fn sys_sendfile(out_fd: i32, in_fd: i32, offset: *i64, count: i64) -> i64
     return syscall4(SYS_SENDFILE, out_fd as i64, in_fd as i64, offset as i64, count)
+
+# ============================================================================
+# Terminal I/O Control (Linux-only)
+# ============================================================================
+
+# ioctl syscall wrapper
+[[target_os = "linux"]]
+pub fn sys_ioctl(fd: i32, request: u64, arg: *u8) -> i32
+    return syscall3(SYS_IOCTL, fd as i64, request as i64, arg as i64) as i32
+
+# Terminal ioctl request codes
+[[target_os = "linux"]]
+pub const TCGETS: u64 = 0x5401      # Get termios structure
+[[target_os = "linux"]]
+pub const TCSETS: u64 = 0x5402      # Set termios immediately
+[[target_os = "linux"]]
+pub const TCSETSW: u64 = 0x5403     # Set termios after output drain
+[[target_os = "linux"]]
+pub const TCSETSF: u64 = 0x5404     # Set termios, flush pending input
+[[target_os = "linux"]]
+pub const TIOCGWINSZ: u64 = 0x5413  # Get window size
+
+# Termios structure (Linux x86-64)
+# Total size: 60 bytes
+# Layout verified against glibc termios.h:
+#   offsetof c_iflag = 0
+#   offsetof c_oflag = 4
+#   offsetof c_cflag = 8
+#   offsetof c_lflag = 12
+#   offsetof c_line = 16
+#   offsetof c_cc = 17 (size = 32, NCCS = 32)
+#   offsetof c_ispeed = 52 (17 + 32 + 3 padding = 52)
+#   offsetof c_ospeed = 56
+[[target_os = "linux"]]
+pub struct Termios
+    c_iflag: u32       # 0: input mode flags
+    c_oflag: u32       # 4: output mode flags
+    c_cflag: u32       # 8: control mode flags
+    c_lflag: u32       # 12: local mode flags
+    c_line: u8         # 16: line discipline
+    c_cc: [32]u8       # 17: control characters (NCCS = 32)
+    # Note: c_cc is 32 bytes, then 3 bytes padding to align c_ispeed
+    __pad0: u8         # 49: padding for alignment
+    __pad1: u8         # 50: padding for alignment
+    __pad2: u8         # 51: padding for alignment
+    c_ispeed: u32      # 52: input speed
+    c_ospeed: u32      # 56: output speed
+
+# c_lflag bits (local mode flags)
+[[target_os = "linux"]]
+pub const ISIG: u32 = 1         # Enable signals (INTR, QUIT, SUSP)
+[[target_os = "linux"]]
+pub const ICANON: u32 = 2       # Canonical mode (line-by-line input)
+[[target_os = "linux"]]
+pub const ECHO: u32 = 8         # Echo input characters
+[[target_os = "linux"]]
+pub const ECHOE: u32 = 16       # Echo erase character as BS-SP-BS
+[[target_os = "linux"]]
+pub const ECHOK: u32 = 32       # Echo NL after kill character
+[[target_os = "linux"]]
+pub const ECHONL: u32 = 64      # Echo NL even if ECHO is off
+[[target_os = "linux"]]
+pub const IEXTEN: u32 = 32768   # Enable implementation-defined input processing
+
+# c_iflag bits (input mode flags)
+[[target_os = "linux"]]
+pub const IGNBRK: u32 = 1       # Ignore BREAK condition
+[[target_os = "linux"]]
+pub const BRKINT: u32 = 2       # Signal interrupt on break
+[[target_os = "linux"]]
+pub const IGNPAR: u32 = 4       # Ignore parity errors
+[[target_os = "linux"]]
+pub const PARMRK: u32 = 8       # Mark parity errors
+[[target_os = "linux"]]
+pub const INPCK: u32 = 16       # Enable input parity check
+[[target_os = "linux"]]
+pub const ISTRIP: u32 = 32      # Strip 8th bit
+[[target_os = "linux"]]
+pub const INLCR: u32 = 64       # Translate NL to CR
+[[target_os = "linux"]]
+pub const IGNCR: u32 = 128      # Ignore CR
+[[target_os = "linux"]]
+pub const ICRNL: u32 = 256      # Translate CR to NL
+[[target_os = "linux"]]
+pub const IXON: u32 = 1024      # Enable XON/XOFF output control
+[[target_os = "linux"]]
+pub const IXOFF: u32 = 4096     # Enable XON/XOFF input control
+
+# c_oflag bits (output mode flags)
+[[target_os = "linux"]]
+pub const OPOST: u32 = 1        # Post-process output
+
+# Control character indices for c_cc array
+[[target_os = "linux"]]
+pub const VINTR: i32 = 0        # Interrupt character (Ctrl+C)
+[[target_os = "linux"]]
+pub const VQUIT: i32 = 1        # Quit character (Ctrl+\)
+[[target_os = "linux"]]
+pub const VERASE: i32 = 2       # Erase character (Backspace)
+[[target_os = "linux"]]
+pub const VKILL: i32 = 3        # Kill character (Ctrl+U)
+[[target_os = "linux"]]
+pub const VEOF: i32 = 4         # EOF character (Ctrl+D)
+[[target_os = "linux"]]
+pub const VTIME: i32 = 5        # Timeout in 0.1s units
+[[target_os = "linux"]]
+pub const VMIN: i32 = 6         # Minimum characters for read
+[[target_os = "linux"]]
+pub const VSTART: i32 = 8       # Start character (Ctrl+Q)
+[[target_os = "linux"]]
+pub const VSTOP: i32 = 9        # Stop character (Ctrl+S)
+[[target_os = "linux"]]
+pub const VSUSP: i32 = 10       # Suspend character (Ctrl+Z)
+
+# Window size structure for TIOCGWINSZ
+[[target_os = "linux"]]
+pub struct Winsize
+    ws_row: u16        # Rows (in characters)
+    ws_col: u16        # Columns (in characters)
+    ws_xpixel: u16     # Horizontal size (pixels, unused)
+    ws_ypixel: u16     # Vertical size (pixels, unused)
+
+# Convenience function to get terminal attributes
+[[target_os = "linux"]]
+pub fn tcgetattr(fd: i32, termios_p: *Termios) -> i32
+    return sys_ioctl(fd, TCGETS, termios_p as *u8)
+
+# Convenience function to set terminal attributes
+[[target_os = "linux"]]
+pub fn tcsetattr(fd: i32, termios_p: *Termios) -> i32
+    return sys_ioctl(fd, TCSETS, termios_p as *u8)
+
+# Convenience function to set terminal attributes after drain
+[[target_os = "linux"]]
+pub fn tcsetattr_drain(fd: i32, termios_p: *Termios) -> i32
+    return sys_ioctl(fd, TCSETSW, termios_p as *u8)
+
+# Convenience function to set terminal attributes and flush
+[[target_os = "linux"]]
+pub fn tcsetattr_flush(fd: i32, termios_p: *Termios) -> i32
+    return sys_ioctl(fd, TCSETSF, termios_p as *u8)
+
+# Convenience function to get window size
+[[target_os = "linux"]]
+pub fn get_winsize(fd: i32, ws: *Winsize) -> i32
+    return sys_ioctl(fd, TIOCGWINSZ, ws as *u8)
+
+# ============================================================================
+# Terminal I/O Control (Harland)
+# ============================================================================
+# Harland uses a simpler terminal model. The serial console is always in
+# "raw" mode from the kernel's perspective - the shell handles line editing.
+# These are stub implementations for API compatibility.
+
+# Terminal attributes for Harland (minimal subset)
+[[target_os = "harland"]]
+pub struct TtyAttrs
+    flags: u32         # Terminal flags (echo, raw mode, etc.)
+
+# Harland terminal flags
+[[target_os = "harland"]]
+pub const TTY_ECHO: u32 = 1       # Echo input characters
+[[target_os = "harland"]]
+pub const TTY_ICANON: u32 = 2     # Canonical mode (line buffering)
+[[target_os = "harland"]]
+pub const TTY_ISIG: u32 = 4       # Enable signals
+
+# Harland syscall numbers for TTY
+[[target_os = "harland"]]
+const SYS_TTY_GETATTR: i64 = 30
+
+[[target_os = "harland"]]
+const SYS_TTY_SETATTR: i64 = 31
+
+# Get terminal attributes (Harland)
+# Note: Currently returns 0 with default flags since Harland serial
+# console doesn't have termios. Shell handles all line editing.
+[[target_os = "harland"]]
+pub fn sys_tty_getattr(fd: i32, attrs: *TtyAttrs) -> i32
+    # TODO: Implement when kernel supports TTY attributes
+    # For now, return success with echo enabled (matches current behavior)
+    (*attrs).flags = TTY_ECHO
+    return 0
+
+# Set terminal attributes (Harland)
+# Note: Currently a no-op since Harland serial console is always "raw"
+# from the kernel's perspective.
+[[target_os = "harland"]]
+pub fn sys_tty_setattr(fd: i32, attrs: *TtyAttrs) -> i32
+    # TODO: Implement when kernel supports TTY attributes
+    # For now, just return success
+    return 0

--- a/projects/rzsh/docs/ROADMAP.md
+++ b/projects/rzsh/docs/ROADMAP.md
@@ -1,0 +1,459 @@
+# rzsh Terminal Roadmap
+
+This document outlines the feature roadmap for rzsh, covering terminal improvements and the kernel syscalls needed to support them.
+
+## Current State Analysis
+
+### What We Have
+
+| Feature | Linux | Harland | Notes |
+|---------|-------|---------|-------|
+| Basic input/output | ✓ | ✓ | sys_read/sys_write |
+| Line editing (backspace) | ✓ | ✓ | Manual terminal escape handling |
+| Ctrl+C interrupt | ✓ | ✓ | Character-level detection |
+| Ctrl+D EOF | ✓ | ✓ | Character-level detection |
+| Built-in commands | ✓ | ✓ | help, exit, pid, echo, ls, clear |
+| External commands | ✓ | ✓ | fork+execve / spawn_args |
+| Directory listing | ✓ | ✓ | getdents64 / sys_readdir |
+| Screen clear (ESC codes) | ✓ | ✓ | ANSI escape sequences |
+
+### What We're Missing
+
+| Feature | Priority | Requires Kernel Support |
+|---------|----------|------------------------|
+| Arrow key navigation | High | No (escape sequence parsing) |
+| Command history | High | No (userspace buffer) |
+| Tab completion | Medium | sys_stat or equivalent |
+| Raw mode terminal | High | sys_ioctl (Linux), sys_tty_* (Harland) |
+| Working directory (cd) | High | sys_chdir, sys_getcwd |
+| Environment variables | Medium | Userspace only |
+| Pipes | Medium | sys_pipe, sys_dup2 |
+| Redirection | Medium | sys_dup2, file I/O |
+| Job control (bg/fg) | Low | Signals, process groups |
+| Signal handling | Low | sys_rt_sigaction |
+
+---
+
+## Phase 1: Line Editing Improvements
+
+**Goal:** Make rzsh feel like a proper interactive shell with arrow keys and history.
+
+### 1.1 Raw Mode Terminal (HIGH PRIORITY)
+
+**Problem:** Currently the terminal is in "cooked" mode where the kernel handles line buffering. This means:
+- We can't detect individual keypresses immediately
+- Arrow keys send escape sequences that interfere with input
+- Special keys (Home, End, Delete) don't work
+
+**Solution (Linux):** Implement raw terminal mode via `ioctl`:
+
+```ritz
+# ritzlib/sys.ritz - New syscalls needed
+
+# Terminal I/O control
+[[target_os = "linux"]]
+pub fn sys_ioctl(fd: i32, request: u64, arg: *u8) -> i32
+    return syscall3(SYS_IOCTL, fd as i64, request as i64, arg as i64) as i32
+
+# ioctl request codes for terminal
+[[target_os = "linux"]]
+pub const TCGETS: u64 = 0x5401      # Get termios
+[[target_os = "linux"]]
+pub const TCSETS: u64 = 0x5402      # Set termios
+[[target_os = "linux"]]
+pub const TCSETSW: u64 = 0x5403     # Set termios, wait for drain
+[[target_os = "linux"]]
+pub const TCSETSF: u64 = 0x5404     # Set termios, flush pending input
+```
+
+**Solution (Harland):** Create a minimal TTY subsystem:
+
+```ritz
+# Harland kernel - new syscalls (kernel/src/main.ritz)
+const SYS_TTY_GETATTR: u64 = 30    # Get terminal attributes
+const SYS_TTY_SETATTR: u64 = 31    # Set terminal attributes
+
+# ritzlib/sys.ritz - Harland wrappers
+[[target_os = "harland"]]
+pub fn sys_tty_getattr(fd: i32, attr: *TtyAttrs) -> i32
+
+[[target_os = "harland"]]
+pub fn sys_tty_setattr(fd: i32, attr: *TtyAttrs) -> i32
+```
+
+### 1.2 Escape Sequence Parsing
+
+Once in raw mode, we need to parse escape sequences:
+
+```
+Arrow Up:    ESC [ A  (0x1B 0x5B 0x41)
+Arrow Down:  ESC [ B
+Arrow Right: ESC [ C
+Arrow Left:  ESC [ D
+Home:        ESC [ H
+End:         ESC [ F
+Delete:      ESC [ 3 ~
+```
+
+**Implementation:** Add escape sequence state machine to `common.ritz`:
+
+```ritz
+enum InputState
+    Normal
+    Escape        # Saw ESC
+    Bracket       # Saw ESC [
+    Extended      # Saw ESC [ digit
+
+enum Key
+    Char(u8)
+    Up
+    Down
+    Left
+    Right
+    Home
+    End
+    Delete
+    Backspace
+    Enter
+    CtrlC
+    CtrlD
+    Unknown
+```
+
+### 1.3 Cursor Movement
+
+Add functions to move cursor within the line:
+
+```ritz
+fn cursor_left(n: i32)
+    # ESC [ <n> D
+
+fn cursor_right(n: i32)
+    # ESC [ <n> C
+
+fn cursor_save()
+    # ESC [ s
+
+fn cursor_restore()
+    # ESC [ u
+```
+
+### 1.4 Command History
+
+Simple ring buffer for history:
+
+```ritz
+const HISTORY_SIZE: i32 = 100
+const MAX_HISTORY_LINE: i64 = 512
+
+var g_history: [100][512]u8
+var g_history_count: i32 = 0
+var g_history_pos: i32 = 0     # Current position when navigating
+var g_history_next: i32 = 0    # Next slot to write
+
+fn history_add(line: *u8)
+fn history_prev() -> *u8
+fn history_next() -> *u8
+```
+
+---
+
+## Phase 2: Working Directory & Navigation
+
+**Goal:** Support `cd` command and path operations.
+
+### 2.1 Linux Implementation
+
+Already have syscalls:
+- `sys_getcwd` - Get current working directory
+- `sys_chdir` - Change directory
+
+### 2.2 Harland Implementation
+
+Need new syscalls:
+
+```ritz
+# Kernel syscall numbers
+const SYS_GETCWD: u64 = 32
+const SYS_CHDIR: u64 = 33
+
+# Implementation in kernel/src/main.ritz
+fn sys_getcwd_impl(buf: *u8, size: i64) -> i64
+    # Copy process's cwd path to buf
+    # Return length on success, -1 on error
+
+fn sys_chdir_impl(path: *u8) -> i32
+    # Resolve path and set process's cwd
+    # Return 0 on success, -errno on error
+```
+
+### 2.3 Shell Integration
+
+```ritz
+# common.ritz
+fn cmd_cd(argc: i32) -> i32
+    if argc == 1
+        # cd with no args -> go to home (or /)
+        return os_chdir(c"/")
+
+    let path: *u8 = g_argv[1]
+    let result: i32 = os_chdir(path)
+
+    if result < 0
+        puts(c"cd: ")
+        puts(path)
+        println(c": No such directory")
+        return 1
+
+    return 0
+
+fn cmd_pwd() -> i32
+    var buf: [256]u8
+    let len: i64 = os_getcwd(@buf[0], 256)
+    if len > 0
+        println(@buf[0])
+        return 0
+    return 1
+```
+
+---
+
+## Phase 3: Tab Completion
+
+**Goal:** Complete file/command names with Tab key.
+
+### 3.1 Requirements
+
+1. `sys_stat` or equivalent to check if path is file/directory
+2. `sys_readdir` (already have) to list directory contents
+3. Prefix matching algorithm
+
+### 3.2 Linux Implementation
+
+Already have `sys_stat`, `sys_lstat` in ritzlib/sys.ritz.
+
+### 3.3 Harland Implementation
+
+Add sys_stat syscall:
+
+```ritz
+const SYS_STAT: u64 = 34
+
+# Minimal stat structure for Harland
+struct HarlandStat
+    st_mode: u32     # File type and permissions
+    st_size: i64     # File size in bytes
+    st_mtime: i64    # Modification time
+
+# File type bits (compatible with Linux)
+const S_IFDIR: u32 = 0x4000   # Directory
+const S_IFREG: u32 = 0x8000   # Regular file
+```
+
+### 3.4 Completion Algorithm
+
+```ritz
+fn tab_complete(line: *u8, pos: i64) -> i64
+    # 1. Find word boundaries
+    # 2. Determine if completing command or file
+    # 3. If command (first word):
+    #    - Search /bin for matches
+    # 4. If file:
+    #    - Parse path prefix (dir + partial name)
+    #    - List directory, find matches
+    # 5. If single match: complete it
+    # 6. If multiple matches: show options
+    # 7. Return new cursor position
+```
+
+---
+
+## Phase 4: Pipes & Redirection
+
+**Goal:** Support `cmd1 | cmd2` and `cmd > file`.
+
+### 4.1 Linux Implementation
+
+Already have:
+- `sys_pipe` - Create pipe
+- `sys_dup2` - Duplicate file descriptor
+- `sys_fork`/`sys_execve` - Process creation
+
+### 4.2 Harland Implementation
+
+Need new syscalls:
+
+```ritz
+const SYS_PIPE: u64 = 35
+const SYS_DUP2: u64 = 36
+
+fn sys_pipe_impl(pipefd: *i32) -> i32
+    # Create IPC channel pair
+    # pipefd[0] = read end
+    # pipefd[1] = write end
+
+fn sys_dup2_impl(oldfd: i32, newfd: i32) -> i32
+    # Duplicate oldfd to newfd
+    # Close newfd if open
+```
+
+### 4.3 Pipe Implementation (Harland Kernel)
+
+Harland has IPC channels that can serve as pipes:
+
+```ritz
+# Use existing channel infrastructure
+fn sys_pipe_impl(pipefd: *i32) -> i32
+    # Create channel pair
+    let pair: ChannelPair = channel_create(pid)
+
+    # Allocate file descriptors
+    let read_fd: i32 = fd_alloc_channel(pair.endpoint_a)
+    let write_fd: i32 = fd_alloc_channel(pair.endpoint_b)
+
+    *pipefd = read_fd
+    *(pipefd + 1) = write_fd
+    return 0
+```
+
+---
+
+## Phase 5: Environment Variables
+
+**Goal:** Support `export VAR=value` and `$VAR` expansion.
+
+### 5.1 Implementation (Pure Userspace)
+
+```ritz
+# Environment storage
+const MAX_ENV_VARS: i32 = 128
+const MAX_ENV_NAME: i32 = 64
+const MAX_ENV_VALUE: i32 = 256
+
+struct EnvVar
+    name: [64]u8
+    value: [256]u8
+    set: bool
+
+var g_environ: [128]EnvVar
+
+fn env_get(name: *u8) -> *u8
+fn env_set(name: *u8, value: *u8) -> i32
+fn env_unset(name: *u8) -> i32
+
+# Shell expansion
+fn expand_vars(input: *u8, output: *u8, max_len: i64) -> i64
+    # Replace $VAR with env value
+    # Handle $? for last exit code
+    # Handle $$ for PID
+```
+
+---
+
+## Implementation Order
+
+### Sprint 1: Raw Mode + Arrow Keys (Week 1-2)
+1. Add `sys_ioctl` to ritzlib/sys.ritz (Linux)
+2. Create termios structure and helpers
+3. Add `sys_tty_getattr`/`sys_tty_setattr` stubs for Harland
+4. Implement escape sequence parser
+5. Add cursor movement functions
+6. Test on Linux
+
+### Sprint 2: History (Week 2-3)
+1. Implement history ring buffer
+2. Integrate with arrow up/down
+3. Add !n and !! syntax (optional)
+4. Test on Linux
+
+### Sprint 3: Working Directory (Week 3-4)
+1. Add `sys_getcwd`/`sys_chdir` to Harland kernel
+2. Add wrapper in ritzlib/sys.ritz
+3. Implement `cd` and `pwd` commands
+4. Update prompt to show cwd (optional)
+
+### Sprint 4: Tab Completion (Week 4-5)
+1. Add `sys_stat` to Harland kernel
+2. Implement prefix matching
+3. Integrate with Tab key
+4. Handle directories vs files
+
+### Sprint 5: Pipes (Week 5-6)
+1. Add `sys_pipe`/`sys_dup2` to Harland kernel
+2. Implement pipe parsing in shell
+3. Create pipeline execution logic
+4. Test with simple commands
+
+---
+
+## Kernel Syscall Summary
+
+### New Linux Syscalls (ritzlib/sys.ritz)
+
+| Syscall | Number | Args | Returns | Description |
+|---------|--------|------|---------|-------------|
+| sys_ioctl | 16 | fd, request, arg | i32 | Device control |
+
+### New Harland Syscalls (kernel/src/main.ritz)
+
+| Syscall | Number | Args | Returns | Description |
+|---------|--------|------|---------|-------------|
+| sys_tty_getattr | 30 | fd, *attr | i32 | Get terminal attributes |
+| sys_tty_setattr | 31 | fd, *attr | i32 | Set terminal attributes |
+| sys_getcwd | 32 | buf, size | i64 | Get working directory |
+| sys_chdir | 33 | path | i32 | Change directory |
+| sys_stat | 34 | path, *stat | i32 | Get file status |
+| sys_pipe | 35 | *pipefd | i32 | Create pipe |
+| sys_dup2 | 36 | oldfd, newfd | i32 | Duplicate file descriptor |
+
+---
+
+## Testing Strategy
+
+### Unit Tests (ritzlib)
+- Test termios structure serialization
+- Test escape sequence parser
+- Test history buffer operations
+- Test environment variable operations
+
+### Integration Tests (rzsh)
+- Test raw mode enable/disable
+- Test arrow key navigation
+- Test history navigation
+- Test cd/pwd commands
+- Test tab completion
+- Test pipe execution
+
+### Cross-Platform Tests
+- Verify same behavior on Linux and Harland
+- Test OS abstraction layer isolation
+
+---
+
+## Files to Modify
+
+### ritzlib/sys.ritz
+- Add `sys_ioctl` (Linux)
+- Add termios structures and constants
+- Add `sys_tty_*` stubs for Harland
+
+### rzsh/src/common.ritz
+- Add escape sequence parser
+- Add history buffer
+- Add cursor movement helpers
+- Add environment variable storage
+
+### rzsh/src/os.ritz
+- Add `os_tty_raw_mode(enable: bool)`
+- Add `os_getcwd`, `os_chdir`
+- Add `os_stat`
+
+### rzsh/src/main.ritz
+- Integrate raw mode on startup/shutdown
+- Update input loop for escape sequences
+- Add new built-in commands (cd, pwd, export)
+
+### harland/kernel/src/main.ritz
+- Add syscall handlers for new syscalls
+- Implement TTY attribute storage
+- Implement per-process cwd tracking

--- a/projects/rzsh/ritz.toml
+++ b/projects/rzsh/ritz.toml
@@ -49,4 +49,5 @@ main_args = 2
 
 [test]
 host-target = "x86_64-linux"
-sources = ["tests"]
+sources = ["test"]
+

--- a/projects/rzsh/src/common.ritz
+++ b/projects/rzsh/src/common.ritz
@@ -46,11 +46,20 @@ pub fn is_whitespace(c: u8) -> bool
 # ============================================================================
 # Line Buffer
 # ============================================================================
+# The line buffer stores the current input line. g_line_len is the total
+# length of the line, g_line_cursor is the current cursor position within
+# the line (for cursor movement with arrow keys).
 
 pub var g_line_buffer: [512]u8
+pub var g_line_len: i64 = 0       # Total length of line
+pub var g_line_cursor: i64 = 0    # Cursor position within line
+
+# Legacy alias for compatibility
 pub var g_line_pos: i64 = 0
 
 pub fn line_clear() -> i32
+    g_line_len = 0
+    g_line_cursor = 0
     g_line_pos = 0
     var i: i64 = 0
     while i < MAX_LINE
@@ -58,23 +67,129 @@ pub fn line_clear() -> i32
         i = i + 1
     return 0
 
+# Add character at cursor position (may insert in middle of line)
 pub fn line_add_char(c: u8) -> i32
-    if g_line_pos < MAX_LINE - 1
-        g_line_buffer[g_line_pos as i32] = c
-        g_line_pos = g_line_pos + 1
+    if g_line_len >= MAX_LINE - 1
+        return 0  # Buffer full
+
+    # If cursor is at end, just append
+    if g_line_cursor == g_line_len
+        g_line_buffer[g_line_len as i32] = c
+        g_line_len = g_line_len + 1
+        g_line_cursor = g_line_cursor + 1
+        g_line_pos = g_line_len
+        g_line_buffer[g_line_len as i32] = 0
+        return 0
+
+    # Insert in middle - shift characters right
+    var i: i64 = g_line_len
+    while i > g_line_cursor
+        g_line_buffer[i as i32] = g_line_buffer[(i - 1) as i32]
+        i = i - 1
+
+    g_line_buffer[g_line_cursor as i32] = c
+    g_line_len = g_line_len + 1
+    g_line_cursor = g_line_cursor + 1
+    g_line_pos = g_line_len
+    g_line_buffer[g_line_len as i32] = 0
     return 0
 
+# Delete character before cursor (backspace)
 pub fn line_backspace() -> i32
-    if g_line_pos > 0
-        g_line_pos = g_line_pos - 1
-        g_line_buffer[g_line_pos as i32] = 0
-        # Erase character on terminal: backspace, space, backspace
-        var bs: u8 = 8
-        var sp: u8 = 32
-        sys_write(STDOUT, @bs, 1)
-        sys_write(STDOUT, @sp, 1)
-        sys_write(STDOUT, @bs, 1)
+    if g_line_cursor == 0
+        return 0  # Nothing to delete
+
+    # Shift characters left from cursor position
+    var i: i64 = g_line_cursor - 1
+    while i < g_line_len - 1
+        g_line_buffer[i as i32] = g_line_buffer[(i + 1) as i32]
+        i = i + 1
+
+    g_line_len = g_line_len - 1
+    g_line_cursor = g_line_cursor - 1
+    g_line_pos = g_line_len
+    g_line_buffer[g_line_len as i32] = 0
     return 0
+
+# Delete character at cursor (delete key)
+pub fn line_delete() -> i32
+    if g_line_cursor >= g_line_len
+        return 0  # Nothing to delete
+
+    # Shift characters left
+    var i: i64 = g_line_cursor
+    while i < g_line_len - 1
+        g_line_buffer[i as i32] = g_line_buffer[(i + 1) as i32]
+        i = i + 1
+
+    g_line_len = g_line_len - 1
+    g_line_pos = g_line_len
+    g_line_buffer[g_line_len as i32] = 0
+    return 0
+
+# Move cursor left
+pub fn line_cursor_left() -> bool
+    if g_line_cursor > 0
+        g_line_cursor = g_line_cursor - 1
+        return true
+    return false
+
+# Move cursor right
+pub fn line_cursor_right() -> bool
+    if g_line_cursor < g_line_len
+        g_line_cursor = g_line_cursor + 1
+        return true
+    return false
+
+# Move cursor to start of line
+pub fn line_cursor_home()
+    g_line_cursor = 0
+
+# Move cursor to end of line
+pub fn line_cursor_end()
+    g_line_cursor = g_line_len
+
+# Kill from cursor to end of line
+pub fn line_kill_to_end()
+    g_line_len = g_line_cursor
+    g_line_pos = g_line_len
+    g_line_buffer[g_line_len as i32] = 0
+
+# Kill from start to cursor
+pub fn line_kill_to_start()
+    if g_line_cursor == 0
+        return
+
+    # Shift remaining characters to start
+    var i: i64 = 0
+    while g_line_cursor + i < g_line_len
+        g_line_buffer[i as i32] = g_line_buffer[(g_line_cursor + i) as i32]
+        i = i + 1
+
+    g_line_len = g_line_len - g_line_cursor
+    g_line_cursor = 0
+    g_line_pos = g_line_len
+    g_line_buffer[g_line_len as i32] = 0
+
+# Set line content (for history navigation)
+pub fn line_set(s: *u8)
+    line_clear()
+    var i: i64 = 0
+    while *(s + i) != 0 and i < MAX_LINE - 1
+        g_line_buffer[i as i32] = *(s + i)
+        i = i + 1
+    g_line_len = i
+    g_line_cursor = i
+    g_line_pos = i
+    g_line_buffer[i as i32] = 0
+
+# Get line length
+pub fn line_length() -> i64
+    return g_line_len
+
+# Get cursor position
+pub fn line_cursor_pos() -> i64
+    return g_line_cursor
 
 # ============================================================================
 # Command Parsing

--- a/projects/rzsh/src/history.ritz
+++ b/projects/rzsh/src/history.ritz
@@ -1,0 +1,148 @@
+# rzsh command history
+#
+# Simple ring buffer for command history with navigation.
+
+import ritzlib.str { strlen, strcmp }
+
+# ============================================================================
+# History configuration
+# ============================================================================
+
+pub const HISTORY_SIZE: i32 = 100
+pub const MAX_HISTORY_LINE: i64 = 512
+
+# ============================================================================
+# History buffer (ring buffer)
+# ============================================================================
+
+# The history buffer stores up to HISTORY_SIZE entries.
+# g_history_write is where the next entry will be written.
+# g_history_count is the number of valid entries.
+# g_history_nav is the current navigation position (for up/down arrows).
+
+var g_history: [100][512]u8
+var g_history_write: i32 = 0      # Next slot to write
+var g_history_count: i32 = 0      # Number of valid entries
+var g_history_nav: i32 = -1       # Navigation position (-1 = at prompt)
+
+# ============================================================================
+# Add a line to history
+# ============================================================================
+# Only adds non-empty lines that differ from the previous entry.
+
+pub fn history_add(line: *u8)
+    let len: i64 = strlen(line)
+
+    # Skip empty lines
+    if len == 0
+        return
+
+    # Skip if same as last entry
+    if g_history_count > 0
+        let last: i32 = (g_history_write + HISTORY_SIZE - 1) % HISTORY_SIZE
+        if strcmp(line, @g_history[last][0]) == 0
+            return
+
+    # Copy line to history buffer
+    var i: i64 = 0
+    while i < len and i < MAX_HISTORY_LINE - 1
+        g_history[g_history_write][i as i32] = *(line + i)
+        i = i + 1
+    g_history[g_history_write][i as i32] = 0
+
+    # Advance write pointer
+    g_history_write = (g_history_write + 1) % HISTORY_SIZE
+
+    # Increment count (up to max)
+    if g_history_count < HISTORY_SIZE
+        g_history_count = g_history_count + 1
+
+# ============================================================================
+# Reset navigation position
+# ============================================================================
+# Call this when starting a new prompt.
+
+pub fn history_reset_nav()
+    g_history_nav = -1
+
+# ============================================================================
+# Navigate up (older entries)
+# ============================================================================
+# Returns pointer to history line, or null if at oldest entry.
+
+pub fn history_up() -> *u8
+    if g_history_count == 0
+        return null
+
+    # If at prompt (nav = -1), start at most recent
+    if g_history_nav == -1
+        g_history_nav = g_history_count - 1
+        let idx: i32 = (g_history_write + HISTORY_SIZE - 1) % HISTORY_SIZE
+        return @g_history[idx][0]
+
+    # If already at oldest, return null
+    if g_history_nav == 0
+        return null
+
+    # Move to older entry
+    g_history_nav = g_history_nav - 1
+    let idx: i32 = (g_history_write + HISTORY_SIZE - g_history_count + g_history_nav) % HISTORY_SIZE
+    return @g_history[idx][0]
+
+# ============================================================================
+# Navigate down (newer entries)
+# ============================================================================
+# Returns pointer to history line, or null if at prompt position.
+
+pub fn history_down() -> *u8
+    if g_history_count == 0
+        return null
+
+    # If at prompt, stay there
+    if g_history_nav == -1
+        return null
+
+    # If at most recent, return to prompt
+    if g_history_nav >= g_history_count - 1
+        g_history_nav = -1
+        return null
+
+    # Move to newer entry
+    g_history_nav = g_history_nav + 1
+    let idx: i32 = (g_history_write + HISTORY_SIZE - g_history_count + g_history_nav) % HISTORY_SIZE
+    return @g_history[idx][0]
+
+# ============================================================================
+# Get current navigation position
+# ============================================================================
+# Returns -1 if at prompt, otherwise 0-based index into history.
+
+pub fn history_nav_pos() -> i32
+    return g_history_nav
+
+# ============================================================================
+# Get history count
+# ============================================================================
+
+pub fn history_count() -> i32
+    return g_history_count
+
+# ============================================================================
+# Get history entry by index (0 = oldest)
+# ============================================================================
+
+pub fn history_get(index: i32) -> *u8
+    if index < 0 or index >= g_history_count
+        return null
+
+    let idx: i32 = (g_history_write + HISTORY_SIZE - g_history_count + index) % HISTORY_SIZE
+    return @g_history[idx][0]
+
+# ============================================================================
+# Clear history
+# ============================================================================
+
+pub fn history_clear()
+    g_history_write = 0
+    g_history_count = 0
+    g_history_nav = -1

--- a/projects/rzsh/src/input.ritz
+++ b/projects/rzsh/src/input.ritz
@@ -1,0 +1,313 @@
+# rzsh input handling
+#
+# This module provides escape sequence parsing for arrow keys and special keys.
+# It also provides line editing utilities for cursor movement.
+
+import ritzlib.sys { sys_read, sys_write, STDIN, STDOUT }
+import ritzlib.str { strlen }
+
+# ============================================================================
+# Input key codes
+# ============================================================================
+
+# Special key codes (values > 255 to distinguish from regular chars)
+pub const KEY_NONE: i32 = 0
+pub const KEY_CHAR: i32 = 1        # Regular character (value in low byte)
+pub const KEY_UP: i32 = 256
+pub const KEY_DOWN: i32 = 257
+pub const KEY_RIGHT: i32 = 258
+pub const KEY_LEFT: i32 = 259
+pub const KEY_HOME: i32 = 260
+pub const KEY_END: i32 = 261
+pub const KEY_DELETE: i32 = 262
+pub const KEY_BACKSPACE: i32 = 263
+pub const KEY_ENTER: i32 = 264
+pub const KEY_TAB: i32 = 265
+pub const KEY_CTRL_C: i32 = 266
+pub const KEY_CTRL_D: i32 = 267
+pub const KEY_CTRL_A: i32 = 268
+pub const KEY_CTRL_E: i32 = 269
+pub const KEY_CTRL_K: i32 = 270    # Kill to end of line
+pub const KEY_CTRL_U: i32 = 271    # Kill to start of line
+pub const KEY_CTRL_W: i32 = 272    # Kill previous word
+pub const KEY_CTRL_L: i32 = 273    # Clear screen
+pub const KEY_ESCAPE: i32 = 274    # Bare escape (after timeout)
+pub const KEY_UNKNOWN: i32 = 275
+
+# ============================================================================
+# Escape sequence parser state
+# ============================================================================
+
+# Parser states
+const STATE_NORMAL: i32 = 0
+const STATE_ESCAPE: i32 = 1      # Saw ESC (0x1B)
+const STATE_BRACKET: i32 = 2     # Saw ESC [
+const STATE_EXTENDED: i32 = 3    # Saw ESC [ digit (for sequences like ESC [ 3 ~)
+
+# Parser state (global for simplicity)
+var g_parse_state: i32 = 0
+var g_escape_param: i32 = 0
+
+# Reset parser state
+pub fn input_reset()
+    g_parse_state = STATE_NORMAL
+    g_escape_param = 0
+
+# ============================================================================
+# Parse a single byte into a key code
+# ============================================================================
+# Returns:
+#   KEY_NONE if more bytes needed (escape sequence in progress)
+#   KEY_CHAR + (char << 16) for regular characters
+#   KEY_* for special keys
+
+pub fn input_parse_byte(b: u8) -> i32
+    if g_parse_state == STATE_NORMAL
+        # Regular input mode
+        if b == 27  # ESC
+            g_parse_state = STATE_ESCAPE
+            return KEY_NONE
+
+        if b == 127 or b == 8  # DEL or Backspace
+            return KEY_BACKSPACE
+
+        if b == 13 or b == 10  # CR or LF
+            return KEY_ENTER
+
+        if b == 9  # Tab
+            return KEY_TAB
+
+        if b == 3  # Ctrl+C
+            return KEY_CTRL_C
+
+        if b == 4  # Ctrl+D (EOF)
+            return KEY_CTRL_D
+
+        if b == 1  # Ctrl+A (start of line)
+            return KEY_CTRL_A
+
+        if b == 5  # Ctrl+E (end of line)
+            return KEY_CTRL_E
+
+        if b == 11  # Ctrl+K (kill to end)
+            return KEY_CTRL_K
+
+        if b == 21  # Ctrl+U (kill to start)
+            return KEY_CTRL_U
+
+        if b == 23  # Ctrl+W (kill word)
+            return KEY_CTRL_W
+
+        if b == 12  # Ctrl+L (clear screen)
+            return KEY_CTRL_L
+
+        # Regular printable character
+        if b >= 32 and b < 127
+            return KEY_CHAR | ((b as i32) << 16)
+
+        # Other control characters - return as unknown
+        return KEY_UNKNOWN
+
+    if g_parse_state == STATE_ESCAPE
+        # Saw ESC, waiting for next byte
+        if b == 91  # '[' = 0x5B
+            g_parse_state = STATE_BRACKET
+            return KEY_NONE
+
+        if b == 79  # 'O' = 0x4F (some terminals use ESC O for function keys)
+            g_parse_state = STATE_BRACKET  # Treat same as CSI for now
+            return KEY_NONE
+
+        # ESC followed by something else - reset and treat ESC as escape key
+        g_parse_state = STATE_NORMAL
+        # Return the character that followed ESC as a regular char
+        return KEY_ESCAPE  # The next call will process the current byte
+
+    if g_parse_state == STATE_BRACKET
+        # Saw ESC [, waiting for final byte
+        if b == 65  # 'A'
+            g_parse_state = STATE_NORMAL
+            return KEY_UP
+
+        if b == 66  # 'B'
+            g_parse_state = STATE_NORMAL
+            return KEY_DOWN
+
+        if b == 67  # 'C'
+            g_parse_state = STATE_NORMAL
+            return KEY_RIGHT
+
+        if b == 68  # 'D'
+            g_parse_state = STATE_NORMAL
+            return KEY_LEFT
+
+        if b == 72  # 'H'
+            g_parse_state = STATE_NORMAL
+            return KEY_HOME
+
+        if b == 70  # 'F'
+            g_parse_state = STATE_NORMAL
+            return KEY_END
+
+        # Check for digit (extended sequence like ESC [ 3 ~)
+        if b >= 48 and b <= 57  # '0'-'9'
+            g_escape_param = (b - 48) as i32
+            g_parse_state = STATE_EXTENDED
+            return KEY_NONE
+
+        # Unknown sequence - reset
+        g_parse_state = STATE_NORMAL
+        return KEY_UNKNOWN
+
+    if g_parse_state == STATE_EXTENDED
+        # Saw ESC [ digit, looking for ~ or more digits
+        if b >= 48 and b <= 57  # More digits
+            g_escape_param = g_escape_param * 10 + ((b - 48) as i32)
+            return KEY_NONE
+
+        if b == 126  # '~'
+            g_parse_state = STATE_NORMAL
+            let param: i32 = g_escape_param
+            g_escape_param = 0
+
+            if param == 1  # Home
+                return KEY_HOME
+            if param == 3  # Delete
+                return KEY_DELETE
+            if param == 4  # End
+                return KEY_END
+            if param == 5  # Page Up (ignore for now)
+                return KEY_UNKNOWN
+            if param == 6  # Page Down (ignore for now)
+                return KEY_UNKNOWN
+
+            return KEY_UNKNOWN
+
+        # Unknown extended sequence - reset
+        g_parse_state = STATE_NORMAL
+        g_escape_param = 0
+        return KEY_UNKNOWN
+
+    # Should not reach here
+    g_parse_state = STATE_NORMAL
+    return KEY_UNKNOWN
+
+# ============================================================================
+# Check if parser is in the middle of an escape sequence
+# ============================================================================
+
+pub fn input_in_escape() -> bool
+    return g_parse_state != STATE_NORMAL
+
+# ============================================================================
+# Extract character from KEY_CHAR result
+# ============================================================================
+
+pub fn input_get_char(key: i32) -> u8
+    return ((key >> 16) & 0xFF) as u8
+
+# ============================================================================
+# Cursor movement helpers
+# ============================================================================
+
+# Move cursor left by n positions
+pub fn cursor_left(n: i32)
+    if n <= 0
+        return
+
+    # ESC [ <n> D
+    var buf: [16]u8
+    buf[0] = 27   # ESC
+    buf[1] = 91   # [
+
+    var i: i32 = 2
+    if n >= 100
+        buf[i] = 48 + ((n / 100) as u8)
+        i = i + 1
+    if n >= 10
+        buf[i] = 48 + (((n / 10) % 10) as u8)
+        i = i + 1
+    buf[i] = 48 + ((n % 10) as u8)
+    i = i + 1
+
+    buf[i] = 68   # D
+    i = i + 1
+
+    sys_write(STDOUT, @buf[0], i as i64)
+
+# Move cursor right by n positions
+pub fn cursor_right(n: i32)
+    if n <= 0
+        return
+
+    # ESC [ <n> C
+    var buf: [16]u8
+    buf[0] = 27   # ESC
+    buf[1] = 91   # [
+
+    var i: i32 = 2
+    if n >= 100
+        buf[i] = 48 + ((n / 100) as u8)
+        i = i + 1
+    if n >= 10
+        buf[i] = 48 + (((n / 10) % 10) as u8)
+        i = i + 1
+    buf[i] = 48 + ((n % 10) as u8)
+    i = i + 1
+
+    buf[i] = 67   # C
+    i = i + 1
+
+    sys_write(STDOUT, @buf[0], i as i64)
+
+# Move cursor to column n (1-based)
+pub fn cursor_column(n: i32)
+    if n <= 0
+        n = 1
+
+    # ESC [ <n> G
+    var buf: [16]u8
+    buf[0] = 27   # ESC
+    buf[1] = 91   # [
+
+    var i: i32 = 2
+    if n >= 100
+        buf[i] = 48 + ((n / 100) as u8)
+        i = i + 1
+    if n >= 10
+        buf[i] = 48 + (((n / 10) % 10) as u8)
+        i = i + 1
+    buf[i] = 48 + ((n % 10) as u8)
+    i = i + 1
+
+    buf[i] = 71   # G
+    i = i + 1
+
+    sys_write(STDOUT, @buf[0], i as i64)
+
+# Clear from cursor to end of line
+pub fn clear_to_eol()
+    # ESC [ K (or ESC [ 0 K)
+    var buf: [4]u8
+    buf[0] = 27   # ESC
+    buf[1] = 91   # [
+    buf[2] = 75   # K
+    sys_write(STDOUT, @buf[0], 3)
+
+# Save cursor position
+pub fn cursor_save()
+    # ESC [ s
+    var buf: [3]u8
+    buf[0] = 27
+    buf[1] = 91
+    buf[2] = 115  # s
+    sys_write(STDOUT, @buf[0], 3)
+
+# Restore cursor position
+pub fn cursor_restore()
+    # ESC [ u
+    var buf: [3]u8
+    buf[0] = 27
+    buf[1] = 91
+    buf[2] = 117  # u
+    sys_write(STDOUT, @buf[0], 3)

--- a/projects/rzsh/src/main.ritz
+++ b/projects/rzsh/src/main.ritz
@@ -8,7 +8,10 @@
 
 import common {
     puts, println, putchar, print_num, is_whitespace,
-    g_line_buffer, g_line_pos, line_clear, line_add_char, line_backspace,
+    g_line_buffer, g_line_len, g_line_cursor, g_line_pos,
+    line_clear, line_add_char, line_backspace, line_delete,
+    line_cursor_left, line_cursor_right, line_cursor_home, line_cursor_end,
+    line_kill_to_end, line_kill_to_start, line_set, line_length, line_cursor_pos,
     g_argv, parse_args,
     cmd_help, cmd_exit, cmd_pid, cmd_echo, cmd_clear, print_prompt,
     MAX_LINE, MAX_ARGS, MAX_PATH,
@@ -17,7 +20,23 @@ import common {
 
 import os {
     os_readdir, os_spawn_and_wait, os_yield,
-    os_default_ls_path, os_bin_path_1, os_bin_path_2
+    os_default_ls_path, os_bin_path_1, os_bin_path_2,
+    os_enable_raw_mode, os_disable_raw_mode, os_is_raw_mode
+}
+
+import input {
+    input_reset, input_parse_byte, input_in_escape, input_get_char,
+    cursor_left, cursor_right, clear_to_eol,
+    KEY_NONE, KEY_CHAR, KEY_UP, KEY_DOWN, KEY_RIGHT, KEY_LEFT,
+    KEY_HOME, KEY_END, KEY_DELETE, KEY_BACKSPACE, KEY_ENTER, KEY_TAB,
+    KEY_CTRL_C, KEY_CTRL_D, KEY_CTRL_A, KEY_CTRL_E,
+    KEY_CTRL_K, KEY_CTRL_U, KEY_CTRL_W, KEY_CTRL_L,
+    KEY_ESCAPE, KEY_UNKNOWN
+}
+
+import history {
+    history_add, history_reset_nav, history_up, history_down,
+    history_count
 }
 
 import ritzlib.sys { sys_read, sys_write }
@@ -189,6 +208,28 @@ fn print_help()
     println(c"  clear     Clear the screen")
 
 # ============================================================================
+# Redraw line from cursor position
+# ============================================================================
+# After modifying text mid-line, redraw the remainder and reposition cursor
+
+fn redraw_line_from_cursor()
+    # Save cursor position
+    let cur: i64 = line_cursor_pos()
+    let len: i64 = line_length()
+
+    # Write rest of line from cursor
+    if cur < len
+        sys_write(STDOUT, @g_line_buffer[cur as i32], len - cur)
+
+    # Clear anything after (in case line got shorter)
+    clear_to_eol()
+
+    # Move cursor back to where it should be
+    let chars_to_move_back: i32 = (len - cur) as i32
+    if chars_to_move_back > 0
+        cursor_left(chars_to_move_back)
+
+# ============================================================================
 # Main
 # ============================================================================
 
@@ -200,6 +241,13 @@ pub fn main(argc: i32, argv: **u8) -> i32
             print_help()
             return 0
 
+    # Enable raw mode for escape sequence handling
+    let raw_result: i32 = os_enable_raw_mode()
+    if raw_result != 0
+        puts(c"Warning: Could not enable raw mode (")
+        print_num(raw_result)
+        println(c")")
+
     println(c"")
     println(c"===========================================")
     println(version_string())
@@ -208,39 +256,161 @@ pub fn main(argc: i32, argv: **u8) -> i32
     println(c"")
 
     var read_buf: [1]u8
-    var running: bool = true
+    var running: i32 = 1
 
-    while running
+    while running != 0
         print_prompt()
         line_clear()
+        history_reset_nav()
+        input_reset()
 
-        var reading: bool = true
-        while reading
+        var reading: i32 = 1
+        while reading != 0
             let n: i64 = sys_read(STDIN, @read_buf[0], 1)
 
             if n > 0
-                let c: u8 = read_buf[0]
+                let b: u8 = read_buf[0]
+                let key: i32 = input_parse_byte(b)
 
-                if c == 13 or c == 10
+                if key == KEY_NONE
+                    # In the middle of escape sequence, continue reading
+                    continue
+
+                if key == KEY_ENTER
                     println(c"")
+                    # Add to history before processing
+                    if line_length() > 0
+                        history_add(@g_line_buffer[0])
                     process_line()
-                    reading = false
-                else if c == 127 or c == 8
-                    line_backspace()
-                else if c == 3
+                    reading = 0
+
+                else if key == KEY_BACKSPACE
+                    if line_cursor_pos() > 0
+                        # Visual: backspace, print rest of line, clear extra, reposition
+                        line_backspace()
+                        # Move visual cursor back
+                        cursor_left(1)
+                        # Redraw from new position
+                        redraw_line_from_cursor()
+
+                else if key == KEY_DELETE
+                    if line_cursor_pos() < line_length()
+                        line_delete()
+                        redraw_line_from_cursor()
+
+                else if key == KEY_LEFT
+                    if line_cursor_left()
+                        cursor_left(1)
+
+                else if key == KEY_RIGHT
+                    if line_cursor_right()
+                        cursor_right(1)
+
+                else if key == KEY_HOME or key == KEY_CTRL_A
+                    let move_amount: i32 = line_cursor_pos() as i32
+                    line_cursor_home()
+                    if move_amount > 0
+                        cursor_left(move_amount)
+
+                else if key == KEY_END or key == KEY_CTRL_E
+                    let cur: i64 = line_cursor_pos()
+                    let len: i64 = line_length()
+                    let move_amount: i32 = (len - cur) as i32
+                    line_cursor_end()
+                    if move_amount > 0
+                        cursor_right(move_amount)
+
+                else if key == KEY_UP
+                    let hist: *u8 = history_up()
+                    if hist != null
+                        # Clear current line visually
+                        let cur: i64 = line_cursor_pos()
+                        if cur > 0
+                            cursor_left(cur as i32)
+                        clear_to_eol()
+                        # Set line to history entry
+                        line_set(hist)
+                        # Display it
+                        puts(hist)
+
+                else if key == KEY_DOWN
+                    let hist: *u8 = history_down()
+                    # Clear current line visually
+                    let cur: i64 = line_cursor_pos()
+                    if cur > 0
+                        cursor_left(cur as i32)
+                    clear_to_eol()
+                    if hist != null
+                        # Set line to history entry
+                        line_set(hist)
+                        puts(hist)
+                    else
+                        # Back to empty prompt
+                        line_clear()
+
+                else if key == KEY_CTRL_C
                     println(c"^C")
                     line_clear()
-                    reading = false
-                else if c == 4
-                    if g_line_pos == 0
+                    reading = 0
+
+                else if key == KEY_CTRL_D
+                    if line_length() == 0
                         println(c"")
-                        running = false
-                        reading = false
-                else if c >= 32 and c < 127
+                        running = 0
+                        reading = 0
+                    # If line has content, Ctrl+D does nothing (or could delete char)
+
+                else if key == KEY_CTRL_K
+                    # Kill to end of line
+                    line_kill_to_end()
+                    clear_to_eol()
+
+                else if key == KEY_CTRL_U
+                    # Kill to start of line
+                    let cur: i64 = line_cursor_pos()
+                    if cur > 0
+                        cursor_left(cur as i32)
+                    line_kill_to_start()
+                    redraw_line_from_cursor()
+
+                else if key == KEY_CTRL_L
+                    # Clear screen: ESC [ 2 J ESC [ H
+                    var clr_buf: [8]u8
+                    clr_buf[0] = 27   # ESC
+                    clr_buf[1] = 91   # [
+                    clr_buf[2] = 50   # 2
+                    clr_buf[3] = 74   # J
+                    clr_buf[4] = 27   # ESC
+                    clr_buf[5] = 91   # [
+                    clr_buf[6] = 72   # H
+                    sys_write(STDOUT, @clr_buf[0], 7)
+                    print_prompt()
+                    # Redraw current line
+                    if line_length() > 0
+                        sys_write(STDOUT, @g_line_buffer[0], line_length())
+                        # Position cursor correctly
+                        let cur: i64 = line_cursor_pos()
+                        let len: i64 = line_length()
+                        if cur < len
+                            cursor_left((len - cur) as i32)
+
+                else if (key & 0xFFFF) == KEY_CHAR
+                    let c: u8 = input_get_char(key)
+                    let at_end: bool = line_cursor_pos() == line_length()
                     line_add_char(c)
-                    putchar(c)
+                    if at_end
+                        # Simple case: just echo the character
+                        putchar(c)
+                    else
+                        # Inserted in middle: need to redraw
+                        putchar(c)
+                        redraw_line_from_cursor()
+
+                # Other keys (TAB, CTRL_W, etc.) can be added later
+
             else
                 os_yield()
 
+    os_disable_raw_mode()
     println(c"Goodbye!")
     return 0

--- a/projects/rzsh/src/os.ritz
+++ b/projects/rzsh/src/os.ritz
@@ -12,8 +12,12 @@ import ritzlib.sys {
     # Linux-specific (only used when target_os=linux)
     sys_open, sys_close, sys_getdents64, sys_fork, sys_execve, sys_wait4, sys_exit,
     O_RDONLY, O_DIRECTORY,
+    tcgetattr, tcsetattr, Termios,
+    ECHO, ICANON, ISIG, IEXTEN, ICRNL, IXON,
+    VMIN, VTIME, STDIN,
     # Harland-specific (only used when target_os=harland)
-    sys_readdir, sys_spawn_args, sys_wait, sys_yield
+    sys_readdir, sys_spawn_args, sys_wait, sys_yield,
+    sys_tty_getattr, sys_tty_setattr, TtyAttrs, TTY_ECHO, TTY_ICANON
 }
 
 import ritzlib.str { strlen }
@@ -155,3 +159,83 @@ pub fn os_bin_path_1() -> *u8
 [[target_os = "harland"]]
 pub fn os_bin_path_2() -> *u8
     return c"/bin/"  # Only one path on Harland for now
+
+# ============================================================================
+# Terminal raw mode
+# ============================================================================
+# Raw mode disables canonical input (line buffering) and echo, allowing
+# character-by-character input with escape sequence detection.
+
+# Shared state for raw mode tracking (used by both targets)
+# Note: g_orig_termios storage is platform-specific but we need one buffer
+# that holds Termios (60 bytes) or TtyAttrs (4 bytes) depending on target.
+# We allocate enough for Termios (the larger one).
+var g_termios_storage: [64]u8
+# 0 = not in raw mode, 1 = in raw mode
+var g_raw_mode_active: i32 = 0
+
+# Linux: Save original termios and apply raw mode settings
+[[target_os = "linux"]]
+pub fn os_enable_raw_mode() -> i32
+    if g_raw_mode_active != 0
+        return 0  # Already in raw mode
+
+    # Cast storage to Termios pointer
+    let orig_termios: *Termios = @g_termios_storage[0] as *Termios
+
+    # Get current terminal settings
+    let r1: i32 = tcgetattr(STDIN, orig_termios)
+    if r1 != 0
+        return r1  # Failed (probably not a tty)
+
+    # Create raw mode settings
+    var raw: Termios = *orig_termios
+
+    # Disable canonical mode, echo, signals, extended processing
+    raw.c_lflag = raw.c_lflag & (0xFFFFFFFF ^ (ECHO | ICANON | ISIG | IEXTEN))
+
+    # Disable CR->NL translation and XON/XOFF
+    raw.c_iflag = raw.c_iflag & (0xFFFFFFFF ^ (ICRNL | IXON))
+
+    # Set minimum characters for read to 1, timeout to 0
+    raw.c_cc[VMIN] = 1
+    raw.c_cc[VTIME] = 0
+
+    # Apply raw mode
+    let r2: i32 = tcsetattr(STDIN, @raw)
+    if r2 != 0
+        return r2
+
+    g_raw_mode_active = 1
+    return 0
+
+[[target_os = "linux"]]
+pub fn os_disable_raw_mode() -> i32
+    if g_raw_mode_active == 0
+        return 0  # Not in raw mode
+
+    # Restore original terminal settings
+    let orig_termios: *Termios = @g_termios_storage[0] as *Termios
+    let r: i32 = tcsetattr(STDIN, orig_termios)
+    g_raw_mode_active = 0
+    return r
+
+[[target_os = "linux"]]
+pub fn os_is_raw_mode() -> bool
+    return g_raw_mode_active != 0
+
+# Harland: Terminal is always in "raw" mode from the shell's perspective
+# The kernel provides character-by-character input via serial console
+[[target_os = "harland"]]
+pub fn os_enable_raw_mode() -> i32
+    g_raw_mode_active = 1
+    return 0  # Always succeeds - Harland serial is already raw
+
+[[target_os = "harland"]]
+pub fn os_disable_raw_mode() -> i32
+    g_raw_mode_active = 0
+    return 0
+
+[[target_os = "harland"]]
+pub fn os_is_raw_mode() -> bool
+    return g_raw_mode_active != 0

--- a/projects/rzsh/test/test_history.ritz
+++ b/projects/rzsh/test/test_history.ritz
@@ -1,0 +1,251 @@
+# Tests for command history
+
+import ritzlib.sys { sys_write, STDOUT }
+import ritzlib.str { strlen, strcmp }
+
+import src.history {
+    history_add, history_reset_nav, history_up, history_down,
+    history_nav_pos, history_count, history_get, history_clear,
+    HISTORY_SIZE
+}
+
+fn puts(s: *u8) -> i64
+    return sys_write(STDOUT, s, strlen(s))
+
+fn println(s: *u8) -> i64
+    puts(s)
+    var nl: u8 = 10
+    return sys_write(STDOUT, @nl, 1)
+
+fn print_num(n: i32)
+    if n < 0
+        var minus: u8 = 45
+        sys_write(STDOUT, @minus, 1)
+        print_num(-n)
+        return
+    if n >= 10
+        print_num(n / 10)
+    var digit: u8 = ((n % 10) + 48) as u8
+    sys_write(STDOUT, @digit, 1)
+
+# ============================================================================
+# Test: Basic add and count
+# ============================================================================
+
+[[test]]
+fn test_history_add() -> i32
+    println(c"Testing history add...")
+    history_clear()
+
+    if history_count() != 0
+        println(c"  FAIL: count should be 0 after clear")
+        return 1
+
+    history_add(c"first command")
+    if history_count() != 1
+        puts(c"  FAIL: count should be 1, got ")
+        print_num(history_count())
+        println(c"")
+        return 1
+
+    history_add(c"second command")
+    if history_count() != 2
+        println(c"  FAIL: count should be 2")
+        return 1
+
+    # Empty strings should not be added
+    history_add(c"")
+    if history_count() != 2
+        println(c"  FAIL: empty string should not be added")
+        return 1
+
+    println(c"  PASS: History add works")
+    return 0
+
+# ============================================================================
+# Test: Duplicate detection
+# ============================================================================
+
+[[test]]
+fn test_history_no_duplicates() -> i32
+    println(c"Testing history duplicate detection...")
+    history_clear()
+
+    history_add(c"cmd1")
+    history_add(c"cmd1")  # Duplicate - should not be added
+    if history_count() != 1
+        puts(c"  FAIL: count should be 1, got ")
+        print_num(history_count())
+        println(c"")
+        return 1
+
+    history_add(c"cmd2")
+    history_add(c"cmd1")  # Different from last - should be added
+    if history_count() != 3
+        puts(c"  FAIL: count should be 3, got ")
+        print_num(history_count())
+        println(c"")
+        return 1
+
+    println(c"  PASS: Duplicate detection works")
+    return 0
+
+# ============================================================================
+# Test: Navigation up
+# ============================================================================
+
+[[test]]
+fn test_history_up() -> i32
+    println(c"Testing history navigation up...")
+    history_clear()
+
+    history_add(c"oldest")
+    history_add(c"middle")
+    history_add(c"newest")
+    history_reset_nav()
+
+    # First up should get "newest"
+    let h1: *u8 = history_up()
+    if h1 == null
+        println(c"  FAIL: first up returned null")
+        return 1
+    if strcmp(h1, c"newest") != 0
+        puts(c"  FAIL: expected 'newest', got '")
+        puts(h1)
+        println(c"'")
+        return 1
+
+    # Second up should get "middle"
+    let h2: *u8 = history_up()
+    if h2 == null
+        println(c"  FAIL: second up returned null")
+        return 1
+    if strcmp(h2, c"middle") != 0
+        puts(c"  FAIL: expected 'middle', got '")
+        puts(h2)
+        println(c"'")
+        return 1
+
+    # Third up should get "oldest"
+    let h3: *u8 = history_up()
+    if h3 == null
+        println(c"  FAIL: third up returned null")
+        return 1
+    if strcmp(h3, c"oldest") != 0
+        puts(c"  FAIL: expected 'oldest', got '")
+        puts(h3)
+        println(c"'")
+        return 1
+
+    # Fourth up should return null (at oldest)
+    let h4: *u8 = history_up()
+    if h4 != null
+        println(c"  FAIL: fourth up should return null")
+        return 1
+
+    println(c"  PASS: Navigation up works")
+    return 0
+
+# ============================================================================
+# Test: Navigation down
+# ============================================================================
+
+[[test]]
+fn test_history_down() -> i32
+    println(c"Testing history navigation down...")
+    history_clear()
+
+    history_add(c"oldest")
+    history_add(c"newest")
+    history_reset_nav()
+
+    # Go up twice (to oldest)
+    history_up()  # newest
+    history_up()  # oldest
+
+    # Now go down - should get "newest"
+    let h1: *u8 = history_down()
+    if h1 == null
+        println(c"  FAIL: first down returned null")
+        return 1
+    if strcmp(h1, c"newest") != 0
+        puts(c"  FAIL: expected 'newest', got '")
+        puts(h1)
+        println(c"'")
+        return 1
+
+    # Second down should return null (back at prompt)
+    let h2: *u8 = history_down()
+    if h2 != null
+        println(c"  FAIL: second down should return null (at prompt)")
+        return 1
+
+    # Navigation position should be -1 (at prompt)
+    if history_nav_pos() != -1
+        puts(c"  FAIL: nav_pos should be -1, got ")
+        print_num(history_nav_pos())
+        println(c"")
+        return 1
+
+    println(c"  PASS: Navigation down works")
+    return 0
+
+# ============================================================================
+# Test: Get by index
+# ============================================================================
+
+[[test]]
+fn test_history_get() -> i32
+    println(c"Testing history_get...")
+    history_clear()
+
+    history_add(c"cmd0")
+    history_add(c"cmd1")
+    history_add(c"cmd2")
+
+    # Index 0 should be oldest
+    let h0: *u8 = history_get(0)
+    if h0 == null or strcmp(h0, c"cmd0") != 0
+        println(c"  FAIL: get(0) should return 'cmd0'")
+        return 1
+
+    # Index 2 should be newest
+    let h2: *u8 = history_get(2)
+    if h2 == null or strcmp(h2, c"cmd2") != 0
+        println(c"  FAIL: get(2) should return 'cmd2'")
+        return 1
+
+    # Out of range should return null
+    let h3: *u8 = history_get(3)
+    if h3 != null
+        println(c"  FAIL: get(3) should return null")
+        return 1
+
+    let h_neg: *u8 = history_get(-1)
+    if h_neg != null
+        println(c"  FAIL: get(-1) should return null")
+        return 1
+
+    println(c"  PASS: history_get works")
+    return 0
+
+# ============================================================================
+# Test: Empty history navigation
+# ============================================================================
+
+[[test]]
+fn test_history_empty() -> i32
+    println(c"Testing empty history navigation...")
+    history_clear()
+    history_reset_nav()
+
+    if history_up() != null
+        println(c"  FAIL: up on empty history should return null")
+        return 1
+
+    if history_down() != null
+        println(c"  FAIL: down on empty history should return null")
+        return 1
+
+    println(c"  PASS: Empty history handled correctly")
+    return 0

--- a/projects/rzsh/test/test_input.ritz
+++ b/projects/rzsh/test/test_input.ritz
@@ -1,0 +1,260 @@
+# Tests for escape sequence parsing
+
+import ritzlib.sys { sys_write, STDOUT }
+import ritzlib.str { strlen }
+
+import src.input {
+    input_reset, input_parse_byte, input_in_escape, input_get_char,
+    KEY_NONE, KEY_CHAR, KEY_UP, KEY_DOWN, KEY_RIGHT, KEY_LEFT,
+    KEY_HOME, KEY_END, KEY_DELETE, KEY_BACKSPACE, KEY_ENTER, KEY_TAB,
+    KEY_CTRL_C, KEY_CTRL_D, KEY_CTRL_A, KEY_CTRL_E,
+    KEY_ESCAPE, KEY_UNKNOWN
+}
+
+fn puts(s: *u8) -> i64
+    return sys_write(STDOUT, s, strlen(s))
+
+fn println(s: *u8) -> i64
+    puts(s)
+    var nl: u8 = 10
+    return sys_write(STDOUT, @nl, 1)
+
+fn print_num(n: i32)
+    if n < 0
+        var minus: u8 = 45
+        sys_write(STDOUT, @minus, 1)
+        print_num(-n)
+        return
+    if n >= 10
+        print_num(n / 10)
+    var digit: u8 = ((n % 10) + 48) as u8
+    sys_write(STDOUT, @digit, 1)
+
+fn assert_eq(name: *u8, expected: i32, actual: i32) -> bool
+    if expected != actual
+        puts(c"  FAIL: ")
+        puts(name)
+        puts(c" expected ")
+        print_num(expected)
+        puts(c" got ")
+        print_num(actual)
+        println(c"")
+        return false
+    return true
+
+# ============================================================================
+# Test: Regular characters
+# ============================================================================
+
+[[test]]
+fn test_regular_chars() -> i32
+    println(c"Testing regular character parsing...")
+    input_reset()
+
+    # Test printable characters
+    let key_a: i32 = input_parse_byte(97)  # 'a'
+    if (key_a & 0xFFFF) != KEY_CHAR
+        println(c"  FAIL: 'a' should return KEY_CHAR")
+        return 1
+
+    let char_a: u8 = input_get_char(key_a)
+    if char_a != 97
+        puts(c"  FAIL: char should be 'a' (97), got ")
+        print_num(char_a as i32)
+        println(c"")
+        return 1
+
+    # Test space
+    let key_sp: i32 = input_parse_byte(32)  # ' '
+    if (key_sp & 0xFFFF) != KEY_CHAR
+        println(c"  FAIL: space should return KEY_CHAR")
+        return 1
+
+    if input_get_char(key_sp) != 32
+        println(c"  FAIL: space char wrong")
+        return 1
+
+    println(c"  PASS: Regular characters parsed correctly")
+    return 0
+
+# ============================================================================
+# Test: Control characters
+# ============================================================================
+
+[[test]]
+fn test_control_chars() -> i32
+    println(c"Testing control character parsing...")
+    input_reset()
+
+    # Backspace (127)
+    if not assert_eq(c"backspace 127", KEY_BACKSPACE, input_parse_byte(127))
+        return 1
+
+    # Backspace (8)
+    if not assert_eq(c"backspace 8", KEY_BACKSPACE, input_parse_byte(8))
+        return 1
+
+    # Enter (13)
+    if not assert_eq(c"enter CR", KEY_ENTER, input_parse_byte(13))
+        return 1
+
+    # Enter (10)
+    if not assert_eq(c"enter LF", KEY_ENTER, input_parse_byte(10))
+        return 1
+
+    # Tab
+    if not assert_eq(c"tab", KEY_TAB, input_parse_byte(9))
+        return 1
+
+    # Ctrl+C
+    if not assert_eq(c"ctrl-c", KEY_CTRL_C, input_parse_byte(3))
+        return 1
+
+    # Ctrl+D
+    if not assert_eq(c"ctrl-d", KEY_CTRL_D, input_parse_byte(4))
+        return 1
+
+    # Ctrl+A
+    if not assert_eq(c"ctrl-a", KEY_CTRL_A, input_parse_byte(1))
+        return 1
+
+    # Ctrl+E
+    if not assert_eq(c"ctrl-e", KEY_CTRL_E, input_parse_byte(5))
+        return 1
+
+    println(c"  PASS: Control characters parsed correctly")
+    return 0
+
+# ============================================================================
+# Test: Arrow keys
+# ============================================================================
+
+[[test]]
+fn test_arrow_keys() -> i32
+    println(c"Testing arrow key parsing...")
+
+    # Up arrow: ESC [ A
+    input_reset()
+    if not assert_eq(c"up esc", KEY_NONE, input_parse_byte(27))
+        return 1
+    if not input_in_escape()
+        println(c"  FAIL: should be in escape state")
+        return 1
+    if not assert_eq(c"up bracket", KEY_NONE, input_parse_byte(91))
+        return 1
+    if not assert_eq(c"up A", KEY_UP, input_parse_byte(65))
+        return 1
+    if input_in_escape()
+        println(c"  FAIL: should not be in escape state")
+        return 1
+
+    # Down arrow: ESC [ B
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    if not assert_eq(c"down B", KEY_DOWN, input_parse_byte(66))
+        return 1
+
+    # Right arrow: ESC [ C
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    if not assert_eq(c"right C", KEY_RIGHT, input_parse_byte(67))
+        return 1
+
+    # Left arrow: ESC [ D
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    if not assert_eq(c"left D", KEY_LEFT, input_parse_byte(68))
+        return 1
+
+    println(c"  PASS: Arrow keys parsed correctly")
+    return 0
+
+# ============================================================================
+# Test: Home/End keys
+# ============================================================================
+
+[[test]]
+fn test_home_end() -> i32
+    println(c"Testing Home/End key parsing...")
+
+    # Home: ESC [ H
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    if not assert_eq(c"home H", KEY_HOME, input_parse_byte(72))
+        return 1
+
+    # End: ESC [ F
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    if not assert_eq(c"end F", KEY_END, input_parse_byte(70))
+        return 1
+
+    # Home alternate: ESC [ 1 ~
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    if not assert_eq(c"home 1", KEY_NONE, input_parse_byte(49))  # '1'
+        return 1
+    if not assert_eq(c"home ~", KEY_HOME, input_parse_byte(126))  # '~'
+        return 1
+
+    # End alternate: ESC [ 4 ~
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    input_parse_byte(52)  # '4'
+    if not assert_eq(c"end 4~", KEY_END, input_parse_byte(126))
+        return 1
+
+    println(c"  PASS: Home/End keys parsed correctly")
+    return 0
+
+# ============================================================================
+# Test: Delete key
+# ============================================================================
+
+[[test]]
+fn test_delete() -> i32
+    println(c"Testing Delete key parsing...")
+
+    # Delete: ESC [ 3 ~
+    input_reset()
+    input_parse_byte(27)
+    input_parse_byte(91)
+    input_parse_byte(51)  # '3'
+    if not assert_eq(c"delete 3~", KEY_DELETE, input_parse_byte(126))
+        return 1
+
+    println(c"  PASS: Delete key parsed correctly")
+    return 0
+
+# ============================================================================
+# Test: Escape key (bare ESC)
+# ============================================================================
+
+[[test]]
+fn test_bare_escape() -> i32
+    println(c"Testing bare ESC handling...")
+
+    # ESC followed by non-sequence character
+    input_reset()
+    let r1: i32 = input_parse_byte(27)
+    if r1 != KEY_NONE
+        println(c"  FAIL: ESC should return KEY_NONE")
+        return 1
+
+    # Non-bracket character after ESC
+    let r2: i32 = input_parse_byte(120)  # 'x' - not a valid sequence start
+    if r2 != KEY_ESCAPE
+        puts(c"  FAIL: ESC+x should return KEY_ESCAPE, got ")
+        print_num(r2)
+        println(c"")
+        return 1
+
+    println(c"  PASS: Bare ESC handled correctly")
+    return 0

--- a/projects/rzsh/test/test_termios.ritz
+++ b/projects/rzsh/test/test_termios.ritz
@@ -1,0 +1,204 @@
+# Test file for terminal I/O support
+#
+# Tests termios structures and syscalls for raw mode terminal support.
+# These tests run on Linux only since that's where we develop/test.
+
+import ritzlib.sys {
+    sys_write, sys_ioctl, tcgetattr, tcsetattr, get_winsize,
+    Termios, Winsize,
+    TCGETS, TCSETS, TIOCGWINSZ,
+    ECHO, ICANON, ISIG, IEXTEN, ICRNL, IXON,
+    VMIN, VTIME,
+    STDIN, STDOUT
+}
+import ritzlib.str { strlen }
+
+fn puts(s: *u8) -> i64
+    return sys_write(STDOUT, s, strlen(s))
+
+fn println(s: *u8) -> i64
+    puts(s)
+    var nl: u8 = 10
+    return sys_write(STDOUT, @nl, 1)
+
+fn print_num(n: i32)
+    if n >= 10
+        print_num(n / 10)
+    var digit: u8 = ((n % 10) + 48) as u8
+    sys_write(STDOUT, @digit, 1)
+
+fn print_u32(n: u32)
+    print_num(n as i32)
+
+# ============================================================================
+# Test: Termios structure size
+# ============================================================================
+
+[[test]]
+fn test_termios_get() -> i32
+    println(c"Testing tcgetattr...")
+
+    var termios: Termios
+
+    # Get current terminal attributes
+    let result: i32 = tcgetattr(STDIN, @termios)
+
+    puts(c"  tcgetattr returned: ")
+    print_num(result)
+    println(c"")
+
+    if result != 0
+        # ENOTTY (-25) is expected when running without a terminal
+        # (e.g., in CI, piped, or under test harness)
+        println(c"  SKIP: stdin is not a tty (expected in CI)")
+        return 0  # Skip, not fail
+
+    # Print some values to verify structure is being read correctly
+    puts(c"  c_lflag: ")
+    print_u32(termios.c_lflag)
+    println(c"")
+
+    puts(c"  c_iflag: ")
+    print_u32(termios.c_iflag)
+    println(c"")
+
+    puts(c"  c_oflag: ")
+    print_u32(termios.c_oflag)
+    println(c"")
+
+    puts(c"  c_cflag: ")
+    print_u32(termios.c_cflag)
+    println(c"")
+
+    # Verify ECHO is set (should be for normal terminal)
+    # Note: When run via test harness, ECHO may not be set
+    puts(c"  ECHO flag: ")
+    if (termios.c_lflag & ECHO) != 0
+        println(c"set")
+    else
+        println(c"not set")
+
+    puts(c"  ICANON flag: ")
+    if (termios.c_lflag & ICANON) != 0
+        println(c"set")
+    else
+        println(c"not set")
+
+    println(c"  PASS: tcgetattr succeeded")
+    return 0
+
+# ============================================================================
+# Test: Get window size
+# ============================================================================
+
+[[test]]
+fn test_winsize() -> i32
+    println(c"Testing get_winsize...")
+
+    var ws: Winsize
+
+    let result: i32 = get_winsize(STDOUT, @ws)
+
+    puts(c"  get_winsize returned: ")
+    print_num(result)
+    println(c"")
+
+    # Note: This may fail if stdout is not a tty (e.g., piped output)
+    if result != 0
+        println(c"  INFO: get_winsize failed (stdout may not be a tty)")
+        # Don't fail the test - this is expected when running under a test harness
+        return 0
+
+    puts(c"  Rows: ")
+    print_num(ws.ws_row as i32)
+    println(c"")
+
+    puts(c"  Cols: ")
+    print_num(ws.ws_col as i32)
+    println(c"")
+
+    println(c"  PASS: get_winsize succeeded")
+    return 0
+
+# ============================================================================
+# Test: Raw mode enable/disable
+# ============================================================================
+
+[[test]]
+fn test_raw_mode_roundtrip() -> i32
+    println(c"Testing raw mode roundtrip...")
+
+    # Get original termios
+    var orig: Termios
+    let r1: i32 = tcgetattr(STDIN, @orig)
+    if r1 != 0
+        # ENOTTY (-25) is expected when running without a terminal
+        println(c"  SKIP: stdin is not a tty (expected in CI)")
+        return 0  # Skip, not fail
+
+    let orig_lflag: u32 = orig.c_lflag
+    puts(c"  Original c_lflag: ")
+    print_u32(orig_lflag)
+    println(c"")
+
+    # Modify to raw mode - work on orig directly since we already saved orig_lflag
+    # We'll restore from a fresh tcgetattr call
+
+    # Disable canonical mode, echo, signals, extended processing
+    orig.c_lflag = orig.c_lflag & (0xFFFFFFFF ^ (ECHO | ICANON | ISIG | IEXTEN))
+
+    # Disable CR->NL translation and XON/XOFF
+    orig.c_iflag = orig.c_iflag & (0xFFFFFFFF ^ (ICRNL | IXON))
+
+    # Set minimum characters for read to 1, timeout to 0
+    orig.c_cc[VMIN] = 1
+    orig.c_cc[VTIME] = 0
+
+    puts(c"  Modified c_lflag: ")
+    print_u32(orig.c_lflag)
+    println(c"")
+
+    # Apply raw mode
+    let r2: i32 = tcsetattr(STDIN, @orig)
+    if r2 != 0
+        println(c"  FAIL: tcsetattr (raw) failed")
+        return 1
+
+    println(c"  Raw mode applied")
+
+    # Get fresh copy of terminal state and restore original lflag
+    # (We can't easily copy structs, so we modify in place)
+    var restore: Termios
+    let r2b: i32 = tcgetattr(STDIN, @restore)
+    if r2b != 0
+        println(c"  FAIL: tcgetattr for restore failed")
+        return 1
+
+    # Restore original flags
+    restore.c_lflag = orig_lflag
+    restore.c_iflag = restore.c_iflag | ICRNL | IXON
+
+    let r3: i32 = tcsetattr(STDIN, @restore)
+    if r3 != 0
+        println(c"  FAIL: tcsetattr (restore) failed")
+        return 1
+
+    println(c"  Original mode restored")
+
+    # Verify restoration
+    var verify: Termios
+    let r4: i32 = tcgetattr(STDIN, @verify)
+    if r4 != 0
+        println(c"  FAIL: Verification tcgetattr failed")
+        return 1
+
+    if verify.c_lflag != orig_lflag
+        puts(c"  FAIL: c_lflag not restored. Expected: ")
+        print_u32(orig_lflag)
+        puts(c", got: ")
+        print_u32(verify.c_lflag)
+        println(c"")
+        return 1
+
+    println(c"  PASS: Raw mode roundtrip succeeded")
+    return 0


### PR DESCRIPTION
## Summary

This PR adds readline-like terminal input handling to rzsh:

- **Raw terminal mode** - Disables line buffering and echo for character-by-character input
- **Escape sequence parsing** - Handles arrow keys, Home/End, Delete, and other special keys
- **Cursor movement** - Left/right arrows move within the line, Home/End jump to start/end
- **Mid-line editing** - Insert and delete characters anywhere in the line with proper screen redraw
- **Command history** - Up/down arrows navigate through previously entered commands
- **Emacs-style keybindings** - Ctrl+A/E (home/end), Ctrl+K/U (kill line), Ctrl+L (clear screen)

### Architecture

The implementation follows the OS abstraction pattern:
- `os.ritz` - `os_enable_raw_mode()` uses Linux termios, Harland stubs (serial is inherently raw)
- `input.ritz` - Platform-independent escape sequence state machine
- `history.ritz` - Ring buffer for command history with navigation
- `common.ritz` - Line buffer with separate length and cursor position tracking

### Files Changed

- `projects/ritz/ritzlib/sys.ritz` - Added termios structures and tcgetattr/tcsetattr wrappers
- `projects/rzsh/src/os.ritz` - Added raw mode enable/disable functions
- `projects/rzsh/src/input.ritz` - New escape sequence parser and cursor helpers
- `projects/rzsh/src/history.ritz` - New command history ring buffer
- `projects/rzsh/src/common.ritz` - Updated line buffer with cursor-aware editing
- `projects/rzsh/src/main.ritz` - Integrated all features into main input loop
- `projects/rzsh/test/` - Added tests for input parsing and history

## Test plan

- [x] Build passes for both Linux and Harland targets
- [x] Shell runs in terminal with raw mode (tested via `script`)
- [x] Arrow keys move cursor left/right
- [x] Home/End and Ctrl+A/E work
- [x] Backspace/Delete work at any position
- [x] Up/down arrows navigate history
- [x] Ctrl+C cancels line, Ctrl+D exits on empty line
- [x] Ctrl+K/U kill to end/start of line
- [x] Ctrl+L clears screen and redraws prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)