### PR TITLE
Add getcwd/chdir syscalls and pipeline design

### DIFF
--- a/projects/harland/boot/test.sh
+++ b/projects/harland/boot/test.sh
@@ -163,10 +163,15 @@ for elf in "$INDIUM_DIR/build/debug"/*.elf; do
     fi
 done
 
-# Copy prism_demo
+# Copy prism binaries
 if [ -f "$PRISM_DIR/build/debug/prism_demo.elf" ]; then
     cp "$PRISM_DIR/build/debug/prism_demo.elf" "$INITRAMFS_TMP/bin/prism_demo"
     echo "    /bin/prism_demo"
+fi
+
+if [ -f "$PRISM_DIR/build/debug/hello_gfx.elf" ]; then
+    cp "$PRISM_DIR/build/debug/hello_gfx.elf" "$INITRAMFS_TMP/bin/hello_gfx"
+    echo "    /bin/hello_gfx"
 fi
 
 # Copy rzsh

--- a/projects/harland/docs/PIPELINE_DESIGN.md
+++ b/projects/harland/docs/PIPELINE_DESIGN.md
@@ -1,0 +1,465 @@
+# Pipeline & I/O Design for Harland
+
+> Design document for shell pipelines, I/O redirection, and capability-based
+> process spawning in the Harland microkernel.
+
+## Overview
+
+Harland uses `spawn()` not `fork()+exec()`, and channels instead of Unix pipes.
+This document outlines how shell pipelines (`cmd1 | cmd2 | cmd3`) and I/O
+redirection (`cmd > file`, `cmd < file`) should work in this model.
+
+## Design Principles
+
+1. **Capabilities over magic numbers** - No `stdin=0, stdout=1, stderr=2` magic.
+   I/O endpoints are explicit capabilities granted at spawn time.
+
+2. **Typed channels** - `Channel<T>` for IPC. For byte streams, `Channel<u8>`
+   with internal buffering (chunks of 4KB).
+
+3. **Explicit grants** - Parent must explicitly grant capabilities to child.
+   Secure default: children get nothing unless granted.
+
+4. **No fork()** - Process creation is always explicit via `spawn()`.
+
+---
+
+## Part 1: Channel-Based Byte Streams
+
+### Channel Types
+
+```ritz
+# Typed channel endpoints
+struct ChannelRead<T>
+    id: u64          # Kernel-assigned handle
+
+struct ChannelWrite<T>
+    id: u64          # Kernel-assigned handle
+
+# Byte channel for stdin/stdout (buffered internally)
+type ByteReader = ChannelRead<u8>
+type ByteWriter = ChannelWrite<u8>
+```
+
+### Internal Buffering
+
+Byte channels use internal 4KB chunks for efficiency:
+
+```ritz
+# Kernel-side buffer (internal, not exposed to userspace)
+struct ChannelBuffer
+    chunks: Vec<[u8; 4096]>
+    read_pos: usize        # Position in first chunk
+    write_closed: bool
+    read_closed: bool
+```
+
+User code reads/writes bytes; the kernel handles chunking transparently:
+
+```ritz
+# Userspace API
+fn channel_read(reader: ByteReader, buf: []u8) -> Result<usize, IoError>
+fn channel_write(writer: ByteWriter, data: []u8) -> Result<usize, IoError>
+fn channel_close_read(reader: ByteReader)
+fn channel_close_write(writer: ByteWriter)
+```
+
+### Syscall Interface
+
+```ritz
+# Create a byte channel (returns read + write endpoints)
+const SYS_CHANNEL_CREATE: u64 = 50
+
+fn sys_channel_create() -> i64
+    # Returns: channel ID on success, negative on error
+    # Caller then uses SYS_CHANNEL_READ/WRITE with this ID
+
+const SYS_CHANNEL_READ: u64 = 51
+const SYS_CHANNEL_WRITE: u64 = 52
+const SYS_CHANNEL_CLOSE: u64 = 53
+
+fn sys_channel_read(chan_id: u64, buf: *u8, len: u64) -> i64
+    # Returns bytes read, 0 on EOF, negative on error
+
+fn sys_channel_write(chan_id: u64, buf: *u8, len: u64) -> i64
+    # Returns bytes written, negative on error
+
+fn sys_channel_close(chan_id: u64, which: u64) -> i64
+    # which: 0=read end, 1=write end
+```
+
+---
+
+## Part 2: Capability-Based Spawn
+
+### Current State
+
+```ritz
+# What we have now (syscall.ritz)
+fn sys_spawn(path: *u8) -> i64
+fn sys_spawn_args(path: *u8, argv: **u8, argc: i32) -> i64
+```
+
+### Target State
+
+```ritz
+# New spawn with explicit I/O capabilities
+const SYS_SPAWN_EX: u64 = 25
+
+struct SpawnOptions
+    stdin_cap: u64      # Channel ID for stdin (0 = none/closed)
+    stdout_cap: u64     # Channel ID for stdout (0 = none/closed)
+    stderr_cap: u64     # Channel ID for stderr (0 = none/closed)
+    cwd_cap: u64        # Path capability for cwd (0 = inherit)
+    flags: u64          # Reserved
+
+fn sys_spawn_ex(
+    path: *u8,
+    argv: **u8,
+    argc: i32,
+    opts: *SpawnOptions
+) -> i64
+    # Returns PID on success, negative on error
+```
+
+### How Children See I/O
+
+When a child is spawned with `SpawnOptions`, the kernel:
+
+1. Creates the process with empty capability table
+2. If `stdin_cap != 0`: Maps channel ID to the child's "stdin slot"
+3. If `stdout_cap != 0`: Maps channel ID to the child's "stdout slot"
+4. If `stderr_cap != 0`: Maps channel ID to the child's "stderr slot"
+
+Child code uses standard I/O syscalls:
+
+```ritz
+# In child process (e.g., cat, grep, etc.)
+fn main() -> i32
+    var buf: [4096]u8
+
+    # sys_read with fd=0 reads from the stdin capability
+    let n = sys_read(0, @buf[0], 4096)
+
+    # sys_write with fd=1 writes to the stdout capability
+    sys_write(1, @buf[0], n as u64)
+
+    0
+```
+
+The kernel translates fd 0/1/2 to the actual channel capabilities.
+
+---
+
+## Part 3: Shell Pipeline Example
+
+### Parsing `ls | grep foo | wc -l`
+
+```ritz
+# Shell parses pipeline into:
+struct PipelineStage
+    cmd: StrView
+    args: Vec<StrView>
+
+let stages: Vec<PipelineStage> = [
+    PipelineStage { cmd: "ls", args: [] },
+    PipelineStage { cmd: "grep", args: ["foo"] },
+    PipelineStage { cmd: "wc", args: ["-l"] },
+]
+```
+
+### Execution Flow
+
+```ritz
+fn execute_pipeline(stages: []PipelineStage) -> i32
+    let n = stages.len()
+
+    # Create n-1 channels (one between each pair of stages)
+    var channels: Vec<(ByteReader, ByteWriter)> = Vec::new()
+    for i in 0..n-1
+        channels.push(sys_channel_create())
+
+    # Spawn each stage with appropriate I/O
+    var pids: Vec<i64> = Vec::new()
+
+    for i in 0..n
+        var opts: SpawnOptions
+
+        # stdin: read from previous channel (or shell's stdin for first)
+        if i == 0
+            opts.stdin_cap = shell_stdin_cap
+        else
+            opts.stdin_cap = channels[i-1].0.id  # read end
+
+        # stdout: write to next channel (or shell's stdout for last)
+        if i == n - 1
+            opts.stdout_cap = shell_stdout_cap
+        else
+            opts.stdout_cap = channels[i].1.id  # write end
+
+        # stderr: inherit shell's stderr
+        opts.stderr_cap = shell_stderr_cap
+
+        let pid = sys_spawn_ex(stages[i].cmd, stages[i].args, opts)
+        pids.push(pid)
+
+        # Close our handles (children have their own refs)
+        if i > 0
+            channel_close_read(channels[i-1].0)   # We don't read
+        if i < n - 1
+            channel_close_write(channels[i].1)    # We don't write
+
+    # Wait for all processes
+    var last_exit = 0
+    for pid in pids
+        last_exit = sys_wait(pid)
+
+    last_exit
+```
+
+---
+
+## Part 4: I/O Redirection
+
+### Output Redirection (`cmd > file`)
+
+```ritz
+fn execute_with_redirect_out(cmd: StrView, args: []StrView, path: StrView) -> i32
+    # Open file for writing
+    let fd = sys_open(path.ptr, O_WRONLY | O_CREAT | O_TRUNC)
+    if fd < 0
+        return -1
+
+    # Spawn with stdout pointing to file
+    var opts: SpawnOptions
+    opts.stdin_cap = shell_stdin_cap
+    opts.stdout_cap = fd as u64  # File descriptor as capability
+    opts.stderr_cap = shell_stderr_cap
+
+    let pid = sys_spawn_ex(cmd, args, opts)
+    sys_close(fd)  # Close our handle
+
+    sys_wait(pid)
+```
+
+### Input Redirection (`cmd < file`)
+
+```ritz
+fn execute_with_redirect_in(cmd: StrView, args: []StrView, path: StrView) -> i32
+    # Open file for reading
+    let fd = sys_open(path.ptr, O_RDONLY)
+    if fd < 0
+        return -1
+
+    # Spawn with stdin pointing to file
+    var opts: SpawnOptions
+    opts.stdin_cap = fd as u64
+    opts.stdout_cap = shell_stdout_cap
+    opts.stderr_cap = shell_stderr_cap
+
+    let pid = sys_spawn_ex(cmd, args, opts)
+    sys_close(fd)
+
+    sys_wait(pid)
+```
+
+---
+
+## Part 5: Built-in Commands
+
+These commands modify shell state and cannot be external binaries:
+
+| Command | Why Built-in | Implementation |
+|---------|--------------|----------------|
+| `cd DIR` | Changes shell's CWD | `sys_chdir(dir)` |
+| `pwd` | Shows shell's CWD | `sys_getcwd(buf)` |
+| `exit [N]` | Exits shell process | `sys_exit(n)` |
+| `export VAR=VAL` | Modifies shell env | In-memory env table |
+
+### Required Syscalls
+
+```ritz
+const SYS_GETCWD: u64 = 26
+const SYS_CHDIR: u64 = 27
+
+fn sys_getcwd(buf: *u8, size: u64) -> i64
+    # Returns length of path, or negative on error
+    # Writes null-terminated path to buf
+
+fn sys_chdir(path: *u8) -> i64
+    # Returns 0 on success, negative on error
+    # Changes the calling process's CWD
+```
+
+### Per-Process CWD
+
+```ritz
+# In kernel Process struct
+pub struct Process
+    pid: u64
+    state: u64
+    entry_point: u64
+    user_stack_top: u64
+    kernel_stack_top: u64
+    page_table: u64
+    # NEW: Working directory
+    cwd: [256]u8           # Current working directory path
+    cwd_len: u16           # Length of CWD string
+```
+
+---
+
+## Part 6: ritzutils Project
+
+External utilities that work with pipelines:
+
+| Utility | Description |
+|---------|-------------|
+| `cat` | Concatenate files to stdout |
+| `head` | Output first N lines |
+| `tail` | Output last N lines |
+| `wc` | Word/line/byte count |
+| `grep` | Pattern matching |
+| `sort` | Sort lines |
+| `uniq` | Remove duplicate lines |
+| `tr` | Translate characters |
+| `cut` | Extract columns |
+| `tee` | Copy stdin to file and stdout |
+
+### Project Structure
+
+```
+projects/ritzutils/
+├── ritz.toml           # Multi-binary build
+├── src/
+│   ├── cat.ritz
+│   ├── head.ritz
+│   ├── tail.ritz
+│   ├── wc.ritz
+│   ├── grep.ritz
+│   └── ...
+└── build/debug/
+    ├── cat.elf
+    ├── head.elf
+    └── ...
+```
+
+### ritz.toml
+
+```toml
+[package]
+name = "ritzutils"
+version = "0.1.0"
+target = "harland"
+
+[[bin]]
+name = "cat"
+path = "src/cat.ritz"
+
+[[bin]]
+name = "head"
+path = "src/head.ritz"
+
+[[bin]]
+name = "wc"
+path = "src/wc.ritz"
+
+# ... more binaries
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation (This PR)
+- [ ] `sys_getcwd` syscall
+- [ ] `sys_chdir` syscall
+- [ ] Per-process CWD in Process struct
+- [ ] Tests for CWD operations
+
+### Phase 2: Byte Channels
+- [ ] `sys_channel_create` syscall
+- [ ] `sys_channel_read` / `sys_channel_write` syscalls
+- [ ] `sys_channel_close` syscall
+- [ ] Internal buffering (4KB chunks)
+- [ ] Tests for channel operations
+
+### Phase 3: Spawn with Capabilities
+- [ ] `sys_spawn_ex` syscall
+- [ ] `SpawnOptions` struct
+- [ ] Map stdin/stdout/stderr caps to fd 0/1/2
+- [ ] Tests for capability-based spawn
+
+### Phase 4: ritzutils
+- [ ] Create project structure
+- [ ] Implement `cat` utility
+- [ ] Update indium build to include ritzutils
+- [ ] Test `cat` with pipelines
+
+### Phase 5: rzsh Integration
+- [ ] `cd` / `pwd` builtins
+- [ ] Pipeline parsing (`|`)
+- [ ] Output redirection (`>`, `>>`)
+- [ ] Input redirection (`<`)
+
+---
+
+## Security Considerations
+
+### Principle of Least Privilege
+
+Children receive **only** the capabilities explicitly granted:
+
+```ritz
+# BAD (Unix-style): Child inherits everything
+fork()  # Child has access to all parent's fds, memory, etc.
+
+# GOOD (Harland-style): Explicit grants
+var opts: SpawnOptions
+opts.stdin_cap = channel.read_end    # Only stdin
+opts.stdout_cap = channel.write_end  # Only stdout
+# No stderr, no filesystem, no network
+spawn_ex(cmd, args, opts)
+```
+
+### Secure Defaults
+
+```ritz
+# Default SpawnOptions (no capabilities)
+const SPAWN_OPTS_DEFAULT: SpawnOptions = SpawnOptions {
+    stdin_cap: 0,   # Closed
+    stdout_cap: 0,  # Closed
+    stderr_cap: 0,  # Closed
+    cwd_cap: 0,     # Inherit parent's CWD
+    flags: 0,
+}
+```
+
+### Capability Inheritance Options
+
+For convenience, we may add flags:
+
+```ritz
+const SPAWN_INHERIT_STDIO: u64 = 1 << 0    # Inherit stdin/stdout/stderr
+const SPAWN_INHERIT_CWD: u64 = 1 << 1      # Inherit CWD
+const SPAWN_INHERIT_ENV: u64 = 1 << 2      # Inherit environment
+
+# Shell convenience: inherit everything (less secure)
+var opts: SpawnOptions
+opts.flags = SPAWN_INHERIT_STDIO | SPAWN_INHERIT_CWD | SPAWN_INHERIT_ENV
+```
+
+But the secure default remains explicit grants.
+
+---
+
+## References
+
+- `projects/harland/docs/ARCHITECTURE.md` - Kernel architecture
+- `projects/harland/docs/KERNEL_CONTRACT.md` - API contract
+- `projects/harland/kernel/src/arch/x86_64/syscall.ritz` - Syscall implementation
+- `projects/rzsh/` - Ritz shell project
+
+---
+
+*This design document was created for LARB review and implementation planning.*

--- a/projects/harland/kernel/src/arch/x86_64/syscall.ritz
+++ b/projects/harland/kernel/src/arch/x86_64/syscall.ritz
@@ -19,11 +19,12 @@
 #   - IA32_SFMASK (0xC0000084): RFLAGS mask (clear IF on entry)
 #   - IA32_EFER (0xC0000080): Enable SCE bit for SYSCALL instruction
 
-import fs.knamespace { KNamespace, knamespace_get, knamespace_list, knamespace_read }
+import fs.knamespace { KNamespace, knamespace_get, knamespace_list, knamespace_read, knamespace_lookup }
 import fs.kdir_entry { KDirEntry }
 import fs.kblob { KBlobStore, KBlobId, kblob_get_store, kblob_store_get, kblob_store_get_size }
 import fs.kpath { strview_from_ptr }
 import serial { StrView }
+import process { process_get_cwd, process_set_cwd }
 
 # ============================================================================
 # MSR Numbers for SYSCALL/SYSRET
@@ -65,6 +66,8 @@ pub const SYS_SPAWN: u64 = 21
 pub const SYS_WAIT: u64 = 22
 pub const SYS_GETPID: u64 = 23
 pub const SYS_YIELD: u64 = 24
+pub const SYS_GETCWD: u64 = 26
+pub const SYS_CHDIR: u64 = 27
 
 # IPC
 pub const SYS_IPC_SEND: u64 = 30
@@ -251,6 +254,12 @@ pub fn syscall_handler(frame: *SyscallFrame) -> i64
     if syscall_num == SYS_ACPI_POWEROFF
         return sys_acpi_poweroff()
 
+    if syscall_num == SYS_GETCWD
+        return sys_getcwd(arg1 as *u8, arg2 as u64)
+
+    if syscall_num == SYS_CHDIR
+        return sys_chdir(arg1 as *u8)
+
     # Unknown syscall
     return -1
 
@@ -293,6 +302,58 @@ fn sys_yield() -> i64
 fn sys_getpid() -> i64
     # TODO: Return current process ID
     return 1  # Placeholder
+
+# ============================================================================
+# Working Directory Syscalls
+# ============================================================================
+
+# sys_getcwd: Get current working directory
+# buf: Buffer to write path to
+# size: Size of buffer
+# Returns: Length of path on success, -1 on error (buffer too small)
+fn sys_getcwd(buf: *u8, size: u64) -> i64
+    var cwd_len: u16 = 0
+    let cwd: *u8 = process_get_cwd(@cwd_len)
+
+    # Check buffer size (need room for null terminator)
+    if size < (cwd_len as u64 + 1)
+        return -1
+
+    # Copy CWD to user buffer
+    var i: u16 = 0
+    while i < cwd_len
+        *(buf + i as i64) = *(cwd + i as i64)
+        i = i + 1
+    *(buf + cwd_len as i64) = 0  # Null terminate
+
+    return cwd_len as i64
+
+# sys_chdir: Change current working directory
+# path: Path to new directory (null-terminated)
+# Returns: 0 on success, -1 on error (path not found or not a directory)
+fn sys_chdir(path: *u8) -> i64
+    # Get path length
+    let path_len: i64 = strlen(path)
+    if path_len == 0 or path_len >= 255
+        return -1
+
+    # Verify the path exists in the namespace
+    let ns: *KNamespace = knamespace_get()
+    if ns == 0 as *KNamespace
+        return -1
+
+    let path_view: StrView = strview_from_ptr(path, path_len)
+
+    # Check if path exists (by trying to list it as a directory)
+    var entries: [1]KDirEntry
+    let count: i32 = knamespace_list(ns, @path_view, @entries[0], 1)
+
+    # knamespace_list returns -1 if path not found, >= 0 otherwise
+    if count < 0
+        return -1
+
+    # Path exists, update CWD
+    return process_set_cwd(path, path_len as u16) as i64
 
 # ============================================================================
 # Serial Output (import from main or inline)

--- a/projects/harland/kernel/src/main.ritz
+++ b/projects/harland/kernel/src/main.ritz
@@ -2086,6 +2086,8 @@ const SYS_WAIT: u64 = 22
 const SYS_GETPID: u64 = 23
 const SYS_YIELD: u64 = 24
 const SYS_SPAWN_ARGS: u64 = 25
+const SYS_GETCWD: u64 = 26
+const SYS_CHDIR: u64 = 27
 const SYS_ACPI_POWEROFF: u64 = 200
 const SYS_FB_INFO: u64 = 210      # Get framebuffer info
 const SYS_FB_MAP: u64 = 211       # Map framebuffer into userspace
@@ -2764,6 +2766,80 @@ fn sys_munmap_impl(addr: u64, length: u64) -> i64
     return 0
 
 # ============================================================================
+# Working Directory Syscalls
+# ============================================================================
+#
+# Per-process current working directory support.
+# CWD is stored as a simple path string (max 255 bytes).
+# These syscalls allow userspace to:
+#   1. Get the current working directory (getcwd)
+#   2. Change the current working directory (chdir)
+
+# Global CWD storage (single process for now)
+var g_cwd: [256]u8
+var g_cwd_len: u16 = 1
+
+# Initialize CWD to root
+fn init_cwd()
+    g_cwd[0] = 47  # '/'
+    g_cwd[1] = 0   # null terminator
+    g_cwd_len = 1
+
+# sys_getcwd_impl: Get current working directory
+# Args: buf = buffer to write path to, size = buffer size
+# Returns: length of path on success, -1 if buffer too small
+fn sys_getcwd_impl(buf: *u8, size: u64) -> i64
+    # Check buffer size (need room for null terminator)
+    if size < (g_cwd_len as u64 + 1)
+        return -1
+
+    # Copy CWD to user buffer
+    var i: u16 = 0
+    while i < g_cwd_len
+        *(buf + i as i64) = g_cwd[i]
+        i = i + 1
+    *(buf + g_cwd_len as i64) = 0  # Null terminate
+
+    return g_cwd_len as i64
+
+# sys_chdir_impl: Change current working directory
+# Args: path = path to new directory (null-terminated)
+# Returns: 0 on success, -1 on error
+fn sys_chdir_impl(path: *u8) -> i64
+    # Get path length
+    var path_len: i64 = 0
+    while *(path + path_len) != 0 and path_len < 255
+        path_len = path_len + 1
+
+    if path_len == 0 or path_len >= 255
+        return -1
+
+    # Verify the path exists in the namespace
+    let ns: *KNamespace = knamespace_get()
+    if ns == 0 as *KNamespace
+        return -1
+
+    let path_view: StrView = strview_from_ptr(path, path_len)
+
+    # Check if path exists (by trying to list it as a directory)
+    var entries: [1]KDirEntry
+    let count: i32 = knamespace_list(ns, @path_view, @entries[0], 1)
+
+    # knamespace_list returns -1 if path not found, >= 0 otherwise
+    if count < 0
+        return -1
+
+    # Path exists, update CWD
+    var i: i64 = 0
+    while i < path_len
+        g_cwd[i] = *(path + i)
+        i = i + 1
+    g_cwd[path_len] = 0
+    g_cwd_len = path_len as u16
+
+    return 0
+
+# ============================================================================
 # Framebuffer Syscalls (for Prism compositor)
 # ============================================================================
 #
@@ -3104,6 +3180,15 @@ pub fn syscall_handler(rax: u64, rdi: u64, rsi: u64, rdx: u64, r10: u64) -> i64
     if rax == SYS_MUNMAP
         # munmap(addr, length)
         return sys_munmap_impl(rdi, rsi)
+
+    # Working directory syscalls
+    if rax == SYS_GETCWD
+        # getcwd(buf, size) -> length or -1
+        return sys_getcwd_impl(rdi as *u8, rsi)
+
+    if rax == SYS_CHDIR
+        # chdir(path) -> 0 or -1
+        return sys_chdir_impl(rdi as *u8)
 
     # ACPI power management syscalls
     if rax == SYS_ACPI_POWEROFF
@@ -4352,6 +4437,9 @@ pub fn kernel_main(boot_info_addr: u64) -> i32
         klog(c"  [..] Initial filesystem")
         initramfs_load()
         klog(c"\r  [OK] Initial filesystem\n")
+
+        # Initialize working directory to root
+        init_cwd()
 
         # Test filesystem operations
         fs_quick_test()

--- a/projects/harland/kernel/src/process.ritz
+++ b/projects/harland/kernel/src/process.ritz
@@ -14,6 +14,9 @@ pub struct Process
     user_stack_top: u64         # Top of user stack
     kernel_stack_top: u64       # Top of kernel stack (for syscalls)
     page_table: u64             # CR3 value (PML4 physical address)
+    # Working directory
+    cwd: [256]u8                # Current working directory path (null-terminated)
+    cwd_len: u16                # Length of CWD string (excluding null)
 
 # Process states
 const PROCESS_READY: u64 = 0
@@ -94,6 +97,11 @@ pub fn process_create_init() -> i32
     current_process.user_stack_top = USER_STACK_TOP
     # Use current page table for now (identity mapped)
     # TODO: Create separate user page table
+
+    # Initialize CWD to root
+    current_process.cwd[0] = 47  # '/'
+    current_process.cwd[1] = 0   # null terminator
+    current_process.cwd_len = 1
 
     prints("[process] Creating init process\n")
     prints("  Entry point: 0x")
@@ -191,3 +199,32 @@ fn serial_print_hex(value: u64) -> i32
         serial_write_byte(*(hex_chars + nibble as i64))
         i = i - 1
     return 0
+
+# ============================================================================
+# Current Working Directory
+# ============================================================================
+
+# Get the current process's CWD
+# Returns pointer to the CWD buffer and sets len to the length
+pub fn process_get_cwd(len: *u16) -> *u8
+    *len = current_process.cwd_len
+    return @current_process.cwd[0]
+
+# Set the current process's CWD
+# Returns 0 on success, -1 if path too long
+pub fn process_set_cwd(path: *u8, path_len: u16) -> i32
+    if path_len >= 255
+        return -1
+
+    # Copy path to CWD buffer
+    var i: u16 = 0
+    while i < path_len
+        current_process.cwd[i] = *(path + i as i64)
+        i = i + 1
+    current_process.cwd[path_len] = 0  # Null terminate
+    current_process.cwd_len = path_len
+    return 0
+
+# Get a pointer to the current process
+pub fn process_current() -> *Process
+    return @current_process

--- a/projects/indium/ritz.toml
+++ b/projects/indium/ritz.toml
@@ -264,3 +264,19 @@ script = "user/linker_pie.ld"
 
 [bin.mmap_test.flags]
 pic = true
+
+[[bin]]
+name = "cwd_test"
+entry = "cwd_test::main"
+target = "x86_64-unknown-none"
+target_os = "harland"
+sources = ["user"]
+freestanding = true
+link_runtime = true
+main_args = 0
+
+[bin.cwd_test.linker]
+script = "user/linker_pie.ld"
+
+[bin.cwd_test.flags]
+pic = true

--- a/projects/indium/user/cwd_test.ritz
+++ b/projects/indium/user/cwd_test.ritz
@@ -1,0 +1,92 @@
+# CWD Test - Tests getcwd and chdir syscalls
+#
+# Tests:
+# 1. getcwd returns "/" for initial process
+# 2. chdir to /bin succeeds
+# 3. getcwd returns "/bin" after chdir
+# 4. chdir to nonexistent path fails
+#
+# Returns 0 on success, 1 on failure.
+
+import libharland { print_str, sys_getcwd, sys_chdir, strcmp }
+
+# Helper: string equality (returns 1 if equal)
+fn str_eq(a: *u8, b: *u8) -> i32
+    if strcmp(a, b) == 0
+        return 1
+    return 0
+
+pub fn main() -> i32
+    var buf: [256]u8
+    var failed: i32 = 0
+
+    # Test 1: getcwd returns "/" initially
+    print_str(c"[cwd_test] getcwd initial... ")
+    let len1: i64 = sys_getcwd(@buf[0], 256)
+    if len1 < 0
+        print_str(c"FAIL (error)\n")
+        failed = 1
+    else if str_eq(@buf[0], c"/") == 1
+        print_str(c"PASS (cwd=/)\n")
+    else
+        print_str(c"FAIL (expected /, got: ")
+        print_str(@buf[0])
+        print_str(c")\n")
+        failed = 1
+
+    # Test 2: chdir to /bin
+    print_str(c"[cwd_test] chdir /bin... ")
+    let result2: i32 = sys_chdir(c"/bin")
+    if result2 == 0
+        print_str(c"PASS\n")
+    else
+        print_str(c"FAIL\n")
+        failed = 1
+
+    # Test 3: getcwd returns "/bin"
+    print_str(c"[cwd_test] getcwd after chdir... ")
+    let len3: i64 = sys_getcwd(@buf[0], 256)
+    if len3 < 0
+        print_str(c"FAIL (error)\n")
+        failed = 1
+    else if str_eq(@buf[0], c"/bin") == 1
+        print_str(c"PASS (cwd=/bin)\n")
+    else
+        print_str(c"FAIL (expected /bin, got: ")
+        print_str(@buf[0])
+        print_str(c")\n")
+        failed = 1
+
+    # Test 4: chdir to nonexistent path should fail
+    print_str(c"[cwd_test] chdir /nonexistent... ")
+    let result4: i32 = sys_chdir(c"/nonexistent")
+    if result4 < 0
+        print_str(c"PASS (correctly failed)\n")
+    else
+        print_str(c"FAIL (should have failed)\n")
+        failed = 1
+
+    # Test 5: chdir back to root
+    print_str(c"[cwd_test] chdir /... ")
+    let result5: i32 = sys_chdir(c"/")
+    if result5 == 0
+        print_str(c"PASS\n")
+    else
+        print_str(c"FAIL\n")
+        failed = 1
+
+    # Test 6: verify back at root
+    print_str(c"[cwd_test] getcwd final... ")
+    let len6: i64 = sys_getcwd(@buf[0], 256)
+    if len6 < 0
+        print_str(c"FAIL (error)\n")
+        failed = 1
+    else if str_eq(@buf[0], c"/") == 1
+        print_str(c"PASS (cwd=/)\n")
+    else
+        print_str(c"FAIL (expected /, got: ")
+        print_str(@buf[0])
+        print_str(c")\n")
+        failed = 1
+
+    return failed

--- a/projects/indium/user/init.ritz
+++ b/projects/indium/user/init.ritz
@@ -132,6 +132,7 @@ fn run_tier1_tests() -> i32
     run_test(c"/bin/seq10",       c"seq10",       0)
     run_test(c"/bin/cat_motd",    c"cat_motd",    0)
     run_test(c"/bin/hello_gfx",   c"hello_gfx",   0)
+    run_test(c"/bin/cwd_test",    c"cwd_test",    0)
 
     # Test rzsh --help (non-interactive)
     var rzsh_argv: [2]*u8

--- a/projects/indium/user/init.ritz
+++ b/projects/indium/user/init.ritz
@@ -131,6 +131,7 @@ fn run_tier1_tests() -> i32
     run_test(c"/bin/hello_tier1", c"hello_tier1", 0)
     run_test(c"/bin/seq10",       c"seq10",       0)
     run_test(c"/bin/cat_motd",    c"cat_motd",    0)
+    run_test(c"/bin/hello_gfx",   c"hello_gfx",   0)
 
     # Test rzsh --help (non-interactive)
     var rzsh_argv: [2]*u8

--- a/projects/indium/user/libharland.ritz
+++ b/projects/indium/user/libharland.ritz
@@ -16,6 +16,7 @@ import ritzlib.sys {
     syscall0, syscall1, syscall2, syscall3, syscall4,
     sys_read, sys_write, sys_exit, sys_yield, sys_getpid,
     sys_spawn, sys_spawn_args, sys_wait, sys_readdir, sys_acpi_poweroff,
+    sys_getcwd, sys_chdir,
     sys_mmap, sys_munmap,
     PROT_READ, PROT_WRITE, PROT_EXEC, MAP_PRIVATE, MAP_ANONYMOUS, MAP_FIXED,
     STDIN, STDOUT, STDERR

--- a/projects/prism/ritz.toml
+++ b/projects/prism/ritz.toml
@@ -26,6 +26,22 @@ script = "linker_pie.ld"
 [bin.prism_demo.flags]
 pic = true
 
+# Graphical Hello World demo with bitmap font
+[[bin]]
+name = "hello_gfx"
+entry = "hello_gfx::main"
+target = "x86_64-unknown-none"
+target_os = "harland"
+freestanding = true
+link_runtime = true
+main_args = 0
+
+[bin.hello_gfx.linker]
+script = "linker_pie.ld"
+
+[bin.hello_gfx.flags]
+pic = true
+
 # Dependencies temporarily disabled while angelo is being fixed
 # [dependencies]
 # angelo = { path = "../angelo" }

--- a/projects/prism/src/hello_gfx.ritz
+++ b/projects/prism/src/hello_gfx.ritz
@@ -1,0 +1,199 @@
+# Graphical Hello World for Harland
+#
+# Minimal userspace program that demonstrates bitmap text rendering
+# on the framebuffer. Uses a simple 8x8 bitmap font for ASCII.
+
+import ritzlib.sys { syscall1, syscall2, STDOUT }
+import ritzlib.str { strlen }
+
+# Harland framebuffer syscalls
+const SYS_WRITE: i64 = 1
+const SYS_FB_INFO: i64 = 210
+const SYS_FB_MAP: i64 = 211
+
+# Framebuffer info structure (must match kernel definition)
+struct FbInfo
+    addr: u64       # Physical address
+    width: u32      # Horizontal resolution
+    height: u32     # Vertical resolution
+    pitch: u32      # Bytes per scanline
+    bpp: u8         # Bits per pixel
+    format: u8      # Pixel format (0=RGBX, 1=BGRX)
+    _pad: [2]u8
+
+# Get framebuffer info
+fn sys_fb_info(info: *FbInfo) -> i64
+    syscall1(SYS_FB_INFO, info as i64)
+
+# Map framebuffer into userspace
+fn sys_fb_map() -> i64
+    syscall1(SYS_FB_MAP, 0)
+
+# Print to serial console
+fn print_str(s: *u8)
+    let len = strlen(s)
+    syscall2(SYS_WRITE, STDOUT as i64, s as i64, len as i64)
+
+# Pack RGB into BGRX format (common for UEFI)
+fn pack_bgrx(r: u8, g: u8, b: u8) -> u32
+    (b as u32) | ((g as u32) << 8) | ((r as u32) << 16)
+
+# Set a single pixel (bounds-checked)
+fn put_pixel(fb: *u32, pitch: u32, width: u32, height: u32, x: u32, y: u32, color: u32)
+    if x >= width or y >= height
+        return
+    let pixels_per_line = pitch / 4
+    let offset = (y as u64) * (pixels_per_line as u64) + (x as u64)
+    *(fb + offset) = color
+
+# Clear screen with a color
+fn clear_screen(fb: *u32, pitch: u32, width: u32, height: u32, color: u32)
+    let pixels_per_line = pitch / 4
+    var y: u32 = 0
+    while y < height
+        let row_offset = (y as u64) * (pixels_per_line as u64)
+        var x: u32 = 0
+        while x < width
+            *(fb + row_offset + (x as u64)) = color
+            x = x + 1
+        y = y + 1
+
+# =============================================================================
+# 8x8 Bitmap Font
+# =============================================================================
+
+# Get the bit pattern for a character's row
+# Returns 8 bits where MSB = leftmost pixel
+fn font_row(c: u8, row: u32) -> u8
+    let idx = row as usize
+
+    # H (72)
+    if c == 72
+        let font: [8]u8 = [0x66, 0x66, 0x66, 0x7E, 0x66, 0x66, 0x66, 0x00]
+        return font[idx]
+    # e (101)
+    if c == 101
+        let font: [8]u8 = [0x00, 0x00, 0x3C, 0x66, 0x7E, 0x60, 0x3C, 0x00]
+        return font[idx]
+    # l (108)
+    if c == 108
+        let font: [8]u8 = [0x38, 0x18, 0x18, 0x18, 0x18, 0x18, 0x3C, 0x00]
+        return font[idx]
+    # o (111)
+    if c == 111
+        let font: [8]u8 = [0x00, 0x00, 0x3C, 0x66, 0x66, 0x66, 0x3C, 0x00]
+        return font[idx]
+    # comma (44)
+    if c == 44
+        let font: [8]u8 = [0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x18, 0x30]
+        return font[idx]
+    # space (32)
+    if c == 32
+        return 0x00
+    # a (97)
+    if c == 97
+        let font: [8]u8 = [0x00, 0x00, 0x3C, 0x06, 0x3E, 0x66, 0x3E, 0x00]
+        return font[idx]
+    # r (114)
+    if c == 114
+        let font: [8]u8 = [0x00, 0x00, 0x6C, 0x76, 0x60, 0x60, 0x60, 0x00]
+        return font[idx]
+    # n (110)
+    if c == 110
+        let font: [8]u8 = [0x00, 0x00, 0x7C, 0x66, 0x66, 0x66, 0x66, 0x00]
+        return font[idx]
+    # d (100)
+    if c == 100
+        let font: [8]u8 = [0x06, 0x06, 0x3E, 0x66, 0x66, 0x66, 0x3E, 0x00]
+        return font[idx]
+    # ! (33)
+    if c == 33
+        let font: [8]u8 = [0x18, 0x18, 0x18, 0x18, 0x18, 0x00, 0x18, 0x00]
+        return font[idx]
+
+    # Default: empty glyph
+    0x00
+
+# Draw a single character at (x, y) with scaling
+fn draw_char(fb: *u32, pitch: u32, width: u32, height: u32, x: u32, y: u32, c: u8, color: u32, scale: u32)
+    var row: u32 = 0
+    while row < 8
+        let row_bits = font_row(c, row)
+        var col: u32 = 0
+        while col < 8
+            # Check if pixel is set (MSB first)
+            let mask: u8 = (0x80 >> col) as u8
+            if (row_bits and mask) != 0
+                # Draw scaled pixel block
+                var sy: u32 = 0
+                while sy < scale
+                    var sx: u32 = 0
+                    while sx < scale
+                        let px = x + col * scale + sx
+                        let py = y + row * scale + sy
+                        put_pixel(fb, pitch, width, height, px, py, color)
+                        sx = sx + 1
+                    sy = sy + 1
+            col = col + 1
+        row = row + 1
+
+# Draw a null-terminated string at (x, y)
+fn draw_string(fb: *u32, pitch: u32, width: u32, height: u32, x: u32, y: u32, text: *u8, color: u32, scale: u32)
+    var cur_x = x
+    var i: usize = 0
+    while *(text + i) != 0
+        let c = *(text + i)
+        draw_char(fb, pitch, width, height, cur_x, y, c, color, scale)
+        cur_x = cur_x + 8 * scale + scale  # 8px char + 1px spacing
+        i = i + 1
+
+# =============================================================================
+# Main
+# =============================================================================
+
+pub fn main() -> i32
+    print_str(c"[hello_gfx] Starting...\n")
+
+    # Get framebuffer info
+    var info: FbInfo
+    let info_result = sys_fb_info(@info)
+    if info_result != 0
+        print_str(c"[hello_gfx] ERROR: No framebuffer available\n")
+        return 1
+
+    print_str(c"[hello_gfx] Framebuffer detected\n")
+
+    # Map framebuffer into our address space
+    let fb_addr = sys_fb_map()
+    if fb_addr < 0
+        print_str(c"[hello_gfx] ERROR: Failed to map framebuffer\n")
+        return 1
+
+    print_str(c"[hello_gfx] Framebuffer mapped\n")
+
+    let fb = fb_addr as *u32
+
+    # Clear to Catppuccin Mocha base (dark blue #1E1E2E)
+    let bg = pack_bgrx(0x1E, 0x1E, 0x2E)
+    clear_screen(fb, info.pitch, info.width, info.height, bg)
+
+    print_str(c"[hello_gfx] Screen cleared\n")
+
+    # Calculate centered text position
+    # "Hello, Harland!" is 15 chars, each (8*scale + scale) pixels wide
+    let scale: u32 = 4
+    let char_width = 8 * scale + scale
+    let text_width = 15 * char_width
+    let text_height = 8 * scale
+
+    let text_x = (info.width - text_width) / 2
+    let text_y = (info.height - text_height) / 2
+
+    # Draw text in white
+    let white = pack_bgrx(0xFF, 0xFF, 0xFF)
+    draw_string(fb, info.pitch, info.width, info.height, text_x, text_y, c"Hello, Harland!", white, scale)
+
+    print_str(c"[hello_gfx] Text drawn\n")
+    print_str(c"[hello_gfx] SUCCESS - Hello, Harland! displayed!\n")
+
+    0

--- a/projects/ritz/ritz0/emitter_llvmlite.py
+++ b/projects/ritz/ritz0/emitter_llvmlite.py
@@ -4296,6 +4296,19 @@ class LLVMEmitter:
                     zero = ir.Constant(self.i32, 0)
                     ptr = self.builder.gep(alloca, [zero, index])
                     return self.builder.load(ptr)
+            elif name in self.params:
+                # let binding - array value is SSA (not alloca)
+                # Need to extract element using extractvalue
+                val, ty = self.params[name]
+                if isinstance(ty, ir.ArrayType):
+                    # For fixed-size arrays from let bindings, we need to
+                    # store temporarily to extract by dynamic index
+                    # (extractvalue requires constant index)
+                    alloca = self._alloca_in_entry_block(ty, f"{name}.tmp")
+                    self.builder.store(val, alloca)
+                    zero = ir.Constant(self.i32, 0)
+                    ptr = self.builder.gep(alloca, [zero, index])
+                    return self.builder.load(ptr)
             elif name in self.const_arrays:
                 # Const array - use two-level GEP [0, index] on the global
                 gvar, ty = self.const_arrays[name]

--- a/projects/ritz/ritzlib/sys.ritz
+++ b/projects/ritz/ritzlib/sys.ritz
@@ -71,6 +71,12 @@ const SYS_MUNMAP: i64 = 11
 [[target_os = "harland"]]
 const SYS_ACPI_POWEROFF: i64 = 200
 
+[[target_os = "harland"]]
+const SYS_GETCWD: i64 = 26
+
+[[target_os = "harland"]]
+const SYS_CHDIR: i64 = 27
+
 # Harland memory protection flags
 [[target_os = "harland"]]
 pub const PROT_READ: i32 = 1
@@ -122,6 +128,21 @@ pub fn sys_readdir(path: *u8, buf: *u8, buf_size: i64) -> i64
 [[target_os = "harland"]]
 pub fn sys_acpi_poweroff()
     syscall0(SYS_ACPI_POWEROFF)
+
+# sys_getcwd: Get current working directory
+# buf: Buffer to write path to (null-terminated)
+# size: Size of buffer
+# Returns: Length of path on success, -1 on error
+[[target_os = "harland"]]
+pub fn sys_getcwd(buf: *u8, size: i64) -> i64
+    return syscall2(SYS_GETCWD, buf as i64, size)
+
+# sys_chdir: Change current working directory
+# path: Path to new directory (null-terminated)
+# Returns: 0 on success, -1 on error
+[[target_os = "harland"]]
+pub fn sys_chdir(path: *u8) -> i32
+    return syscall1(SYS_CHDIR, path as i64) as i32
 
 # Harland memory mapping syscalls
 # sys_mmap: Map anonymous memory pages


### PR DESCRIPTION
## Summary

Phase 1 of shell pipeline support - kernel foundation work:

- **harland**: Add `SYS_GETCWD` (26) and `SYS_CHDIR` (27) syscalls
- **harland**: Add per-process CWD storage (global for now, will be per-process with spawn)
- **harland**: Create `PIPELINE_DESIGN.md` design document for future work
- **ritzlib**: Add `sys_getcwd`/`sys_chdir` wrappers for Harland target
- **indium**: Add `cwd_test` binary to verify syscall functionality
- **indium**: Update test suite (now 10 tests, all passing)

This enables shell builtins like `cd` and `pwd` to work on Harland. The design doc outlines the full pipeline implementation using capability-based channels instead of Unix pipes.

## Test Results

- UEFI boot: 10/10 tests passing
- BIOS boot: Kernel tests passing

## Test plan

- [x] `cwd_test` passes all 6 CWD tests
- [x] Full UEFI test suite passes (10/10)
- [x] Kernel builds without warnings
- [ ] Verify rzsh can use getcwd/chdir (future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)