### PR TITLE
ritz0: Fix duplicate memset function error

### DIFF
--- a/projects/ritz/ritz0/emitter_llvmlite.py
+++ b/projects/ritz/ritz0/emitter_llvmlite.py
@@ -2755,6 +2755,12 @@ class LLVMEmitter:
 
         Signature: void *memset(void *dest, int c, size_t n)
         """
+        # Check if memset already exists (e.g., from ritzlib.str import)
+        # If so, skip emitting our version - the user-provided one will work
+        for gv in self.module.global_values:
+            if gv.name == "memset":
+                return  # memset already defined, don't emit duplicate
+
         # void* memset(void* dest, int c, size_t n)
         memset_ty = ir.FunctionType(
             self.i8.as_pointer(),


### PR DESCRIPTION
## Summary
- Fix compiler error when both user code imports `ritzlib.str` (which has `memset`) and uses array fill syntax `[0; N]` (which triggers `llvm.memset` intrinsic)
- The emitter now checks if `memset` already exists before emitting its version

## Problem
When LLVM lowers the `llvm.memset` intrinsic, the compiler emits its own `memset` function for `-nostdlib` linking. However, if user code imports `ritzlib.str` (which defines its own `memset`), this caused a `DuplicatedNameError: memset`.

This was causing 60 test failures in squeeze when tests used array fill syntax.

## Solution
Check if `memset` already exists in the module before emitting. If a user-provided memset exists, skip emitting our version since the user's implementation will work fine.

## Test plan
- [x] `./rz test squeeze` - All 199 tests pass (previously 60 failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)