### PR TITLE
ritz,cryptosec: Fix stack alignment, TLS buffer, and TaskServer API

### DIFF
--- a/projects/cryptosec/lib/tls13_record.ritz
+++ b/projects/cryptosec/lib/tls13_record.ritz
@@ -79,8 +79,9 @@ pub fn tls13_parse_inner_plaintext(inner: *u8, inner_len: i32, content_type: *u8
 # ============================================================================
 
 pub fn tls13_record_encrypt(key: *u8, key_len: i32, iv: *u8, seq: u64, plaintext: *u8, plaintext_len: i32, content_type: u8, out: *u8, out_cap: i32) -> i32
-    var inner: [1024]u8
-    let inner_len: i32 = tls13_build_inner_plaintext(plaintext, plaintext_len, content_type, @inner[0], 1024)
+    # TLS 1.3 handshake messages can be up to ~4KB (with large certificates)
+    var inner: [8192]u8
+    let inner_len: i32 = tls13_build_inner_plaintext(plaintext, plaintext_len, content_type, @inner[0], 8192)
     if inner_len < 0
         return -1
 

--- a/projects/ritz/ritzlib/async_tasks.ritz
+++ b/projects/ritz/ritzlib/async_tasks.ritz
@@ -500,6 +500,36 @@ pub fn task_server_destroy(srv: *TaskServer)
     uring_destroy(@srv.ring)
 
 
+# Create a TaskServer on the heap (too large for stack - ~4.5MB)
+# Returns null on allocation failure
+pub fn task_server_create(listen_fd: i32) -> *TaskServer
+    # TaskServer is large due to TaskPool containing arrays
+    # Allocate via mmap
+    let size: i64 = 5 * 1024 * 1024  # 5MB to be safe
+    let flags: i32 = MAP_PRIVATE + MAP_ANONYMOUS
+    let prot: i32 = PROT_READ + PROT_WRITE
+    let ptr: *u8 = sys_mmap(0, size, prot, flags, -1, 0)
+    if ptr == (-1 as *u8)
+        return null
+
+    let srv: *TaskServer = ptr as *TaskServer
+    let ret: i32 = task_server_init(srv, listen_fd)
+    if ret < 0
+        sys_munmap(ptr, size)
+        return null
+
+    return srv
+
+
+# Free a heap-allocated TaskServer
+pub fn task_server_free(srv: *TaskServer)
+    if srv == null
+        return
+    task_server_destroy(srv)
+    let size: i64 = 5 * 1024 * 1024
+    sys_munmap(srv as *u8, size)
+
+
 # Submit an accept SQE
 pub fn task_server_submit_accept(srv: *TaskServer) -> i32
     let sqe = uring_get_sqe(@srv.ring)

--- a/projects/ritz/runtime/ritz_start.x86_64.ll
+++ b/projects/ritz/runtime/ritz_start.x86_64.ll
@@ -18,7 +18,6 @@ entry:
     movq (%rsp), %rdi
     leaq 8(%rsp), %rsi
     andq $$-16, %rsp
-    subq $$8, %rsp
     call main
     movq %rax, %rdi
     movq $$60, %rax

--- a/projects/ritz/runtime/ritz_start_envp.x86_64.ll
+++ b/projects/ritz/runtime/ritz_start_envp.x86_64.ll
@@ -24,7 +24,6 @@ entry:
     shlq $$3, %rax
     leaq 8(%rsp,%rax), %rdx
     andq $$-16, %rsp
-    subq $$8, %rsp
     call main
     movq %rax, %rdi
     movq $$60, %rax


### PR DESCRIPTION
## Summary

- **Fix x86-64 ABI stack alignment** in runtime entry points - removed erroneous `subq $8, %rsp` that caused AVX instruction crashes (SIGSEGV in SHA-256) when main had argc/argv parameters
- **Increase TLS record buffer** from 1KB to 8KB to handle certificate chains (Let's Encrypt certs were 2178 bytes)
- **Add missing TaskServer API** functions (`task_server_create`/`task_server_free`) that valet requires but were missing after PR #85

## Test plan

- [x] Verified HMAC-SHA256 test passes with `main(argc, argv)` signature (was crashing before)
- [x] Verified valet builds successfully
- [x] Verified TLS handshake progresses further (ServerHello + encrypted flight now sends successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)