### PR TITLE
ritz0: Add major language features for angelo compatibility

### DIFF
--- a/projects/ritz/ritz0/emitter_llvmlite.py
+++ b/projects/ritz/ritz0/emitter_llvmlite.py
@@ -2971,6 +2971,24 @@ class LLVMEmitter:
                     self.ritz_types[stmt.name] = inferred_ritz_type
             return None
 
+        elif isinstance(stmt, rast.LetTupleStmt):
+            # Tuple destructuring: let (a, b, c) = expr
+            # Emit the tuple expression
+            tuple_val = self._emit_expr(stmt.value)
+
+            # Extract each element and bind to the corresponding name
+            if not isinstance(tuple_val.type, ir.LiteralStructType):
+                raise ValueError(f"Cannot destructure non-tuple type: {tuple_val.type}")
+
+            if len(stmt.names) != len(tuple_val.type.elements):
+                raise ValueError(f"Tuple destructuring mismatch: expected {len(tuple_val.type.elements)} "
+                               f"elements, got {len(stmt.names)} names")
+
+            for i, name in enumerate(stmt.names):
+                elem_val = self.builder.extract_value(tuple_val, i)
+                self.params[name] = (elem_val, elem_val.type)
+            return None
+
         elif isinstance(stmt, rast.AssignStmt):
             val = self._emit_expr(stmt.value)
             if isinstance(stmt.target, rast.Ident):
@@ -4343,6 +4361,21 @@ class LLVMEmitter:
         elif isinstance(expr, rast.HeapExpr):
             return self._emit_heap_expr(expr)
 
+        elif isinstance(expr, rast.ContinueExpr):
+            return self._emit_continue_expr(expr)
+
+        elif isinstance(expr, rast.BreakExpr):
+            return self._emit_break_expr(expr)
+
+        elif isinstance(expr, rast.ReturnExpr):
+            return self._emit_return_expr(expr)
+
+        elif isinstance(expr, rast.Block):
+            return self._emit_block_expr(expr)
+
+        elif isinstance(expr, rast.AssignExpr):
+            return self._emit_assign_expr(expr)
+
         else:
             raise NotImplementedError(f"Expression: {type(expr)}")
 
@@ -5296,6 +5329,101 @@ class LLVMEmitter:
         #        *p = 100        // modify value
         #        free(p as *u8)  // manual cleanup
         return typed_ptr
+
+    def _emit_continue_expr(self, expr: rast.ContinueExpr) -> ir.Value:
+        """Emit continue as an expression (for use in match arms).
+
+        Branches to the loop continue target and returns an undefined value
+        (since we're diverging, the value is never used).
+        """
+        if not self.loop_stack:
+            raise RuntimeError("continue expression outside of loop")
+        continue_block, _ = self.loop_stack[-1]
+        self.builder.branch(continue_block)
+        # Return an undefined value - this is never used since we branched
+        return ir.Undefined
+
+    def _emit_break_expr(self, expr: rast.BreakExpr) -> ir.Value:
+        """Emit break as an expression (for use in match arms).
+
+        Branches to the loop break target and returns an undefined value
+        (since we're diverging, the value is never used).
+        """
+        if not self.loop_stack:
+            raise RuntimeError("break expression outside of loop")
+        _, break_block = self.loop_stack[-1]
+        self.builder.branch(break_block)
+        # Return an undefined value - this is never used since we branched
+        return ir.Undefined
+
+    def _emit_return_expr(self, expr: rast.ReturnExpr) -> ir.Value:
+        """Emit return as an expression (for use in match arms).
+
+        Emits the return instruction and returns an undefined value
+        (since we're diverging, the value is never used).
+        """
+        ret_type = self.current_fn.function_type.return_type
+        if expr.value is not None:
+            ret_val = self._emit_expr(expr.value)
+            ret_val = self._convert_type(ret_val, ret_type)
+            self.builder.ret(ret_val)
+        else:
+            if ret_type == self.void:
+                self.builder.ret_void()
+            else:
+                self.builder.ret(ir.Constant(ret_type, 0))
+        # Return an undefined value - this is never used since we returned
+        return ir.Undefined
+
+    def _emit_block_expr(self, block: rast.Block) -> ir.Value:
+        """Emit a block expression: { stmts; expr }.
+
+        Evaluates all statements and returns the value of the final expression.
+        Used for multiline match arms and other block contexts.
+        """
+        # Emit all statements
+        for stmt in block.stmts:
+            self._emit_stmt(stmt)
+
+        # Emit and return the final expression
+        if block.expr is not None:
+            return self._emit_expr(block.expr)
+        else:
+            # Void block - return undefined
+            return ir.Undefined
+
+    def _emit_assign_expr(self, expr: rast.AssignExpr) -> ir.Value:
+        """Emit an assignment expression: target = value.
+
+        Used for side-effect assignments in match arms:
+            Some(x) => self.field = x
+
+        Returns the assigned value.
+        """
+        val = self._emit_expr(expr.value)
+
+        # Handle different target types (similar to AssignStmt handling)
+        if isinstance(expr.target, rast.Ident):
+            name = expr.target.name
+            if name in self.locals:
+                alloca, ty = self.locals[name]
+                val = self._convert_type(val, ty)
+                self.builder.store(val, alloca)
+            elif name in self.globals:
+                gvar, ty = self.globals[name]
+                val = self._convert_type(val, ty)
+                self.builder.store(val, gvar)
+            else:
+                raise ValueError(f"Unknown variable: {name}")
+
+        else:
+            # For field access, index, dereference - use _emit_lvalue_addr
+            ptr = self._emit_lvalue_addr(expr.target)
+            target_ty = ptr.type.pointee
+            val = self._convert_type(val, target_ty)
+            self.builder.store(val, ptr)
+
+        return val
 
     def _emit_closure(self, closure: rast.Closure) -> ir.Value:
         """Emit a closure expression: |params| body.
@@ -7174,6 +7302,18 @@ class LLVMEmitter:
                     self._emit_array_convert_loop(src_alloca, arr_alloca, val.type, target_type)
 
                 return self.builder.load(arr_alloca)
+
+        # Struct/tuple conversion: {T1, T2, ...} to {U1, U2, ...}
+        # Both LiteralStructType (tuples) and IdentifiedStructType (named structs)
+        if isinstance(val.type, ir.LiteralStructType) and isinstance(target_type, ir.LiteralStructType):
+            if len(val.type.elements) == len(target_type.elements):
+                # Convert element by element
+                result = ir.Constant(target_type, ir.Undefined)
+                for i in range(len(val.type.elements)):
+                    elem = self.builder.extract_value(val, i)
+                    converted_elem = self._convert_type(elem, target_type.elements[i])
+                    result = self.builder.insert_value(result, converted_elem, i)
+                return result
 
         return val
 

--- a/projects/ritz/ritz0/parser.py
+++ b/projects/ritz/ritz0/parser.py
@@ -1014,10 +1014,32 @@ class Parser:
         raise ParseError(f"Expected expression, got {tok.type.name}", span)
 
     def parse_if(self) -> rast.If:
-        """Parse an if expression."""
+        """Parse an if expression.
+
+        Supports both block-style and ternary style:
+            if cond                           # block style
+                body
+            else
+                other
+
+            if cond then a else b             # ternary style (single line)
+        """
         span = self._current().span
         self._expect(TokenType.IF)
         cond = self.parse_expr()
+
+        # Check for ternary style: if cond then a else b
+        if self._at(TokenType.THEN):
+            self._advance()
+            then_expr = self.parse_expr()
+            self._expect(TokenType.ELSE)
+            else_expr = self.parse_expr()
+            # Wrap expressions in blocks for consistency
+            then_block = rast.Block(then_expr.span, [], then_expr)
+            else_block = rast.Block(else_expr.span, [], else_expr)
+            return rast.If(span, cond, then_block, else_block)
+
+        # Block style
         then_block = self.parse_block()
 
         else_block = None
@@ -1072,7 +1094,7 @@ class Parser:
 
         # Check for multiline arm: => followed by newline+indent
         if self._at(TokenType.NEWLINE):
-            self._advance()
+            self._skip_newlines()  # Skip all newlines (handles comments producing extra NEWLINEs)
             if self._at(TokenType.INDENT):
                 # Multiline: parse as block
                 body = self.parse_block()
@@ -1080,12 +1102,54 @@ class Parser:
                 # Just newline, then next arm - error
                 raise ParseError("Expected expression or indented block after '=>'", span)
         else:
-            # Single line: parse expression
-            body = self.parse_expr()
+            # Single line: parse expression or control flow statement
+            body = self.parse_match_arm_body()
             # Skip newline after arm body
             self._skip_newlines()
 
         return rast.MatchArm(span, pattern, guard, body)
+
+    def parse_match_arm_body(self) -> rast.Expr:
+        """Parse a single-line match arm body.
+
+        Supports regular expressions plus control flow and assignments:
+            Some(x) => x + 1
+            None => continue
+            None => break
+            None => return -1
+            Some(x) => self.field = x   (assignment as side-effect)
+        """
+        span = self._current().span
+
+        # continue as expression
+        if self._at(TokenType.CONTINUE):
+            self._advance()
+            return rast.ContinueExpr(span)
+
+        # break as expression
+        if self._at(TokenType.BREAK):
+            self._advance()
+            return rast.BreakExpr(span)
+
+        # return as expression
+        if self._at(TokenType.RETURN):
+            self._advance()
+            # Check if there's a value (not at newline/EOF)
+            if not self._at(TokenType.NEWLINE, TokenType.EOF, TokenType.DEDENT):
+                value = self.parse_expr()
+                return rast.ReturnExpr(span, value)
+            return rast.ReturnExpr(span, None)
+
+        # Parse expression - but check for assignment after
+        expr = self.parse_expr()
+
+        # Check for assignment (convert to AssignExpr for match arm context)
+        if self._at(TokenType.EQ):
+            self._advance()
+            value = self.parse_expr()
+            return rast.AssignExpr(span, expr, value)
+
+        return expr
 
     def parse_pattern(self) -> rast.Pattern:
         """Parse a pattern."""
@@ -1345,10 +1409,34 @@ class Parser:
 
         return rast.ExprStmt(span, expr)
 
-    def parse_let(self) -> rast.LetStmt:
-        """Parse a let binding."""
+    def parse_let(self) -> rast.Stmt:
+        """Parse a let binding.
+
+        Supports both regular bindings and tuple destructuring:
+            let x = expr
+            let x: T = expr
+            let (a, b, c) = expr
+        """
         span = self._current().span
         self._expect(TokenType.LET)
+
+        # Check for tuple destructuring: let (a, b, ...) = expr
+        if self._at(TokenType.LPAREN):
+            self._advance()
+            names = []
+            while not self._at(TokenType.RPAREN):
+                name_tok = self._expect(TokenType.IDENT)
+                names.append(name_tok.value)
+                if self._at(TokenType.COMMA):
+                    self._advance()
+                else:
+                    break
+            self._expect(TokenType.RPAREN)
+            self._expect(TokenType.EQ)
+            value = self.parse_expr()
+            return rast.LetTupleStmt(span, names, value)
+
+        # Regular binding
         name_tok = self._expect(TokenType.IDENT)
 
         type_ann = None

--- a/projects/ritz/ritz0/ritz_ast.py
+++ b/projects/ritz/ritz0/ritz_ast.py
@@ -482,6 +482,44 @@ class HeapExpr(Expr):
 
 
 @dataclass
+class ContinueExpr(Expr):
+    """Continue as an expression (for use in match arms).
+
+    Has the never type (!) since it diverges.
+    """
+    pass
+
+
+@dataclass
+class BreakExpr(Expr):
+    """Break as an expression (for use in match arms).
+
+    Has the never type (!) since it diverges.
+    """
+    pass
+
+
+@dataclass
+class ReturnExpr(Expr):
+    """Return as an expression (for use in match arms).
+
+    Has the never type (!) since it diverges.
+    """
+    value: Optional[Expr] = None
+
+
+@dataclass
+class AssignExpr(Expr):
+    """Assignment as an expression (for use in match arms).
+
+    Evaluates to the assigned value. Used for side-effect assignments:
+        Some(x) => self.field = x
+    """
+    target: Expr
+    value: Expr
+
+
+@dataclass
 class ClosureParam:
     """A closure parameter: name with optional type."""
     name: str
@@ -576,6 +614,13 @@ class LetStmt(Stmt):
     name: str
     type: Optional[Type]
     value: Optional[Expr]
+
+
+@dataclass
+class LetTupleStmt(Stmt):
+    """Tuple destructuring: let (a, b, c) = expr."""
+    names: List[str]
+    value: Expr
 
 
 @dataclass

--- a/projects/ritz/ritz0/tokens.py
+++ b/projects/ritz/ritz0/tokens.py
@@ -56,6 +56,7 @@ class TokenType(Enum):
     NULL = auto()
     HEAP = auto()
     PUB = auto()
+    THEN = auto()          # then (for ternary: if cond then a else b)
 
     # Logical operators as keywords (pythonic style)
     AND = auto()           # and
@@ -172,6 +173,7 @@ KEYWORDS = {
     'null': TokenType.NULL,
     'heap': TokenType.HEAP,
     'pub': TokenType.PUB,
+    'then': TokenType.THEN,
     'for': TokenType.FOR,
     'asm': TokenType.ASM,
     'and': TokenType.AND,


### PR DESCRIPTION
## Summary

Major language improvements to enable idiomatic Ritz patterns used in the angelo font library.

## Language Features Added

### Control Flow as Expressions
- **Continue/break/return in match arms**: `None => continue` now works in match inside loops
- **Assignment expressions in match arms**: `Some(x) => self.field = x` for side-effect assignments

### Expressions
- **Block expressions**: Multiline match arms with statements and final expression
- **Tuple destructuring**: `let (a, b) = tuple_returning_fn()` 
- **Ternary if-then-else**: `if cond then a else b` single-line style

### Bug Fixes
- **Tuple type conversion**: Proper i64 → i32 conversion for tuple elements on return
- **Multiline match arm parsing**: Properly skip newlines after `=>` before INDENT

## Test Plan
- [x] All existing ritz0 tests pass
- [x] Manual testing of each new feature

## Examples

```ritz
# Continue in match arm
for item in list
    let val = match opt
        Some(x) => x
        None => continue

# Tuple destructuring
let (x, y) = get_point()

# Ternary expression
let min = if a < b then a else b

# Assignment in match arm  
match result
    Some(x) => self.cache = x
    None => 0

# Multiline match arm with block
match value
    Some(x) =>
        # Comment works now!
        process(x)
        x + 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)