### PR TITLE
harland: Add AWS ENA network driver and netdev abstraction

### DIFF
--- a/projects/harland/kernel/src/drivers/ena/admin.ritz
+++ b/projects/harland/kernel/src/drivers/ena/admin.ritz
@@ -1,0 +1,366 @@
+# ENA Admin Queue Definitions
+#
+# The admin queue is used for control plane operations:
+# - Creating/destroying submission and completion queues
+# - Getting/setting device features
+# - Querying device statistics
+
+# ============================================================================
+# Admin Queue Command Opcodes
+# ============================================================================
+
+pub const ENA_ADMIN_CREATE_SQ: u8 = 1
+pub const ENA_ADMIN_DESTROY_SQ: u8 = 2
+pub const ENA_ADMIN_CREATE_CQ: u8 = 3
+pub const ENA_ADMIN_DESTROY_CQ: u8 = 4
+pub const ENA_ADMIN_GET_FEATURE: u8 = 8
+pub const ENA_ADMIN_SET_FEATURE: u8 = 9
+pub const ENA_ADMIN_GET_STATS: u8 = 11
+
+# ============================================================================
+# Admin Queue Completion Status
+# ============================================================================
+
+pub const ENA_ADMIN_SUCCESS: u8 = 0
+pub const ENA_ADMIN_RESOURCE_ALLOCATION_FAILURE: u8 = 1
+pub const ENA_ADMIN_BAD_OPCODE: u8 = 2
+pub const ENA_ADMIN_UNSUPPORTED_OPCODE: u8 = 3
+pub const ENA_ADMIN_MALFORMED_REQUEST: u8 = 4
+pub const ENA_ADMIN_ILLEGAL_PARAMETER: u8 = 5
+pub const ENA_ADMIN_UNKNOWN_ERROR: u8 = 6
+pub const ENA_ADMIN_RESOURCE_BUSY: u8 = 7
+
+# ============================================================================
+# Feature IDs (for GET_FEATURE/SET_FEATURE commands)
+# ============================================================================
+
+pub const ENA_ADMIN_DEVICE_ATTRIBUTES: u8 = 1
+pub const ENA_ADMIN_MAX_QUEUES_NUM: u8 = 2
+pub const ENA_ADMIN_HW_HINTS: u8 = 3
+pub const ENA_ADMIN_LLQ: u8 = 4
+pub const ENA_ADMIN_MAX_QUEUES_EXT: u8 = 7
+pub const ENA_ADMIN_RSS_HASH_FUNCTION: u8 = 10
+pub const ENA_ADMIN_STATELESS_OFFLOAD_CONFIG: u8 = 11
+pub const ENA_ADMIN_RSS_INDIRECTION_TABLE_CONFIG: u8 = 12
+pub const ENA_ADMIN_MTU: u8 = 14
+pub const ENA_ADMIN_AENQ_CONFIG: u8 = 26
+pub const ENA_ADMIN_LINK_CONFIG: u8 = 27
+pub const ENA_ADMIN_HOST_ATTR_CONFIG: u8 = 28
+
+# ============================================================================
+# Queue Direction
+# ============================================================================
+
+pub const ENA_ADMIN_SQ_DIRECTION_TX: u8 = 1
+pub const ENA_ADMIN_SQ_DIRECTION_RX: u8 = 2
+
+# ============================================================================
+# Placement Policy (where descriptors reside)
+# ============================================================================
+
+pub const ENA_ADMIN_PLACEMENT_POLICY_HOST: u8 = 1    # Descriptors in host memory
+pub const ENA_ADMIN_PLACEMENT_POLICY_DEV: u8 = 3     # Low Latency Queue (device memory)
+
+# ============================================================================
+# Completion Policy
+# ============================================================================
+
+pub const ENA_ADMIN_COMPLETION_POLICY_DESC: u8 = 0           # CQE for each descriptor
+pub const ENA_ADMIN_COMPLETION_POLICY_DESC_ON_DEMAND: u8 = 1 # CQE on request
+pub const ENA_ADMIN_COMPLETION_POLICY_HEAD_ON_DEMAND: u8 = 2 # Head pointer on request
+pub const ENA_ADMIN_COMPLETION_POLICY_HEAD: u8 = 3           # Head pointer for each
+
+# ============================================================================
+# Admin Queue Common Descriptor (first 4 bytes of every AQ entry)
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminAqCommonDesc
+    command_id: u16     # 11:0 command_id, 15:12 reserved
+    opcode: u8          # ena_admin_aq_opcode
+    flags: u8           # 0: phase, 1: ctrl_data, 2: ctrl_data_indirect
+
+pub const ENA_ADMIN_AQ_COMMON_DESC_SIZE: u32 = 4
+
+# Flags for aq_common_desc.flags
+pub const ENA_ADMIN_AQ_FLAG_PHASE: u8 = 0x01
+pub const ENA_ADMIN_AQ_FLAG_CTRL_DATA: u8 = 0x02
+pub const ENA_ADMIN_AQ_FLAG_CTRL_DATA_INDIRECT: u8 = 0x04
+
+# ============================================================================
+# Admin Queue Entry (64 bytes)
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminAqEntry
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes
+    inline_data: [60]u8                 # Command-specific data
+
+pub const ENA_ADMIN_AQ_ENTRY_SIZE: u32 = 64
+
+# ============================================================================
+# Admin Completion Queue Common Descriptor
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminAcqCommonDesc
+    command_id: u16     # 11:0 command_id, 15:12 reserved
+    status: u8          # Completion status
+    flags: u8           # 0: phase
+    extended_status: u16
+    sq_head_indx: u16   # Which AQ entry was consumed
+
+pub const ENA_ADMIN_ACQ_COMMON_DESC_SIZE: u32 = 8
+
+# Flags for acq_common_desc.flags
+pub const ENA_ADMIN_ACQ_FLAG_PHASE: u8 = 0x01
+
+# ============================================================================
+# Admin Completion Queue Entry (64 bytes)
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminAcqEntry
+    common_desc: EnaAdminAcqCommonDesc  # 8 bytes
+    response_data: [56]u8               # Response-specific data
+
+pub const ENA_ADMIN_ACQ_ENTRY_SIZE: u32 = 64
+
+# ============================================================================
+# Create SQ Command (submission queue)
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminCreateSqCmd
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes (total: 4)
+    sq_identity: u8     # 4:0 reserved, 7:5 sq_direction      # (total: 5)
+    reserved8_w1: u8                                           # (total: 6)
+    sq_caps_2: u8       # 3:0 placement_policy, 6:4 completion_policy # (total: 7)
+    sq_caps_3: u8       # 0: is_physically_contiguous          # (total: 8)
+    cq_idx: u16         # Associated CQ index                  # (total: 10)
+    sq_depth: u16       # Queue depth in entries               # (total: 12)
+    # sq_ba: ena_common_mem_addr (8 bytes total)
+    sq_ba_lo: u32       # SQ base address low (32 bits)        # (total: 16)
+    sq_ba_hi: u16       # SQ base address high (16 bits)       # (total: 18)
+    sq_ba_reserved: u16 # MBZ                                  # (total: 20)
+    # sq_head_writeback: ena_common_mem_addr (8 bytes total)
+    sq_head_wb_lo: u32  # Head writeback address low           # (total: 24)
+    sq_head_wb_hi: u16  # Head writeback address high          # (total: 26)
+    sq_head_wb_reserved: u16  # MBZ                            # (total: 28)
+    reserved0_w7: u32   # MBZ                                  # (total: 32)
+    reserved0_w8: u32   # MBZ                                  # (total: 36)
+    reserved: [28]u8    # Padding to 64 bytes total
+
+# sq_identity field masks
+pub const ENA_ADMIN_SQ_IDENTITY_DIRECTION_SHIFT: u8 = 5
+pub const ENA_ADMIN_SQ_IDENTITY_DIRECTION_MASK: u8 = 0xE0
+
+# sq_caps_2 field masks
+pub const ENA_ADMIN_SQ_CAPS2_PLACEMENT_MASK: u8 = 0x0F
+pub const ENA_ADMIN_SQ_CAPS2_COMPLETION_SHIFT: u8 = 4
+pub const ENA_ADMIN_SQ_CAPS2_COMPLETION_MASK: u8 = 0x70
+
+# sq_caps_3 field masks
+pub const ENA_ADMIN_SQ_CAPS3_CONTIGUOUS_MASK: u8 = 0x01
+
+# ============================================================================
+# Create SQ Response
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminCreateSqResp
+    common_desc: EnaAdminAcqCommonDesc  # 8 bytes
+    sq_idx: u16                         # Assigned SQ index
+    reserved: u16
+    sq_doorbell_offset: u32             # Doorbell offset from MMIO BAR
+    llq_descriptors_offset: u32         # LLQ descriptors offset
+    llq_headers_offset: u32             # LLQ headers offset
+    padding: [40]u8                     # Padding to 64 bytes
+
+# ============================================================================
+# Destroy SQ Command
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminDestroySqCmd
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes
+    sq_idx: u16                         # SQ index to destroy
+    sq_identity: u8                     # 7:5 sq_direction
+    reserved: u8
+    padding: [56]u8                     # Padding to 64 bytes
+
+# ============================================================================
+# Create CQ Command (completion queue)
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminCreateCqCmd
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes
+    cq_caps_1: u8       # 5: interrupt_mode_enabled       # 5 bytes
+    cq_caps_2: u8       # 4:0 cq_entry_size_words (4 or 8) # 6 bytes
+    cq_depth: u16       # Queue depth (must be power of 2) # 8 bytes
+    msix_vector: u32    # MSI-X vector for this CQ         # 12 bytes
+    # cq_ba: ena_common_mem_addr (8 bytes total)
+    cq_ba_lo: u32       # CQ base address low (32 bits)    # 16 bytes
+    cq_ba_hi: u16       # CQ base address high (16 bits)   # 18 bytes
+    cq_ba_reserved: u16 # MBZ                              # 20 bytes
+    padding: [44]u8     # Padding to 64 bytes total
+
+# cq_caps_1 field masks
+pub const ENA_ADMIN_CQ_CAPS1_INTERRUPT_MODE_SHIFT: u8 = 5
+pub const ENA_ADMIN_CQ_CAPS1_INTERRUPT_MODE_MASK: u8 = 0x20
+
+# cq_caps_2 field masks
+pub const ENA_ADMIN_CQ_CAPS2_ENTRY_SIZE_MASK: u8 = 0x1F
+
+# ============================================================================
+# Create CQ Response
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminCreateCqResp
+    common_desc: EnaAdminAcqCommonDesc  # 8 bytes
+    cq_idx: u16                         # Assigned CQ index
+    cq_actual_depth: u16                # Actual CQ depth
+    numa_node_reg_offset: u32           # NUMA config register offset
+    cq_head_db_offset: u32              # Head doorbell offset (for polling)
+    cq_interrupt_unmask_offset: u32     # Interrupt unmask register offset
+    padding: [40]u8                     # Padding to 64 bytes
+
+# ============================================================================
+# Destroy CQ Command
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminDestroyCqCmd
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes
+    cq_idx: u16                         # CQ index to destroy
+    reserved: u16
+    padding: [56]u8                     # Padding to 64 bytes
+
+# ============================================================================
+# Get Feature Command
+# Matches: struct ena_admin_get_feat_cmd from ena_admin_defs.h
+# Layout:
+#   - aq_common_descriptor (4 bytes)
+#   - control_buffer: length (4) + mem_addr (8) = 12 bytes
+#   - feat_common: flags + feature_id + feature_version + reserved = 4 bytes
+#   - raw[11] = 44 bytes
+# Total: 64 bytes
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminGetFeatureCmd
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes  (offset 0)
+    # control_buffer (12 bytes)
+    ctrl_buff_len: u32                  # 4 bytes  (offset 4)
+    ctrl_buff_addr_lo: u32              # 4 bytes  (offset 8)
+    ctrl_buff_addr_hi: u16              # 2 bytes  (offset 12)
+    ctrl_buff_reserved: u16             # 2 bytes  (offset 14)
+    # feat_common (4 bytes)
+    feat_flags: u8                      # 1 byte   (offset 16)
+    feature_id: u8                      # 1 byte   (offset 17)
+    feature_version: u8                 # 1 byte   (offset 18)
+    feat_reserved: u8                   # 1 byte   (offset 19)
+    # raw padding
+    raw: [44]u8                         # 44 bytes (offset 20-63)
+
+# ============================================================================
+# Get Feature Response - Device Attributes
+# This is the response DATA (comes after EnaAdminAcqCommonDesc in the CQE)
+# Matches: struct ena_admin_device_attr_feature_desc from ena_admin_defs.h
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminDeviceAttrFeature
+    common_desc: EnaAdminAcqCommonDesc  # 8 bytes (offset 0)
+    impl_id: u32                        # 4 bytes  (offset 8)
+    device_version: u32                 # 4 bytes  (offset 12)
+    supported_features: u32             # 4 bytes  (offset 16)
+    capabilities: u32                   # 4 bytes  (offset 20)
+    phys_addr_width: u32                # 4 bytes  (offset 24) - note: u32 not u8!
+    virt_addr_width: u32                # 4 bytes  (offset 28) - note: u32 not u8!
+    mac_addr: [6]u8                     # 6 bytes  (offset 32) - Network byte order
+    flow_steering_max_entries: u16      # 2 bytes  (offset 38)
+    max_mtu: u32                        # 4 bytes  (offset 40)
+    padding: [20]u8                     # 20 bytes (offset 44-63)
+
+# ============================================================================
+# Get Feature Response - Max Queues
+# Matches: struct ena_admin_queue_feature_desc from ena_admin_defs.h
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminMaxQueuesFeature
+    common_desc: EnaAdminAcqCommonDesc  # 8 bytes  (offset 0)
+    max_sq_num: u32                     # 4 bytes  (offset 8) - note: u32 not u16!
+    max_sq_depth: u32                   # 4 bytes  (offset 12)
+    max_cq_num: u32                     # 4 bytes  (offset 16)
+    max_cq_depth: u32                   # 4 bytes  (offset 20)
+    max_legacy_llq_num: u32             # 4 bytes  (offset 24)
+    max_legacy_llq_depth: u32           # 4 bytes  (offset 28)
+    max_header_size: u32                # 4 bytes  (offset 32)
+    max_packet_tx_descs: u16            # 2 bytes  (offset 36)
+    max_packet_rx_descs: u16            # 2 bytes  (offset 38)
+    padding: [24]u8                     # 24 bytes (offset 40-63)
+
+# ============================================================================
+# AENQ Entry (Async Event Notification Queue)
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminAenqEntry
+    aenq_common_desc: EnaAdminAcqCommonDesc  # 8 bytes
+    timestamp_lo: u32
+    timestamp_hi: u32
+    inline_data: [48]u8
+
+pub const ENA_ADMIN_AENQ_ENTRY_SIZE: u32 = 64
+
+# AENQ Event Groups (bitmask positions)
+pub const ENA_ADMIN_AENQ_LINK_CHANGE: u8 = 0
+pub const ENA_ADMIN_AENQ_FATAL_ERROR: u8 = 1
+pub const ENA_ADMIN_AENQ_WARNING: u8 = 2
+pub const ENA_ADMIN_AENQ_NOTIFICATION: u8 = 3
+pub const ENA_ADMIN_AENQ_KEEP_ALIVE: u8 = 4
+
+# ============================================================================
+# Set Feature Command
+# Matches: struct ena_admin_set_feat_cmd from ena_admin_defs.h
+# Layout:
+#   - aq_common_descriptor (4 bytes)
+#   - control_buffer: length (4) + mem_addr (8) = 12 bytes
+#   - feat_common: flags + feature_id + feature_version + reserved = 4 bytes
+#   - feature-specific data (up to 44 bytes)
+# Total: 64 bytes
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminSetFeatureCmd
+    common_desc: EnaAdminAqCommonDesc   # 4 bytes  (offset 0)
+    # control_buffer (12 bytes) - not used for inline features
+    ctrl_buff_len: u32                  # 4 bytes  (offset 4)
+    ctrl_buff_addr_lo: u32              # 4 bytes  (offset 8)
+    ctrl_buff_addr_hi: u16              # 2 bytes  (offset 12)
+    ctrl_buff_reserved: u16             # 2 bytes  (offset 14)
+    # feat_common (4 bytes)
+    feat_flags: u8                      # 1 byte   (offset 16)
+    feature_id: u8                      # 1 byte   (offset 17)
+    feature_version: u8                 # 1 byte   (offset 18)
+    feat_reserved: u8                   # 1 byte   (offset 19)
+    # AENQ config data (8 bytes used)
+    aenq_supported_groups: u32          # 4 bytes  (offset 20) - device reports supported
+    aenq_enabled_groups: u32            # 4 bytes  (offset 24) - what we want enabled
+    # Remaining padding
+    padding: [36]u8                     # 36 bytes (offset 28-63)
+
+# ============================================================================
+# Get Feature Response - AENQ Config
+# ============================================================================
+
+[[packed]]
+pub struct EnaAdminAenqFeature
+    common_desc: EnaAdminAcqCommonDesc  # 8 bytes (offset 0)
+    supported_groups: u32               # 4 bytes (offset 8)
+    enabled_groups: u32                 # 4 bytes (offset 12)
+    padding: [48]u8                     # 48 bytes (offset 16-63)

--- a/projects/harland/kernel/src/drivers/ena/device.ritz
+++ b/projects/harland/kernel/src/drivers/ena/device.ritz
@@ -1,0 +1,1319 @@
+# ENA Network Device Driver
+#
+# Driver for Amazon Elastic Network Adapter (ENA).
+# Used in AWS EC2 instances for network connectivity.
+#
+# Reference: https://github.com/amzn/amzn-drivers
+
+import serial { prints, serial_print_hex, serial_print_dec, serial_write_byte }
+import drivers.pci { PciDevice, pci_find_ena, pci_enable_bus_master, pci_enable_memory }
+import drivers.ena.regs {
+    ENA_REGS_VERSION_OFF, ENA_REGS_VERSION_MAJOR_MASK, ENA_REGS_VERSION_MAJOR_SHIFT,
+    ENA_REGS_VERSION_MINOR_MASK, ENA_REGS_CONTROLLER_VERSION_OFF,
+    ENA_REGS_CTRL_VER_MAJOR_MASK, ENA_REGS_CTRL_VER_MAJOR_SHIFT,
+    ENA_REGS_CTRL_VER_MINOR_MASK, ENA_REGS_CTRL_VER_MINOR_SHIFT,
+    ENA_REGS_CTRL_VER_SUBMINOR_MASK, ENA_REGS_DEV_CTL_OFF, ENA_REGS_DEV_CTL_DEV_RESET_MASK,
+    ENA_REGS_DEV_CTL_RESET_REASON_SHIFT, ENA_REGS_DEV_STS_OFF, ENA_REGS_DEV_STS_READY_MASK,
+    ENA_REGS_DEV_STS_RESET_FINISHED_MASK, ENA_REGS_DEV_STS_FATAL_ERROR_MASK,
+    ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK,
+    ENA_REGS_CAPS_OFF, ENA_REGS_CAPS_RESET_TIMEOUT_MASK, ENA_REGS_CAPS_RESET_TIMEOUT_SHIFT,
+    ENA_REGS_AQ_BASE_LO_OFF, ENA_REGS_AQ_BASE_HI_OFF, ENA_REGS_AQ_CAPS_OFF,
+    ENA_REGS_AQ_CAPS_ENTRY_SIZE_SHIFT, ENA_REGS_ACQ_BASE_LO_OFF, ENA_REGS_ACQ_BASE_HI_OFF,
+    ENA_REGS_ACQ_CAPS_OFF, ENA_REGS_ACQ_CAPS_ENTRY_SIZE_SHIFT, ENA_REGS_AQ_DB_OFF,
+    ENA_REGS_ACQ_TAIL_OFF, ENA_REGS_RESET_NORMAL,
+    ENA_REGS_AENQ_BASE_LO_OFF, ENA_REGS_AENQ_BASE_HI_OFF, ENA_REGS_AENQ_CAPS_OFF,
+    ENA_REGS_AENQ_CAPS_ENTRY_SIZE_SHIFT
+}
+import drivers.ena.admin {
+    EnaAdminAqEntry, EnaAdminAcqEntry, EnaAdminGetFeatureCmd, EnaAdminCreateCqCmd,
+    EnaAdminCreateCqResp, EnaAdminCreateSqCmd, EnaAdminCreateSqResp,
+    EnaAdminDeviceAttrFeature, EnaAdminMaxQueuesFeature, EnaAdminAenqEntry,
+    EnaAdminSetFeatureCmd, EnaAdminAenqFeature,
+    ENA_ADMIN_AQ_ENTRY_SIZE, ENA_ADMIN_ACQ_ENTRY_SIZE, ENA_ADMIN_ACQ_FLAG_PHASE,
+    ENA_ADMIN_AENQ_ENTRY_SIZE,
+    ENA_ADMIN_GET_FEATURE, ENA_ADMIN_SET_FEATURE, ENA_ADMIN_CREATE_CQ, ENA_ADMIN_CREATE_SQ,
+    ENA_ADMIN_DEVICE_ATTRIBUTES, ENA_ADMIN_MAX_QUEUES_NUM, ENA_ADMIN_AENQ_CONFIG, ENA_ADMIN_SUCCESS,
+    ENA_ADMIN_PLACEMENT_POLICY_HOST, ENA_ADMIN_COMPLETION_POLICY_DESC,
+    ENA_ADMIN_SQ_IDENTITY_DIRECTION_SHIFT, ENA_ADMIN_SQ_CAPS2_COMPLETION_SHIFT,
+    ENA_ADMIN_SQ_CAPS3_CONTIGUOUS_MASK,
+    ENA_ADMIN_AENQ_LINK_CHANGE, ENA_ADMIN_AENQ_FATAL_ERROR, ENA_ADMIN_AENQ_WARNING,
+    ENA_ADMIN_AENQ_NOTIFICATION, ENA_ADMIN_AENQ_KEEP_ALIVE
+}
+import drivers.ena.io {
+    EnaTxDesc, EnaRxDesc, EnaRxCdescBase,
+    ENA_TX_DESC_SIZE, ENA_RX_DESC_SIZE, ENA_RX_CDESC_BASE_SIZE,
+    ena_tx_build_len_ctrl, ena_tx_build_meta_ctrl_simple, ena_rx_build_ctrl,
+    ena_rx_cdesc_phase_matches, ena_rx_cdesc_get_length, ena_rx_cdesc_get_req_id
+}
+import mm.pmm { pmm_alloc_page, pmm_free_page, PAGE_SIZE }
+import mm.vmm { vmm_virt_to_phys, vmm_map_page, PTE_WRITABLE }
+
+# ============================================================================
+# Configuration Constants
+# ============================================================================
+
+const ENA_MAX_QUEUES: u32 = 4
+const ENA_ADMIN_QUEUE_DEPTH: u32 = 32
+const ENA_ADMIN_CQ_DEPTH: u32 = 32
+const ENA_AENQ_DEPTH: u32 = 32
+const ENA_IO_QUEUE_DEPTH: u32 = 256  # ENA minimum is 256 (ENA_MIN_RING_SIZE)
+const ENA_RX_BUFFER_SIZE: u32 = 2048
+const ENA_TX_BUFFER_SIZE: u32 = 2048
+const ENA_RX_BUFFER_COUNT: u32 = 8   # Reduced for initial testing
+const ENA_TX_BUFFER_COUNT: u32 = 8   # Reduced for initial testing
+
+const ENA_ADMIN_TIMEOUT_US: u32 = 3000000   # 3 seconds
+const ENA_RESET_TIMEOUT_MS: u32 = 1000
+
+# Local constants to avoid module access issues
+const SQ_DIR_TX: u8 = 1
+const SQ_DIR_RX: u8 = 2
+
+# ============================================================================
+# Admin Queue State
+# ============================================================================
+
+struct EnaAdminQueue
+    sq_entries: *EnaAdminAqEntry    # Submission queue entries
+    cq_entries: *EnaAdminAcqEntry   # Completion queue entries
+    sq_phys: u64                          # SQ physical address
+    cq_phys: u64                          # CQ physical address
+    sq_depth: u16
+    cq_depth: u16
+    sq_head: u16                          # Next entry to submit
+    sq_tail: u16                          # Last submitted
+    cq_head: u16                          # Next completion to process
+    sq_phase: u8                          # Current SQ phase bit
+    cq_phase: u8                          # Expected CQ phase bit
+    cmd_id: u16                           # Rolling command ID
+
+# ============================================================================
+# AENQ State (Async Event Notification Queue)
+# ============================================================================
+
+struct EnaAenq
+    entries: *EnaAdminAenqEntry    # AENQ entries
+    phys: u64                            # Physical address
+    depth: u16
+    head: u16                            # Next entry to process
+    phase: u8                            # Expected phase bit
+
+# ============================================================================
+# I/O Queue State
+# ============================================================================
+
+struct EnaIoSq
+    entries: *EnaTxDesc        # For TX: EnaTxDesc, For RX: EnaRxDesc
+    phys: u64                     # Physical address
+    depth: u16
+    head: u16                     # Next to submit
+    tail: u16                     # Last submitted
+    phase: u8
+    doorbell_offset: u32          # Doorbell offset from BAR
+
+struct EnaIoCq
+    entries: *EnaRxCdescBase   # Completion entries
+    phys: u64
+    depth: u16
+    head: u16                     # Next to process
+    phase: u8                     # Expected phase
+    hw_index: u16                 # Hardware-assigned CQ index
+    unmask_offset: u32            # Interrupt unmask register offset
+
+# ============================================================================
+# ENA Device State
+# ============================================================================
+
+pub struct EnaDevice
+    pci_dev: *PciDevice
+    bar0: u64                     # MMIO base address (from BAR0)
+    bar0_size: u64
+    admin_queue: EnaAdminQueue
+    aenq: EnaAenq                 # Async Event Notification Queue
+    tx_sq: EnaIoSq
+    tx_cq: EnaIoCq
+    rx_sq: EnaIoSq
+    rx_cq: EnaIoCq
+    mac: [6]u8
+    mtu: u16
+    max_tx_queues: u16
+    max_rx_queues: u16
+    max_sq_depth: u16
+    max_cq_depth: u16
+    initialized: u8
+
+# Global device instance
+var ena_dev: EnaDevice
+
+# Pre-allocated RX/TX buffers (reduced for initial testing)
+var ena_rx_buffers: [16384]u8     # 8 * 2048 = 16KB
+var ena_tx_buffers: [16384]u8     # 8 * 2048 = 16KB
+
+# RX buffer tracking
+var ena_rx_req_to_buf: [256]u16   # req_id -> buffer index
+
+# ============================================================================
+# Address Calculation Helpers
+# ============================================================================
+
+fn ena_admin_sq_entry_addr(aq: *EnaAdminQueue, idx: u16) -> u64
+    let base: u64 = (*aq).sq_entries as u64
+    let offset: u64 = (idx as u64) * (ENA_ADMIN_AQ_ENTRY_SIZE as u64)
+    base + offset
+
+fn ena_admin_cq_entry_addr(aq: *EnaAdminQueue, idx: u16) -> u64
+    let base: u64 = (*aq).cq_entries as u64
+    let offset: u64 = (idx as u64) * (ENA_ADMIN_ACQ_ENTRY_SIZE as u64)
+    base + offset
+
+fn ena_io_sq_entry_addr(sq: *EnaIoSq, idx: u16, entry_size: u32) -> u64
+    let base: u64 = (*sq).entries as u64
+    let offset: u64 = (idx as u64) * (entry_size as u64)
+    base + offset
+
+fn ena_io_cq_entry_addr(cq: *EnaIoCq, idx: u16, entry_size: u32) -> u64
+    let base: u64 = (*cq).entries as u64
+    let offset: u64 = (idx as u64) * (entry_size as u64)
+    base + offset
+
+fn ena_get_prev_cq_head(aq: *EnaAdminQueue) -> u16
+    if (*aq).cq_head == 0
+        return (ENA_ADMIN_CQ_DEPTH - 1) as u16
+    (*aq).cq_head - 1
+
+fn ena_get_phys_or_virt(phys: u64, virt: u64) -> u64
+    if phys != 0
+        return phys
+    virt
+
+# ============================================================================
+# MMIO Register Access
+# ============================================================================
+
+fn ena_read32(dev: *EnaDevice, offset: u32) -> u32
+    let addr: *u32 = ((*dev).bar0 + offset as u64) as *u32
+    *addr
+
+fn ena_write32(dev: *EnaDevice, offset: u32, value: u32)
+    let addr: *u32 = ((*dev).bar0 + offset as u64) as *u32
+    *addr = value
+    # Memory fence to ensure write is visible
+    asm x86_64:
+        mfence
+
+# ============================================================================
+# Device Reset and Status
+# ============================================================================
+
+# Read capabilities register to get reset timeout
+fn ena_get_reset_timeout(dev: *EnaDevice) -> u32
+    let caps: u32 = ena_read32(dev, ENA_REGS_CAPS_OFF)
+    # Timeout is in 100ms units, bits 5:1
+    let timeout_100ms: u32 = (caps & ENA_REGS_CAPS_RESET_TIMEOUT_MASK) >> ENA_REGS_CAPS_RESET_TIMEOUT_SHIFT
+    if timeout_100ms == 0
+        return 10  # Default 1 second (10 * 100ms)
+    return timeout_100ms
+
+# Wait for reset state to match expected value
+fn ena_wait_for_reset_state(dev: *EnaDevice, expected_state: u32, timeout_100ms: u32) -> i32
+    # Convert 100ms units to iterations (roughly 100k loops per 100ms)
+    var max_iterations: u64 = (timeout_100ms as u64) * 100000
+    if max_iterations < 1000000
+        max_iterations = 1000000  # Minimum ~1 second
+
+    var iterations: u64 = 0
+    while iterations < max_iterations
+        let status: u32 = ena_read32(dev, ENA_REGS_DEV_STS_OFF)
+        let reset_in_progress: u32 = status & ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK
+
+        if reset_in_progress == expected_state
+            return 0
+
+        # Simple delay loop with some volatility to prevent optimization
+        var delay: u32 = 0
+        while delay < 100
+            asm x86_64:
+                pause
+            delay = delay + 1
+
+        iterations = iterations + 1
+
+    return -1  # Timeout
+
+fn ena_device_reset(dev: *EnaDevice, reason: u8) -> i32
+    prints("[ena] Resetting device (reason ")
+    serial_print_dec(reason as u64)
+    prints(")...\n")
+
+    # Get reset timeout from capabilities register
+    let timeout_100ms: u32 = ena_get_reset_timeout(dev)
+    prints("[ena] Reset timeout: ")
+    serial_print_dec(timeout_100ms as u64)
+    prints(" x 100ms\n")
+
+    # Check current device status
+    let initial_status: u32 = ena_read32(dev, ENA_REGS_DEV_STS_OFF)
+    prints("[ena] Initial status: 0x")
+    serial_print_hex(initial_status as u64)
+    prints("\n")
+
+    # Phase 1: Trigger reset by setting reset bit with reason
+    var ctl: u32 = ENA_REGS_DEV_CTL_DEV_RESET_MASK
+    ctl = ctl | ((reason as u32) << ENA_REGS_DEV_CTL_RESET_REASON_SHIFT)
+    ena_write32(dev, ENA_REGS_DEV_CTL_OFF, ctl)
+
+    # Wait for reset-in-progress to become active
+    prints("[ena] Waiting for reset to start...\n")
+    var result: i32 = ena_wait_for_reset_state(dev, ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK, timeout_100ms)
+    if result != 0
+        # Some devices may not set reset-in-progress, try alternative approach
+        prints("[ena] Reset-in-progress not seen, trying alternative...\n")
+        # Read status again
+        let status2: u32 = ena_read32(dev, ENA_REGS_DEV_STS_OFF)
+        prints("[ena] Status after trigger: 0x")
+        serial_print_hex(status2 as u64)
+        prints("\n")
+
+    # Phase 2: Clear reset bit to allow device to complete reset
+    ena_write32(dev, ENA_REGS_DEV_CTL_OFF, 0)
+
+    # Wait for reset-in-progress to clear
+    prints("[ena] Waiting for reset to complete...\n")
+    result = ena_wait_for_reset_state(dev, 0, timeout_100ms)
+    if result != 0
+        let final_status: u32 = ena_read32(dev, ENA_REGS_DEV_STS_OFF)
+        prints("[ena] ERROR: Reset timeout, final status: 0x")
+        serial_print_hex(final_status as u64)
+        prints("\n")
+
+        # Check for fatal error
+        if (final_status & ENA_REGS_DEV_STS_FATAL_ERROR_MASK) != 0
+            prints("[ena] ERROR: Device has fatal error!\n")
+
+        return -1
+
+    prints("[ena] Reset complete\n")
+    return 0
+
+fn ena_wait_for_ready(dev: *EnaDevice) -> i32
+    var timeout: u32 = 0
+    while timeout < 10000
+        let status: u32 = ena_read32(dev, ENA_REGS_DEV_STS_OFF)
+        if (status & ENA_REGS_DEV_STS_READY_MASK) != 0
+            return 0
+        # Check for fatal error
+        if (status & ENA_REGS_DEV_STS_FATAL_ERROR_MASK) != 0
+            prints("[ena] ERROR: Device fatal error\n")
+            return -1
+        # Simple delay
+        var i: u32 = 0
+        while i < 10000
+            i = i + 1
+        timeout = timeout + 1
+
+    prints("[ena] ERROR: Device not ready (timeout)\n")
+    return -1
+
+# ============================================================================
+# Admin Queue Operations
+# ============================================================================
+
+fn ena_admin_queue_init(dev: *EnaDevice) -> i32
+    prints("[ena] Initializing admin queue...\n")
+
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+
+    # Allocate admin SQ memory (must be contiguous)
+    let sq_size: u64 = (ENA_ADMIN_QUEUE_DEPTH * ENA_ADMIN_AQ_ENTRY_SIZE) as u64
+    let sq_page: u64 = pmm_alloc_page()
+    if sq_page == 0
+        prints("[ena] ERROR: Failed to allocate admin SQ\n")
+        return -1
+
+    (*aq).sq_entries = sq_page as *EnaAdminAqEntry
+    (*aq).sq_phys = vmm_virt_to_phys(sq_page)
+    if (*aq).sq_phys == 0
+        (*aq).sq_phys = sq_page  # Identity mapped
+
+    # Allocate admin CQ memory
+    let cq_size: u64 = (ENA_ADMIN_CQ_DEPTH * ENA_ADMIN_ACQ_ENTRY_SIZE) as u64
+    let cq_page: u64 = pmm_alloc_page()
+    if cq_page == 0
+        prints("[ena] ERROR: Failed to allocate admin CQ\n")
+        return -1
+
+    (*aq).cq_entries = cq_page as *EnaAdminAcqEntry
+    (*aq).cq_phys = vmm_virt_to_phys(cq_page)
+    if (*aq).cq_phys == 0
+        (*aq).cq_phys = cq_page
+
+    # Zero out the queues
+    var i: u64 = 0
+    while i < PAGE_SIZE
+        *((sq_page + i) as *u8) = 0
+        *((cq_page + i) as *u8) = 0
+        i = i + 1
+
+    # Initialize queue state
+    (*aq).sq_depth = ENA_ADMIN_QUEUE_DEPTH as u16
+    (*aq).cq_depth = ENA_ADMIN_CQ_DEPTH as u16
+    (*aq).sq_head = 0
+    (*aq).sq_tail = 0
+    (*aq).cq_head = 0
+    (*aq).sq_phase = 1
+    (*aq).cq_phase = 1
+    (*aq).cmd_id = 0
+
+    # Write admin SQ base address
+    ena_write32(dev, ENA_REGS_AQ_BASE_LO_OFF, ((*aq).sq_phys & 0xFFFFFFFF) as u32)
+    ena_write32(dev, ENA_REGS_AQ_BASE_HI_OFF, (((*aq).sq_phys >> 32) & 0xFFFFFFFF) as u32)
+
+    # Write admin SQ caps (depth in lower 16 bits, entry size in upper 16 bits)
+    var aq_caps: u32 = ENA_ADMIN_QUEUE_DEPTH as u32
+    aq_caps = aq_caps | ((ENA_ADMIN_AQ_ENTRY_SIZE as u32) << ENA_REGS_AQ_CAPS_ENTRY_SIZE_SHIFT)
+    ena_write32(dev, ENA_REGS_AQ_CAPS_OFF, aq_caps)
+
+    # Write admin CQ base address
+    ena_write32(dev, ENA_REGS_ACQ_BASE_LO_OFF, ((*aq).cq_phys & 0xFFFFFFFF) as u32)
+    ena_write32(dev, ENA_REGS_ACQ_BASE_HI_OFF, (((*aq).cq_phys >> 32) & 0xFFFFFFFF) as u32)
+
+    # Write admin CQ caps (same format: depth | entry_size << 16)
+    var acq_caps: u32 = ENA_ADMIN_CQ_DEPTH as u32
+    acq_caps = acq_caps | ((ENA_ADMIN_ACQ_ENTRY_SIZE as u32) << ENA_REGS_ACQ_CAPS_ENTRY_SIZE_SHIFT)
+    ena_write32(dev, ENA_REGS_ACQ_CAPS_OFF, acq_caps)
+
+    prints("[ena] Admin queue initialized\n")
+    prints("[ena]   SQ: phys=0x")
+    serial_print_hex((*aq).sq_phys)
+    prints(" depth=")
+    serial_print_dec(ENA_ADMIN_QUEUE_DEPTH as u64)
+    prints(" entry_size=")
+    serial_print_dec(ENA_ADMIN_AQ_ENTRY_SIZE as u64)
+    prints("\n")
+    prints("[ena]   CQ: phys=0x")
+    serial_print_hex((*aq).cq_phys)
+    prints(" depth=")
+    serial_print_dec(ENA_ADMIN_CQ_DEPTH as u64)
+    prints(" entry_size=")
+    serial_print_dec(ENA_ADMIN_ACQ_ENTRY_SIZE as u64)
+    prints("\n")
+    prints("[ena]   AQ_CAPS=0x")
+    serial_print_hex(aq_caps as u64)
+    prints(" ACQ_CAPS=0x")
+    serial_print_hex(acq_caps as u64)
+    prints("\n")
+
+    # Initialize AENQ (Async Event Notification Queue)
+    let aenq_result: i32 = ena_aenq_init(dev)
+    if aenq_result != 0
+        prints("[ena] Warning: AENQ init failed, continuing anyway\n")
+
+    return 0
+
+fn ena_aenq_init(dev: *EnaDevice) -> i32
+    prints("[ena] Initializing AENQ...\n")
+
+    let aenq: *EnaAenq = @(*dev).aenq
+
+    # Allocate AENQ memory
+    let aenq_size: u64 = (ENA_AENQ_DEPTH * ENA_ADMIN_AENQ_ENTRY_SIZE) as u64
+    let aenq_page: u64 = pmm_alloc_page()
+    if aenq_page == 0
+        prints("[ena] ERROR: Failed to allocate AENQ\n")
+        return -1
+
+    (*aenq).entries = aenq_page as *EnaAdminAenqEntry
+    (*aenq).phys = vmm_virt_to_phys(aenq_page)
+    if (*aenq).phys == 0
+        (*aenq).phys = aenq_page  # Identity mapped
+
+    # Zero out the queue
+    var i: u64 = 0
+    while i < PAGE_SIZE
+        *((aenq_page + i) as *u8) = 0
+        i = i + 1
+
+    # Initialize AENQ state
+    (*aenq).depth = ENA_AENQ_DEPTH as u16
+    (*aenq).head = 0
+    (*aenq).phase = 1
+
+    # Write AENQ base address to registers
+    ena_write32(dev, ENA_REGS_AENQ_BASE_LO_OFF, ((*aenq).phys & 0xFFFFFFFF) as u32)
+    ena_write32(dev, ENA_REGS_AENQ_BASE_HI_OFF, (((*aenq).phys >> 32) & 0xFFFFFFFF) as u32)
+
+    # Write AENQ caps (depth in lower 16 bits, entry size in upper 16 bits)
+    var aenq_caps: u32 = ENA_AENQ_DEPTH as u32
+    aenq_caps = aenq_caps | ((ENA_ADMIN_AENQ_ENTRY_SIZE as u32) << ENA_REGS_AENQ_CAPS_ENTRY_SIZE_SHIFT)
+    ena_write32(dev, ENA_REGS_AENQ_CAPS_OFF, aenq_caps)
+
+    prints("[ena]   AENQ: phys=0x")
+    serial_print_hex((*aenq).phys)
+    prints(" depth=")
+    serial_print_dec(ENA_AENQ_DEPTH as u64)
+    prints(" caps=0x")
+    serial_print_hex(aenq_caps as u64)
+    prints("\n")
+
+    return 0
+
+fn ena_admin_submit_cmd(dev: *EnaDevice, cmd: *EnaAdminAqEntry) -> u16
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+
+    # Get command ID and increment (12-bit wrap)
+    let cmd_id: u16 = (*aq).cmd_id
+    (*aq).cmd_id = ((*aq).cmd_id + 1) & 0x0FFF
+
+    # Set command ID and phase bit in the command
+    # The phase bit goes in flags[0]
+    (*cmd).common_desc.command_id = cmd_id
+    (*cmd).common_desc.flags = (*aq).sq_phase
+
+    # Get the tail position (where we write next)
+    let tail_masked: u16 = (*aq).sq_tail
+    let entry_addr: u64 = ena_admin_sq_entry_addr(aq, tail_masked)
+    let dst: *EnaAdminAqEntry = entry_addr as *EnaAdminAqEntry
+
+    # Copy command to submission queue at tail position
+    var i: u32 = 0
+    while i < ENA_ADMIN_AQ_ENTRY_SIZE
+        *((dst as u64 + i as u64) as *u8) = *((cmd as u64 + i as u64) as *u8)
+        i = i + 1
+
+    # Advance tail and flip phase if we wrap
+    (*aq).sq_tail = (*aq).sq_tail + 1
+    if (*aq).sq_tail as u32 >= ENA_ADMIN_QUEUE_DEPTH
+        (*aq).sq_tail = 0
+        (*aq).sq_phase = (*aq).sq_phase ^ 1
+
+    # Memory barrier before doorbell
+    asm x86_64:
+        mfence
+
+    # Ring doorbell with the NEW tail value (after increment)
+    # This tells the device "there's a new command up to this tail"
+    ena_write32(dev, ENA_REGS_AQ_DB_OFF, (*aq).sq_tail as u32)
+
+    # Debug output
+    prints("[ena] Submitted cmd: id=")
+    serial_print_dec(cmd_id as u64)
+    prints(" opcode=")
+    serial_print_dec((*cmd).common_desc.opcode as u64)
+    prints(" tail=")
+    serial_print_dec((*aq).sq_tail as u64)
+    prints(" phase=")
+    serial_print_dec(((*aq).sq_phase ^ 1) as u64)  # Previous phase (what we wrote)
+    prints("\n")
+
+    cmd_id
+
+fn ena_admin_wait_completion(dev: *EnaDevice, cmd_id: u16) -> i32
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+
+    var timeout: u32 = 0
+    while timeout < 100000
+        # Read memory barrier before checking completion
+        asm x86_64:
+            lfence
+
+        let entry_addr: u64 = ena_admin_cq_entry_addr(aq, (*aq).cq_head)
+        let cqe: *EnaAdminAcqEntry = entry_addr as *EnaAdminAcqEntry
+
+        # Check phase bit - device sets this to indicate valid completion
+        let cqe_phase: u8 = (*cqe).common_desc.flags & ENA_ADMIN_ACQ_FLAG_PHASE
+        if cqe_phase == (*aq).cq_phase
+            # Read barrier to ensure we read the rest after phase check
+            asm x86_64:
+                lfence
+
+            # Verify command ID matches (lower 12 bits)
+            let resp_cmd_id: u16 = (*cqe).common_desc.command_id & 0x0FFF
+            if resp_cmd_id == cmd_id
+                let status: u8 = (*cqe).common_desc.status
+
+                # Always advance CQ head after processing, even on error
+                (*aq).cq_head = (*aq).cq_head + 1
+                if (*aq).cq_head as u32 >= ENA_ADMIN_CQ_DEPTH
+                    (*aq).cq_head = 0
+                    (*aq).cq_phase = (*aq).cq_phase ^ 1
+
+                # Update ACQ tail to tell device we consumed this entry
+                ena_write32(dev, ENA_REGS_ACQ_TAIL_OFF, (*aq).cq_head as u32)
+
+                if status == ENA_ADMIN_SUCCESS
+                    return 0
+                else
+                    prints("[ena] Admin command failed, status: ")
+                    serial_print_dec(status as u64)
+                    prints(" extended_status: 0x")
+                    serial_print_hex((*cqe).common_desc.extended_status as u64)
+                    prints(" (cmd_id=")
+                    serial_print_dec(cmd_id as u64)
+                    prints(")\n")
+                    return -(status as i32)
+
+        # Pause to avoid hammering the bus
+        asm x86_64:
+            pause
+        timeout = timeout + 1
+
+    prints("[ena] Admin command timeout (cmd_id=")
+    serial_print_dec(cmd_id as u64)
+    prints(", cq_head=")
+    serial_print_dec((*aq).cq_head as u64)
+    prints(", cq_phase=")
+    serial_print_dec((*aq).cq_phase as u64)
+    prints(")\n")
+
+    # Debug: dump the CQ entry we're looking at
+    let entry_addr: u64 = ena_admin_cq_entry_addr(aq, (*aq).cq_head)
+    let cqe: *EnaAdminAcqEntry = entry_addr as *EnaAdminAcqEntry
+    prints("[ena] CQ entry: flags=0x")
+    serial_print_hex((*cqe).common_desc.flags as u64)
+    prints(" cmd_id=")
+    serial_print_dec((*cqe).common_desc.command_id as u64)
+    prints(" status=")
+    serial_print_dec((*cqe).common_desc.status as u64)
+    prints("\n")
+
+    return -1
+
+# ============================================================================
+# Feature Queries
+# ============================================================================
+
+fn ena_get_device_attributes(dev: *EnaDevice) -> i32
+    prints("[ena] Getting device attributes...\n")
+
+    var cmd: EnaAdminGetFeatureCmd
+    var i: u32 = 0
+    while i < 64
+        *((@cmd as u64 + i as u64) as *u8) = 0
+        i = i + 1
+
+    cmd.common_desc.opcode = ENA_ADMIN_GET_FEATURE
+    cmd.feature_id = ENA_ADMIN_DEVICE_ATTRIBUTES
+
+    let cmd_id: u16 = ena_admin_submit_cmd(dev, @cmd as *EnaAdminAqEntry)
+    let result: i32 = ena_admin_wait_completion(dev, cmd_id)
+
+    if result != 0
+        prints("[ena] Failed to get device attributes\n")
+        return result
+
+    # Parse response from CQ
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+    let prev_head: u16 = ena_get_prev_cq_head(aq)
+    let entry_addr: u64 = ena_admin_cq_entry_addr(aq, prev_head)
+    let resp: *EnaAdminDeviceAttrFeature = entry_addr as *EnaAdminDeviceAttrFeature
+
+    # Copy MAC address
+    var j: i32 = 0
+    while j < 6
+        (*dev).mac[j] = (*resp).mac_addr[j]
+        j = j + 1
+
+    (*dev).mtu = (*resp).max_mtu as u16
+
+    prints("[ena] Device attributes:\n")
+    prints("[ena]   MAC: ")
+    ena_print_mac(dev)
+    prints("\n")
+    prints("[ena]   Max MTU: ")
+    serial_print_dec((*dev).mtu as u64)
+    prints("\n")
+
+    return 0
+
+fn ena_get_max_queues(dev: *EnaDevice) -> i32
+    prints("[ena] Getting max queues info...\n")
+
+    var cmd: EnaAdminGetFeatureCmd
+    var i: u32 = 0
+    while i < 64
+        *((@cmd as u64 + i as u64) as *u8) = 0
+        i = i + 1
+
+    cmd.common_desc.opcode = ENA_ADMIN_GET_FEATURE
+    cmd.feature_id = ENA_ADMIN_MAX_QUEUES_NUM
+
+    let cmd_id: u16 = ena_admin_submit_cmd(dev, @cmd as *EnaAdminAqEntry)
+    let result: i32 = ena_admin_wait_completion(dev, cmd_id)
+
+    if result != 0
+        prints("[ena] Failed to get max queues (may not be supported)\n")
+        # Set defaults
+        (*dev).max_tx_queues = 1
+        (*dev).max_rx_queues = 1
+        (*dev).max_sq_depth = ENA_IO_QUEUE_DEPTH as u16
+        (*dev).max_cq_depth = ENA_IO_QUEUE_DEPTH as u16
+        return 0
+
+    # Parse response
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+    let prev_head: u16 = ena_get_prev_cq_head(aq)
+    let entry_addr: u64 = ena_admin_cq_entry_addr(aq, prev_head)
+    let resp: *EnaAdminMaxQueuesFeature = entry_addr as *EnaAdminMaxQueuesFeature
+
+    (*dev).max_tx_queues = ((*resp).max_sq_num / 2) as u16  # Half for TX
+    (*dev).max_rx_queues = ((*resp).max_sq_num / 2) as u16  # Half for RX
+    (*dev).max_sq_depth = (*resp).max_sq_depth as u16
+    (*dev).max_cq_depth = (*resp).max_cq_depth as u16
+
+    if (*dev).max_tx_queues == 0
+        (*dev).max_tx_queues = 1
+    if (*dev).max_rx_queues == 0
+        (*dev).max_rx_queues = 1
+
+    prints("[ena] Queue limits:\n")
+    prints("[ena]   Max TX queues: ")
+    serial_print_dec((*dev).max_tx_queues as u64)
+    prints("\n")
+    prints("[ena]   Max RX queues: ")
+    serial_print_dec((*dev).max_rx_queues as u64)
+    prints("\n")
+    prints("[ena]   Max SQ depth: ")
+    serial_print_dec((*dev).max_sq_depth as u64)
+    prints("\n")
+
+    return 0
+
+# ============================================================================
+# AENQ Configuration
+# ============================================================================
+
+fn ena_set_aenq_config(dev: *EnaDevice) -> i32
+    prints("[ena] Setting AENQ config...\n")
+
+    # First, get the supported groups
+    var get_cmd: EnaAdminGetFeatureCmd
+    var i: u32 = 0
+    while i < 64
+        *((@get_cmd as u64 + i as u64) as *u8) = 0
+        i = i + 1
+
+    get_cmd.common_desc.opcode = ENA_ADMIN_GET_FEATURE
+    get_cmd.feature_id = ENA_ADMIN_AENQ_CONFIG
+
+    var cmd_id: u16 = ena_admin_submit_cmd(dev, @get_cmd as *EnaAdminAqEntry)
+    var result: i32 = ena_admin_wait_completion(dev, cmd_id)
+
+    if result != 0
+        prints("[ena] Failed to get AENQ config\n")
+        return result
+
+    # Parse response
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+    var prev_head: u16 = ena_get_prev_cq_head(aq)
+    var entry_addr: u64 = ena_admin_cq_entry_addr(aq, prev_head)
+    let resp: *EnaAdminAenqFeature = entry_addr as *EnaAdminAenqFeature
+
+    let supported: u32 = (*resp).supported_groups
+    prints("[ena]   Supported AENQ groups: 0x")
+    serial_print_hex(supported as u64)
+    prints("\n")
+
+    # Request to enable: link change, fatal error, warning, notification, keep-alive
+    var requested: u32 = (1 << ENA_ADMIN_AENQ_LINK_CHANGE as u32)
+    requested = requested | (1 << ENA_ADMIN_AENQ_FATAL_ERROR as u32)
+    requested = requested | (1 << ENA_ADMIN_AENQ_WARNING as u32)
+    requested = requested | (1 << ENA_ADMIN_AENQ_NOTIFICATION as u32)
+    requested = requested | (1 << ENA_ADMIN_AENQ_KEEP_ALIVE as u32)
+
+    # Mask with what device supports
+    let enabled: u32 = requested & supported
+
+    prints("[ena]   Enabling AENQ groups: 0x")
+    serial_print_hex(enabled as u64)
+    prints("\n")
+
+    # Now set the feature
+    var set_cmd: EnaAdminSetFeatureCmd
+    i = 0
+    while i < 64
+        *((@set_cmd as u64 + i as u64) as *u8) = 0
+        i = i + 1
+
+    set_cmd.common_desc.opcode = ENA_ADMIN_SET_FEATURE
+    set_cmd.feature_id = ENA_ADMIN_AENQ_CONFIG
+    set_cmd.aenq_enabled_groups = enabled
+
+    cmd_id = ena_admin_submit_cmd(dev, @set_cmd as *EnaAdminAqEntry)
+    result = ena_admin_wait_completion(dev, cmd_id)
+
+    if result != 0
+        prints("[ena] Failed to set AENQ config\n")
+        return result
+
+    prints("[ena] AENQ config set successfully\n")
+    return 0
+
+# ============================================================================
+# I/O Queue Setup
+# ============================================================================
+
+fn ena_create_cq(dev: *EnaDevice, qid: u16, depth: u16, direction: u8, cq_out: *EnaIoCq) -> i32
+    prints("[ena] Creating CQ ")
+    serial_print_dec(qid as u64)
+    if direction == SQ_DIR_TX
+        prints(" (TX)...\n")
+    else
+        prints(" (RX)...\n")
+
+    # Entry size depends on direction:
+    # TX CQ uses 8-byte entries (EnaTxCdescExt: 2 words)
+    # RX CQ uses 16-byte entries (EnaRxCdescBase: 4 words)
+    var entry_size_words: u8 = 4  # RX default: 16 bytes = 4 words
+    var entry_size_bytes: u64 = 16
+    if direction == SQ_DIR_TX
+        entry_size_words = 2  # TX: 8 bytes = 2 words
+        entry_size_bytes = 8
+
+    # Allocate CQ memory
+    let cq_size: u64 = (depth as u64) * entry_size_bytes
+    let pages_needed: u64 = (cq_size + PAGE_SIZE - 1) / PAGE_SIZE
+    let cq_page: u64 = pmm_alloc_page()
+    if cq_page == 0
+        prints("[ena] ERROR: Failed to allocate CQ memory\n")
+        return -1
+
+    (*cq_out).entries = cq_page as *EnaRxCdescBase
+    (*cq_out).phys = vmm_virt_to_phys(cq_page)
+    if (*cq_out).phys == 0
+        (*cq_out).phys = cq_page
+    (*cq_out).depth = depth
+    (*cq_out).head = 0
+    (*cq_out).phase = 1
+
+    # Zero out CQ
+    var i: u64 = 0
+    while i < PAGE_SIZE
+        *((cq_page + i) as *u8) = 0
+        i = i + 1
+
+    # Build admin command
+    var cmd: EnaAdminCreateCqCmd
+    i = 0
+    while i < 64
+        *((@cmd as u64 + i) as *u8) = 0
+        i = i + 1
+
+    cmd.common_desc.opcode = ENA_ADMIN_CREATE_CQ
+    # The C driver always sets interrupt mode enabled (bit 5), even when polling
+    cmd.cq_caps_1 = 0x20  # Interrupt mode enabled mask
+    cmd.cq_caps_2 = entry_size_words  # Entry size in words (TX=2, RX=4)
+    cmd.cq_depth = depth
+    cmd.msix_vector = 0
+    cmd.cq_ba_lo = ((*cq_out).phys & 0xFFFFFFFF) as u32
+    cmd.cq_ba_hi = (((*cq_out).phys >> 32) & 0xFFFF) as u16
+    cmd.cq_ba_reserved = 0
+
+    prints("[ena] CQ caps1=0x")
+    serial_print_hex(cmd.cq_caps_1 as u64)
+    prints(" caps2=")
+    serial_print_dec(entry_size_words as u64)
+    prints(" words (")
+    serial_print_dec(entry_size_bytes)
+    prints(" bytes)\n")
+
+    let cmd_id: u16 = ena_admin_submit_cmd(dev, @cmd as *EnaAdminAqEntry)
+    let result: i32 = ena_admin_wait_completion(dev, cmd_id)
+
+    if result != 0
+        prints("[ena] Failed to create CQ\n")
+        return result
+
+    # Get response with HW index and interrupt unmask offset
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+    let prev_head: u16 = ena_get_prev_cq_head(aq)
+    let entry_addr: u64 = ena_admin_cq_entry_addr(aq, prev_head)
+    let resp: *EnaAdminCreateCqResp = entry_addr as *EnaAdminCreateCqResp
+
+    (*cq_out).hw_index = (*resp).cq_idx
+    (*cq_out).unmask_offset = (*resp).cq_interrupt_unmask_offset
+
+    prints("[ena] CQ ")
+    serial_print_dec(qid as u64)
+    prints(" created, hw_idx=")
+    serial_print_dec((*cq_out).hw_index as u64)
+    prints("\n")
+
+    return 0
+
+fn ena_create_sq(dev: *EnaDevice, qid: u16, cq_idx: u16, direction: u8, depth: u16, sq_out: *EnaIoSq) -> i32
+    prints("[ena] Creating SQ ")
+    serial_print_dec(qid as u64)
+    if direction == SQ_DIR_TX
+        prints(" (TX)...\n")
+    else
+        prints(" (RX)...\n")
+
+    # Allocate SQ memory
+    var entry_size: u64 = ENA_RX_DESC_SIZE as u64
+    if direction == SQ_DIR_TX
+        entry_size = ENA_TX_DESC_SIZE as u64
+    let sq_size: u64 = (depth as u64) * entry_size
+    let sq_page: u64 = pmm_alloc_page()
+    if sq_page == 0
+        prints("[ena] ERROR: Failed to allocate SQ memory\n")
+        return -1
+
+    (*sq_out).entries = sq_page as *EnaTxDesc
+    (*sq_out).phys = vmm_virt_to_phys(sq_page)
+    if (*sq_out).phys == 0
+        (*sq_out).phys = sq_page
+    (*sq_out).depth = depth
+    (*sq_out).head = 0
+    (*sq_out).tail = 0
+    (*sq_out).phase = 1
+
+    # Zero out SQ
+    var i: u64 = 0
+    while i < PAGE_SIZE
+        *((sq_page + i) as *u8) = 0
+        i = i + 1
+
+    # Build admin command
+    var cmd: EnaAdminCreateSqCmd
+    i = 0
+    while i < 64
+        *((@cmd as u64 + i) as *u8) = 0
+        i = i + 1
+
+    cmd.common_desc.opcode = ENA_ADMIN_CREATE_SQ
+    cmd.sq_identity = direction << ENA_ADMIN_SQ_IDENTITY_DIRECTION_SHIFT
+    var caps2: u8 = ENA_ADMIN_PLACEMENT_POLICY_HOST
+    caps2 = caps2 | (ENA_ADMIN_COMPLETION_POLICY_DESC << ENA_ADMIN_SQ_CAPS2_COMPLETION_SHIFT)
+    cmd.sq_caps_2 = caps2
+    cmd.sq_caps_3 = ENA_ADMIN_SQ_CAPS3_CONTIGUOUS_MASK  # Contiguous memory
+    cmd.cq_idx = cq_idx
+    cmd.sq_depth = depth
+    cmd.sq_ba_lo = ((*sq_out).phys & 0xFFFFFFFF) as u32
+    cmd.sq_ba_hi = (((*sq_out).phys >> 32) & 0xFFFF) as u16
+    cmd.sq_ba_reserved = 0
+
+    # Debug: print what we're sending
+    prints("[ena] SQ cmd: identity=0x")
+    serial_print_hex(cmd.sq_identity as u64)
+    prints(" caps2=0x")
+    serial_print_hex(cmd.sq_caps_2 as u64)
+    prints(" caps3=0x")
+    serial_print_hex(cmd.sq_caps_3 as u64)
+    prints(" cq_idx=")
+    serial_print_dec(cmd.cq_idx as u64)
+    prints(" depth=")
+    serial_print_dec(cmd.sq_depth as u64)
+    prints("\n")
+    prints("[ena] SQ ba: lo=0x")
+    serial_print_hex(cmd.sq_ba_lo as u64)
+    prints(" hi=0x")
+    serial_print_hex(cmd.sq_ba_hi as u64)
+    prints("\n")
+
+    # Dump raw bytes of command (first 36 bytes which is the data portion)
+    prints("[ena] SQ raw: ")
+    ena_dump_bytes(@cmd as *u8, 36)
+
+    let cmd_id: u16 = ena_admin_submit_cmd(dev, @cmd as *EnaAdminAqEntry)
+    let result: i32 = ena_admin_wait_completion(dev, cmd_id)
+
+    if result != 0
+        prints("[ena] Failed to create SQ\n")
+        return result
+
+    # Get doorbell offset from response
+    let aq: *EnaAdminQueue = @(*dev).admin_queue
+    let prev_head: u16 = ena_get_prev_cq_head(aq)
+    let entry_addr: u64 = ena_admin_cq_entry_addr(aq, prev_head)
+    let resp: *EnaAdminCreateSqResp = entry_addr as *EnaAdminCreateSqResp
+
+    (*sq_out).doorbell_offset = (*resp).sq_doorbell_offset
+
+    prints("[ena] SQ ")
+    serial_print_dec(qid as u64)
+    prints(" created, idx=")
+    serial_print_dec((*resp).sq_idx as u64)
+    prints(", doorbell=0x")
+    serial_print_hex((*sq_out).doorbell_offset as u64)
+    prints("\n")
+
+    return 0
+
+fn ena_setup_io_queues(dev: *EnaDevice) -> i32
+    prints("[ena] Setting up I/O queues...\n")
+
+    # Create TX CQ (queue 0)
+    var result: i32 = ena_create_cq(dev, 0, ENA_IO_QUEUE_DEPTH as u16, SQ_DIR_TX, @(*dev).tx_cq)
+    if result != 0
+        return result
+
+    # Create TX SQ - use the hardware CQ index, not our queue ID
+    let tx_cq_hw_idx: u16 = (*dev).tx_cq.hw_index
+    let tx_depth: u16 = ENA_IO_QUEUE_DEPTH as u16
+    prints("[ena] Creating TX SQ with cq_idx=")
+    serial_print_dec(tx_cq_hw_idx as u64)
+    prints("\n")
+    result = ena_create_sq(dev, 0, tx_cq_hw_idx, SQ_DIR_TX, tx_depth, @(*dev).tx_sq)
+    if result != 0
+        return result
+
+    # Create RX CQ (queue 1)
+    result = ena_create_cq(dev, 1, ENA_IO_QUEUE_DEPTH as u16, SQ_DIR_RX, @(*dev).rx_cq)
+    if result != 0
+        return result
+
+    # Create RX SQ - use the hardware CQ index
+    let rx_cq_hw_idx: u16 = (*dev).rx_cq.hw_index
+    let rx_depth: u16 = ENA_IO_QUEUE_DEPTH as u16
+    prints("[ena] Creating RX SQ with cq_idx=")
+    serial_print_dec(rx_cq_hw_idx as u64)
+    prints("\n")
+    result = ena_create_sq(dev, 1, rx_cq_hw_idx, SQ_DIR_RX, rx_depth, @(*dev).rx_sq)
+    if result != 0
+        return result
+
+    prints("[ena] I/O queues ready\n")
+    return 0
+
+# ============================================================================
+# RX Buffer Population
+# ============================================================================
+
+fn ena_populate_rx_buffers(dev: *EnaDevice) -> i32
+    prints("[ena] Populating RX buffers...\n")
+
+    let rx_sq: *EnaIoSq = @(*dev).rx_sq
+    var buf_idx: u32 = 0
+
+    while buf_idx < ENA_RX_BUFFER_COUNT
+        let buf_addr: u64 = (@ena_rx_buffers[0] as u64) + (buf_idx as u64 * ENA_RX_BUFFER_SIZE as u64)
+        let buf_phys: u64 = vmm_virt_to_phys(buf_addr)
+        let phys: u64 = ena_get_phys_or_virt(buf_phys, buf_addr)
+
+        # Get RX descriptor
+        let desc_addr: u64 = ena_io_sq_entry_addr(rx_sq, (*rx_sq).head, ENA_RX_DESC_SIZE)
+        let desc: *EnaRxDesc = desc_addr as *EnaRxDesc
+
+        # Fill descriptor
+        (*desc).length = ENA_RX_BUFFER_SIZE as u16
+        (*desc).reserved2 = 0
+        (*desc).ctrl = ena_rx_build_ctrl((*rx_sq).phase, 1, 1, 1)
+        (*desc).req_id = buf_idx as u16
+        (*desc).reserved6 = 0
+        (*desc).buff_addr_lo = (phys & 0xFFFFFFFF) as u32
+        (*desc).buff_addr_hi = ((phys >> 32) & 0xFFFF) as u16
+        (*desc).reserved16_w3 = 0
+
+        # Track buffer mapping
+        ena_rx_req_to_buf[buf_idx] = buf_idx as u16
+
+        # Advance head
+        (*rx_sq).head = (*rx_sq).head + 1
+        if (*rx_sq).head >= (*rx_sq).depth
+            (*rx_sq).head = 0
+            (*rx_sq).phase = (*rx_sq).phase ^ 1
+
+        buf_idx = buf_idx + 1
+
+    # Ring doorbell
+    asm x86_64:
+        mfence
+    ena_write32(dev, (*rx_sq).doorbell_offset, (*rx_sq).head as u32)
+
+    prints("[ena] Populated ")
+    serial_print_dec(buf_idx as u64)
+    prints(" RX buffers\n")
+
+    return 0
+
+# ============================================================================
+# Public API
+# ============================================================================
+
+pub fn ena_init() -> i32
+    prints("\n[ena] Initializing ENA driver...\n")
+
+    # Find ENA device
+    let pci_dev: *PciDevice = pci_find_ena()
+    if pci_dev == (0 as *PciDevice)
+        prints("[ena] No ENA device found\n")
+        return -1
+
+    prints("[ena] Found ENA device at ")
+    serial_print_dec((*pci_dev).bus as u64)
+    prints(":")
+    serial_print_dec((*pci_dev).device as u64)
+    prints(".")
+    serial_print_dec((*pci_dev).function as u64)
+    prints("\n")
+
+    # Enable PCI bus mastering and memory space
+    pci_enable_bus_master(pci_dev)
+    pci_enable_memory(pci_dev)
+
+    # Get BAR0 (memory-mapped registers)
+    if (*pci_dev).bar_is_io[0] != 0
+        prints("[ena] ERROR: BAR0 is I/O space, expected memory\n")
+        return -1
+
+    ena_dev.pci_dev = pci_dev
+    ena_dev.bar0 = (*pci_dev).bar[0]
+    ena_dev.bar0_size = (*pci_dev).bar_size[0]
+    ena_dev.initialized = 0
+
+    prints("[ena] BAR0: 0x")
+    serial_print_hex(ena_dev.bar0)
+    prints(" size=")
+    serial_print_dec(ena_dev.bar0_size)
+    prints("\n")
+
+    # Map the ENA MMIO region (BAR0) into virtual memory
+    # Identity map the BAR0 pages so we can access the registers
+    let bar0_page: u64 = ena_dev.bar0 & 0xFFFFFFFFFFFFF000  # Page-align
+    var num_pages: u64 = (ena_dev.bar0_size + PAGE_SIZE - 1) / PAGE_SIZE
+    if num_pages < 4
+        num_pages = 4  # Minimum 4 pages (16KB) for ENA registers
+
+    prints("[ena] Mapping ")
+    serial_print_dec(num_pages)
+    prints(" pages for BAR0 MMIO\n")
+
+    var page_idx: u64 = 0
+    while page_idx < num_pages
+        let addr: u64 = bar0_page + (page_idx * PAGE_SIZE)
+        let map_result: i32 = vmm_map_page(addr, addr, PTE_WRITABLE)
+        if map_result != 0
+            prints("[ena] Failed to map BAR0 page at 0x")
+            serial_print_hex(addr)
+            prints("\n")
+            return -1
+        page_idx = page_idx + 1
+    prints("[ena] BAR0 MMIO region mapped\n")
+
+    # Read version registers
+    let version: u32 = ena_read32(@ena_dev, ENA_REGS_VERSION_OFF)
+    let ctrl_version: u32 = ena_read32(@ena_dev, ENA_REGS_CONTROLLER_VERSION_OFF)
+    prints("[ena] Device version: ")
+    serial_print_dec(((version & ENA_REGS_VERSION_MAJOR_MASK) >> ENA_REGS_VERSION_MAJOR_SHIFT) as u64)
+    prints(".")
+    serial_print_dec((version & ENA_REGS_VERSION_MINOR_MASK) as u64)
+    prints("\n")
+    prints("[ena] Controller version: ")
+    serial_print_dec(((ctrl_version & ENA_REGS_CTRL_VER_MAJOR_MASK) >> ENA_REGS_CTRL_VER_MAJOR_SHIFT) as u64)
+    prints(".")
+    serial_print_dec(((ctrl_version & ENA_REGS_CTRL_VER_MINOR_MASK) >> ENA_REGS_CTRL_VER_MINOR_SHIFT) as u64)
+    prints(".")
+    serial_print_dec((ctrl_version & ENA_REGS_CTRL_VER_SUBMINOR_MASK) as u64)
+    prints("\n")
+
+    # Reset device
+    var result: i32 = ena_device_reset(@ena_dev, ENA_REGS_RESET_NORMAL)
+    if result != 0
+        return result
+
+    # Wait for device ready
+    result = ena_wait_for_ready(@ena_dev)
+    if result != 0
+        return result
+
+    # Initialize admin queue
+    result = ena_admin_queue_init(@ena_dev)
+    if result != 0
+        return result
+
+    # Get device attributes (includes MAC)
+    result = ena_get_device_attributes(@ena_dev)
+    if result != 0
+        prints("[ena] Warning: Could not get device attributes\n")
+        # Set default MAC
+        ena_dev.mac[0] = 0x02
+        ena_dev.mac[1] = 0x00
+        ena_dev.mac[2] = 0x00
+        ena_dev.mac[3] = 0x00
+        ena_dev.mac[4] = 0x00
+        ena_dev.mac[5] = 0x01
+        ena_dev.mtu = 1500
+
+    # Get max queue info
+    result = ena_get_max_queues(@ena_dev)
+    if result != 0
+        return result
+
+    # Configure AENQ (async event notification)
+    result = ena_set_aenq_config(@ena_dev)
+    if result != 0
+        prints("[ena] Warning: AENQ config failed, continuing anyway\n")
+
+    # Setup I/O queues
+    result = ena_setup_io_queues(@ena_dev)
+    if result != 0
+        return result
+
+    # Populate RX buffers
+    result = ena_populate_rx_buffers(@ena_dev)
+    if result != 0
+        return result
+
+    ena_dev.initialized = 1
+    prints("[ena] Initialization complete!\n")
+
+    return 0
+
+pub fn ena_send(data: *u8, len: u32) -> i32
+    if ena_dev.initialized == 0
+        return -1
+
+    if len > 1514 or len == 0
+        return -1
+
+    let tx_sq: *EnaIoSq = @ena_dev.tx_sq
+
+    # Get buffer for this packet (simple: use head index)
+    let buf_idx: u32 = tx_sq.head as u32
+    let buf_addr: u64 = (@ena_tx_buffers[0] as u64) + (buf_idx as u64 * ENA_TX_BUFFER_SIZE as u64)
+
+    # Copy packet to buffer
+    var i: u32 = 0
+    while i < len
+        *((buf_addr + i as u64) as *u8) = *(data + i as i64)
+        i = i + 1
+
+    # Get physical address
+    let buf_phys: u64 = vmm_virt_to_phys(buf_addr)
+    let phys: u64 = ena_get_phys_or_virt(buf_phys, buf_addr)
+
+    # Build TX descriptor
+    let desc_addr: u64 = ena_io_sq_entry_addr(tx_sq, (*tx_sq).head, ENA_TX_DESC_SIZE)
+    let desc: *EnaTxDesc = desc_addr as *EnaTxDesc
+
+    let req_id: u16 = (*tx_sq).head
+    (*desc).len_ctrl = ena_tx_build_len_ctrl(len as u16, req_id, (*tx_sq).phase, 1, 1, 1)
+    (*desc).meta_ctrl = ena_tx_build_meta_ctrl_simple(req_id)
+    (*desc).buff_addr_lo = (phys & 0xFFFFFFFF) as u32
+    (*desc).buff_addr_hi_hdr_sz = ((phys >> 32) & 0xFFFF) as u32
+
+    # Advance head
+    (*tx_sq).head = (*tx_sq).head + 1
+    if (*tx_sq).head >= (*tx_sq).depth
+        (*tx_sq).head = 0
+        (*tx_sq).phase = (*tx_sq).phase ^ 1
+
+    # Ring doorbell
+    asm x86_64:
+        mfence
+    ena_write32(@ena_dev, (*tx_sq).doorbell_offset, (*tx_sq).head as u32)
+
+    return 0
+
+pub fn ena_poll(buf: *u8, max_len: u32) -> i32
+    if ena_dev.initialized == 0
+        return -1
+
+    let rx_cq: *EnaIoCq = @ena_dev.rx_cq
+    let rx_sq: *EnaIoSq = @ena_dev.rx_sq
+
+    # Check for completion
+    let cqe_addr: u64 = ena_io_cq_entry_addr(rx_cq, (*rx_cq).head, ENA_RX_CDESC_BASE_SIZE)
+    let cqe: *EnaRxCdescBase = cqe_addr as *EnaRxCdescBase
+
+    if not ena_rx_cdesc_phase_matches(cqe, (*rx_cq).phase)
+        return 0  # No packet
+
+    let pkt_len: u16 = ena_rx_cdesc_get_length(cqe)
+    let req_id: u16 = ena_rx_cdesc_get_req_id(cqe)
+
+    if pkt_len == 0
+        # Advance CQ and return
+        (*rx_cq).head = (*rx_cq).head + 1
+        if (*rx_cq).head >= (*rx_cq).depth
+            (*rx_cq).head = 0
+            (*rx_cq).phase = (*rx_cq).phase ^ 1
+        return 0
+
+    # Get buffer from req_id
+    let buf_idx: u16 = ena_rx_req_to_buf[req_id]
+    let src_addr: u64 = (@ena_rx_buffers[0] as u64) + (buf_idx as u64 * ENA_RX_BUFFER_SIZE as u64)
+
+    # Copy packet to output buffer
+    var copy_len: u32 = pkt_len as u32
+    if copy_len > max_len
+        copy_len = max_len
+
+    var i: u32 = 0
+    while i < copy_len
+        *(buf + i as i64) = *((src_addr + i as u64) as *u8)
+        i = i + 1
+
+    # Advance CQ head
+    (*rx_cq).head = (*rx_cq).head + 1
+    if (*rx_cq).head >= (*rx_cq).depth
+        (*rx_cq).head = 0
+        (*rx_cq).phase = (*rx_cq).phase ^ 1
+
+    # Re-submit the buffer to RX SQ
+    let rx_buf_phys: u64 = vmm_virt_to_phys(src_addr)
+    let phys: u64 = ena_get_phys_or_virt(rx_buf_phys, src_addr)
+
+    let desc_addr: u64 = ena_io_sq_entry_addr(rx_sq, (*rx_sq).head, ENA_RX_DESC_SIZE)
+    let desc: *EnaRxDesc = desc_addr as *EnaRxDesc
+
+    (*desc).length = ENA_RX_BUFFER_SIZE as u16
+    (*desc).reserved2 = 0
+    (*desc).ctrl = ena_rx_build_ctrl((*rx_sq).phase, 1, 1, 1)
+    (*desc).req_id = req_id
+    (*desc).reserved6 = 0
+    (*desc).buff_addr_lo = (phys & 0xFFFFFFFF) as u32
+    (*desc).buff_addr_hi = ((phys >> 32) & 0xFFFF) as u16
+    (*desc).reserved16_w3 = 0
+
+    (*rx_sq).head = (*rx_sq).head + 1
+    if (*rx_sq).head >= (*rx_sq).depth
+        (*rx_sq).head = 0
+        (*rx_sq).phase = (*rx_sq).phase ^ 1
+
+    # Ring RX doorbell
+    asm x86_64:
+        mfence
+    ena_write32(@ena_dev, (*rx_sq).doorbell_offset, (*rx_sq).head as u32)
+
+    return copy_len as i32
+
+pub fn ena_is_ready() -> u8
+    return ena_dev.initialized
+
+pub fn ena_get_mac(mac_out: *u8)
+    var i: i32 = 0
+    while i < 6
+        *(mac_out + i as i64) = ena_dev.mac[i]
+        i = i + 1
+
+pub fn ena_get_device() -> *EnaDevice
+    return @ena_dev
+
+fn ena_print_mac(dev: *EnaDevice)
+    let hex_chars: *u8 = c"0123456789ABCDEF"
+    var i: i32 = 0
+    while i < 6
+        if i > 0
+            prints(":")
+        let byte: u8 = (*dev).mac[i]
+        let hi: u8 = (byte >> 4) & 0x0F
+        let lo: u8 = byte & 0x0F
+        serial_write_byte(*(hex_chars + hi as i64))
+        serial_write_byte(*(hex_chars + lo as i64))
+        i = i + 1
+
+# Debug: dump first N bytes of a struct as hex
+fn ena_dump_bytes(ptr: *u8, count: i32)
+    let hex_chars: *u8 = c"0123456789ABCDEF"
+    var i: i32 = 0
+    while i < count
+        let byte: u8 = *(ptr + i as i64)
+        let hi: u8 = (byte >> 4) & 0x0F
+        let lo: u8 = byte & 0x0F
+        serial_write_byte(*(hex_chars + hi as i64))
+        serial_write_byte(*(hex_chars + lo as i64))
+        if (i + 1) % 4 == 0
+            prints(" ")
+        i = i + 1
+    prints("\n")

--- a/projects/harland/kernel/src/drivers/ena/io.ritz
+++ b/projects/harland/kernel/src/drivers/ena/io.ritz
@@ -1,0 +1,245 @@
+# ENA I/O Descriptors
+#
+# TX and RX submission and completion queue descriptor formats.
+# These are the data plane structures used for packet transmission and reception.
+
+# ============================================================================
+# L3/L4 Protocol Indices (for checksum offload)
+# ============================================================================
+
+pub const ENA_ETH_IO_L3_PROTO_UNKNOWN: u8 = 0
+pub const ENA_ETH_IO_L3_PROTO_IPV4: u8 = 8
+pub const ENA_ETH_IO_L3_PROTO_IPV6: u8 = 11
+
+pub const ENA_ETH_IO_L4_PROTO_UNKNOWN: u8 = 0
+pub const ENA_ETH_IO_L4_PROTO_TCP: u8 = 12
+pub const ENA_ETH_IO_L4_PROTO_UDP: u8 = 13
+
+# ============================================================================
+# TX Submission Queue Descriptor (16 bytes)
+# ============================================================================
+
+pub struct EnaTxDesc
+    len_ctrl: u32       # 15:0 length, 21:16 req_id_hi, 24 phase,
+                        # 26 first, 27 last, 28 comp_req
+    meta_ctrl: u32      # 3:0 l3_proto_idx, 4 DF, 7 tso_en,
+                        # 12:8 l4_proto_idx, 13 l3_csum_en, 14 l4_csum_en,
+                        # 31:22 req_id_lo
+    buff_addr_lo: u32   # Buffer physical address low
+    buff_addr_hi_hdr_sz: u32  # 15:0 addr_hi, 31:24 header_length
+
+pub const ENA_TX_DESC_SIZE: u32 = 16
+
+# TX descriptor len_ctrl field masks
+pub const ENA_TX_DESC_LENGTH_MASK: u32 = 0x0000FFFF
+pub const ENA_TX_DESC_REQ_ID_HI_SHIFT: u32 = 16
+pub const ENA_TX_DESC_REQ_ID_HI_MASK: u32 = 0x003F0000
+pub const ENA_TX_DESC_META_DESC_SHIFT: u32 = 23
+pub const ENA_TX_DESC_META_DESC_MASK: u32 = 0x00800000
+pub const ENA_TX_DESC_PHASE_SHIFT: u32 = 24
+pub const ENA_TX_DESC_PHASE_MASK: u32 = 0x01000000
+pub const ENA_TX_DESC_FIRST_SHIFT: u32 = 26
+pub const ENA_TX_DESC_FIRST_MASK: u32 = 0x04000000
+pub const ENA_TX_DESC_LAST_SHIFT: u32 = 27
+pub const ENA_TX_DESC_LAST_MASK: u32 = 0x08000000
+pub const ENA_TX_DESC_COMP_REQ_SHIFT: u32 = 28
+pub const ENA_TX_DESC_COMP_REQ_MASK: u32 = 0x10000000
+
+# TX descriptor meta_ctrl field masks
+pub const ENA_TX_DESC_L3_PROTO_IDX_MASK: u32 = 0x0000000F
+pub const ENA_TX_DESC_DF_SHIFT: u32 = 4
+pub const ENA_TX_DESC_DF_MASK: u32 = 0x00000010
+pub const ENA_TX_DESC_TSO_EN_SHIFT: u32 = 7
+pub const ENA_TX_DESC_TSO_EN_MASK: u32 = 0x00000080
+pub const ENA_TX_DESC_L4_PROTO_IDX_SHIFT: u32 = 8
+pub const ENA_TX_DESC_L4_PROTO_IDX_MASK: u32 = 0x00001F00
+pub const ENA_TX_DESC_L3_CSUM_EN_SHIFT: u32 = 13
+pub const ENA_TX_DESC_L3_CSUM_EN_MASK: u32 = 0x00002000
+pub const ENA_TX_DESC_L4_CSUM_EN_SHIFT: u32 = 14
+pub const ENA_TX_DESC_L4_CSUM_EN_MASK: u32 = 0x00004000
+pub const ENA_TX_DESC_FCS_DIS_SHIFT: u32 = 15
+pub const ENA_TX_DESC_FCS_DIS_MASK: u32 = 0x00008000
+pub const ENA_TX_DESC_L4_CSUM_PARTIAL_SHIFT: u32 = 17
+pub const ENA_TX_DESC_L4_CSUM_PARTIAL_MASK: u32 = 0x00020000
+pub const ENA_TX_DESC_REQ_ID_LO_SHIFT: u32 = 22
+pub const ENA_TX_DESC_REQ_ID_LO_MASK: u32 = 0xFFC00000
+
+# TX descriptor buff_addr_hi_hdr_sz field masks
+pub const ENA_TX_DESC_ADDR_HI_MASK: u32 = 0x0000FFFF
+pub const ENA_TX_DESC_HEADER_LENGTH_SHIFT: u32 = 24
+pub const ENA_TX_DESC_HEADER_LENGTH_MASK: u32 = 0xFF000000
+
+# ============================================================================
+# TX Completion Queue Descriptor (4/8 bytes)
+# ============================================================================
+
+pub struct EnaTxCdesc
+    req_id: u16         # Request ID
+    status: u8          # Completion status
+    flags: u8           # 0: phase
+
+pub const ENA_TX_CDESC_SIZE: u32 = 4
+
+# Extended TX completion (8 bytes, with sub_qid and sq_head_idx)
+pub struct EnaTxCdescExt
+    req_id: u16
+    status: u8
+    flags: u8
+    sub_qid: u16
+    sq_head_idx: u16
+
+pub const ENA_TX_CDESC_EXT_SIZE: u32 = 8
+
+# TX completion flags
+pub const ENA_TX_CDESC_PHASE_MASK: u8 = 0x01
+
+# ============================================================================
+# RX Submission Queue Descriptor (16 bytes)
+# ============================================================================
+
+pub struct EnaRxDesc
+    length: u16         # Buffer length in bytes (0 = 64KB)
+    reserved2: u8       # MBZ
+    ctrl: u8            # 0: phase, 2: first, 3: last, 4: comp_req
+    req_id: u16         # Request ID
+    reserved6: u16      # MBZ
+    buff_addr_lo: u32   # Buffer physical address low
+    buff_addr_hi: u16   # Buffer physical address high
+    reserved16_w3: u16  # MBZ
+
+pub const ENA_RX_DESC_SIZE: u32 = 16
+
+# RX descriptor ctrl field masks
+pub const ENA_RX_DESC_PHASE_MASK: u8 = 0x01
+pub const ENA_RX_DESC_FIRST_SHIFT: u8 = 2
+pub const ENA_RX_DESC_FIRST_MASK: u8 = 0x04
+pub const ENA_RX_DESC_LAST_SHIFT: u8 = 3
+pub const ENA_RX_DESC_LAST_MASK: u8 = 0x08
+pub const ENA_RX_DESC_COMP_REQ_SHIFT: u8 = 4
+pub const ENA_RX_DESC_COMP_REQ_MASK: u8 = 0x10
+
+# ============================================================================
+# RX Completion Queue Descriptor Base (16 bytes)
+# ============================================================================
+
+pub struct EnaRxCdescBase
+    status: u32         # 4:0 l3_proto_idx, 12:8 l4_proto_idx,
+                        # 13 l3_csum_err, 14 l4_csum_err,
+                        # 15 ipv4_frag, 16 l4_csum_checked,
+                        # 24 phase, 26 first, 27 last, 30 buffer
+    length: u16         # Received packet length
+    req_id: u16         # Request ID
+    hash: u32           # 32-bit RSS hash result
+    sub_qid: u16        # Sub-queue ID
+    offset: u8          # Offset
+    reserved: u8
+
+pub const ENA_RX_CDESC_BASE_SIZE: u32 = 16
+
+# RX completion status field masks
+pub const ENA_RX_CDESC_L3_PROTO_IDX_MASK: u32 = 0x0000001F
+pub const ENA_RX_CDESC_SRC_VLAN_CNT_SHIFT: u32 = 5
+pub const ENA_RX_CDESC_SRC_VLAN_CNT_MASK: u32 = 0x00000060
+pub const ENA_RX_CDESC_L4_PROTO_IDX_SHIFT: u32 = 8
+pub const ENA_RX_CDESC_L4_PROTO_IDX_MASK: u32 = 0x00001F00
+pub const ENA_RX_CDESC_L3_CSUM_ERR_SHIFT: u32 = 13
+pub const ENA_RX_CDESC_L3_CSUM_ERR_MASK: u32 = 0x00002000
+pub const ENA_RX_CDESC_L4_CSUM_ERR_SHIFT: u32 = 14
+pub const ENA_RX_CDESC_L4_CSUM_ERR_MASK: u32 = 0x00004000
+pub const ENA_RX_CDESC_IPV4_FRAG_SHIFT: u32 = 15
+pub const ENA_RX_CDESC_IPV4_FRAG_MASK: u32 = 0x00008000
+pub const ENA_RX_CDESC_L4_CSUM_CHECKED_SHIFT: u32 = 16
+pub const ENA_RX_CDESC_L4_CSUM_CHECKED_MASK: u32 = 0x00010000
+pub const ENA_RX_CDESC_PHASE_SHIFT: u32 = 24
+pub const ENA_RX_CDESC_PHASE_MASK: u32 = 0x01000000
+pub const ENA_RX_CDESC_FIRST_SHIFT: u32 = 26
+pub const ENA_RX_CDESC_FIRST_MASK: u32 = 0x04000000
+pub const ENA_RX_CDESC_LAST_SHIFT: u32 = 27
+pub const ENA_RX_CDESC_LAST_MASK: u32 = 0x08000000
+pub const ENA_RX_CDESC_BUFFER_SHIFT: u32 = 30
+pub const ENA_RX_CDESC_BUFFER_MASK: u32 = 0x40000000
+
+# ============================================================================
+# RX Completion Queue Descriptor Extended (32 bytes)
+# ============================================================================
+
+pub struct EnaRxCdescExt
+    base: EnaRxCdescBase    # 16 bytes
+    buff_addr_lo: u32
+    buff_addr_hi: u16
+    reserved16: u16
+    timestamp_lo: u32
+    timestamp_hi: u32
+
+pub const ENA_RX_CDESC_EXT_SIZE: u32 = 32
+
+# ============================================================================
+# Interrupt Moderation Register
+# ============================================================================
+
+pub struct EnaIntrReg
+    intr_control: u32   # 14:0 rx_intr_delay, 29:15 tx_intr_delay,
+                        # 30 intr_unmask, 31 no_moderation_update
+
+pub const ENA_INTR_UNMASK_SHIFT: u32 = 30
+pub const ENA_INTR_UNMASK_MASK: u32 = 0x40000000
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+# Build TX descriptor len_ctrl field
+pub fn ena_tx_build_len_ctrl(length: u16, req_id: u16, phase: u8, first: u8, last: u8, comp_req: u8) -> u32
+    var val: u32 = length as u32
+    val = val | (((req_id >> 10) as u32 & 0x3F) << ENA_TX_DESC_REQ_ID_HI_SHIFT)
+    if phase != 0
+        val = val | ENA_TX_DESC_PHASE_MASK
+    if first != 0
+        val = val | ENA_TX_DESC_FIRST_MASK
+    if last != 0
+        val = val | ENA_TX_DESC_LAST_MASK
+    if comp_req != 0
+        val = val | ENA_TX_DESC_COMP_REQ_MASK
+    val
+
+# Build TX descriptor meta_ctrl field (no offloads)
+pub fn ena_tx_build_meta_ctrl_simple(req_id: u16) -> u32
+    ((req_id as u32 & 0x3FF) << ENA_TX_DESC_REQ_ID_LO_SHIFT)
+
+# Build RX descriptor ctrl field
+pub fn ena_rx_build_ctrl(phase: u8, first: u8, last: u8, comp_req: u8) -> u8
+    var val: u8 = 0
+    if phase != 0
+        val = val | ENA_RX_DESC_PHASE_MASK
+    if first != 0
+        val = val | ENA_RX_DESC_FIRST_MASK
+    if last != 0
+        val = val | ENA_RX_DESC_LAST_MASK
+    if comp_req != 0
+        val = val | ENA_RX_DESC_COMP_REQ_MASK
+    val
+
+# Extract request ID from TX completion
+pub fn ena_tx_cdesc_get_req_id(cdesc: *EnaTxCdesc) -> u16
+    (*cdesc).req_id
+
+# Check if TX completion phase matches expected
+pub fn ena_tx_cdesc_phase_matches(cdesc: *EnaTxCdesc, expected_phase: u8) -> bool
+    ((*cdesc).flags & ENA_TX_CDESC_PHASE_MASK) == expected_phase
+
+# Extract length from RX completion
+pub fn ena_rx_cdesc_get_length(cdesc: *EnaRxCdescBase) -> u16
+    (*cdesc).length
+
+# Extract request ID from RX completion
+pub fn ena_rx_cdesc_get_req_id(cdesc: *EnaRxCdescBase) -> u16
+    (*cdesc).req_id
+
+# Check if RX completion phase matches expected
+pub fn ena_rx_cdesc_phase_matches(cdesc: *EnaRxCdescBase, expected_phase: u8) -> bool
+    let phase: u8 = (((*cdesc).status & ENA_RX_CDESC_PHASE_MASK) >> ENA_RX_CDESC_PHASE_SHIFT) as u8
+    phase == expected_phase
+
+# Check if RX completion indicates last descriptor
+pub fn ena_rx_cdesc_is_last(cdesc: *EnaRxCdescBase) -> bool
+    ((*cdesc).status & ENA_RX_CDESC_LAST_MASK) != 0

--- a/projects/harland/kernel/src/drivers/ena/regs.ritz
+++ b/projects/harland/kernel/src/drivers/ena/regs.ritz
@@ -1,0 +1,151 @@
+# ENA Register Definitions
+#
+# Based on Amazon ENA driver specifications.
+# These are the memory-mapped register offsets for ENA devices.
+
+# ============================================================================
+# Device Reset Reasons
+# ============================================================================
+
+pub const ENA_REGS_RESET_NORMAL: u8 = 0
+pub const ENA_REGS_RESET_KEEP_ALIVE_TO: u8 = 1
+pub const ENA_REGS_RESET_ADMIN_TO: u8 = 2
+pub const ENA_REGS_RESET_MISS_TX_CMPL: u8 = 3
+pub const ENA_REGS_RESET_INIT_ERR: u8 = 7
+pub const ENA_REGS_RESET_DRIVER_INVALID_STATE: u8 = 8
+pub const ENA_REGS_RESET_SHUTDOWN: u8 = 11
+pub const ENA_REGS_RESET_GENERIC: u8 = 13
+
+# ============================================================================
+# MMIO Register Offsets (BAR0)
+# ============================================================================
+
+pub const ENA_REGS_VERSION_OFF: u32 = 0x00
+pub const ENA_REGS_CONTROLLER_VERSION_OFF: u32 = 0x04
+pub const ENA_REGS_CAPS_OFF: u32 = 0x08
+pub const ENA_REGS_CAPS_EXT_OFF: u32 = 0x0C
+
+# Admin Queue registers
+pub const ENA_REGS_AQ_BASE_LO_OFF: u32 = 0x10
+pub const ENA_REGS_AQ_BASE_HI_OFF: u32 = 0x14
+pub const ENA_REGS_AQ_CAPS_OFF: u32 = 0x18
+
+# Admin Completion Queue registers
+pub const ENA_REGS_ACQ_BASE_LO_OFF: u32 = 0x20
+pub const ENA_REGS_ACQ_BASE_HI_OFF: u32 = 0x24
+pub const ENA_REGS_ACQ_CAPS_OFF: u32 = 0x28
+
+# Admin Queue Doorbell
+pub const ENA_REGS_AQ_DB_OFF: u32 = 0x2C
+pub const ENA_REGS_ACQ_TAIL_OFF: u32 = 0x30
+
+# Async Event Notification Queue registers
+pub const ENA_REGS_AENQ_CAPS_OFF: u32 = 0x34
+pub const ENA_REGS_AENQ_BASE_LO_OFF: u32 = 0x38
+pub const ENA_REGS_AENQ_BASE_HI_OFF: u32 = 0x3C
+pub const ENA_REGS_AENQ_HEAD_DB_OFF: u32 = 0x40
+pub const ENA_REGS_AENQ_TAIL_OFF: u32 = 0x44
+
+# Interrupt and Device Control
+pub const ENA_REGS_INTR_MASK_OFF: u32 = 0x4C
+pub const ENA_REGS_DEV_CTL_OFF: u32 = 0x54
+pub const ENA_REGS_DEV_STS_OFF: u32 = 0x58
+
+# MMIO Register Read (for indirect reads)
+pub const ENA_REGS_MMIO_REG_READ_OFF: u32 = 0x5C
+pub const ENA_REGS_MMIO_RESP_LO_OFF: u32 = 0x60
+pub const ENA_REGS_MMIO_RESP_HI_OFF: u32 = 0x64
+
+# ============================================================================
+# Version Register Masks
+# ============================================================================
+
+pub const ENA_REGS_VERSION_MINOR_MASK: u32 = 0x000000FF
+pub const ENA_REGS_VERSION_MAJOR_SHIFT: u32 = 8
+pub const ENA_REGS_VERSION_MAJOR_MASK: u32 = 0x0000FF00
+
+# ============================================================================
+# Controller Version Register Masks
+# ============================================================================
+
+pub const ENA_REGS_CTRL_VER_SUBMINOR_MASK: u32 = 0x000000FF
+pub const ENA_REGS_CTRL_VER_MINOR_SHIFT: u32 = 8
+pub const ENA_REGS_CTRL_VER_MINOR_MASK: u32 = 0x0000FF00
+pub const ENA_REGS_CTRL_VER_MAJOR_SHIFT: u32 = 16
+pub const ENA_REGS_CTRL_VER_MAJOR_MASK: u32 = 0x00FF0000
+pub const ENA_REGS_CTRL_VER_IMPL_ID_SHIFT: u32 = 24
+pub const ENA_REGS_CTRL_VER_IMPL_ID_MASK: u32 = 0xFF000000
+
+# ============================================================================
+# Capabilities Register Masks
+# ============================================================================
+
+pub const ENA_REGS_CAPS_CONTIGUOUS_QUEUE_REQUIRED_MASK: u32 = 0x00000001
+pub const ENA_REGS_CAPS_RESET_TIMEOUT_SHIFT: u32 = 1
+pub const ENA_REGS_CAPS_RESET_TIMEOUT_MASK: u32 = 0x0000003E
+pub const ENA_REGS_CAPS_DMA_ADDR_WIDTH_SHIFT: u32 = 8
+pub const ENA_REGS_CAPS_DMA_ADDR_WIDTH_MASK: u32 = 0x0000FF00
+pub const ENA_REGS_CAPS_ADMIN_CMD_TO_SHIFT: u32 = 16
+pub const ENA_REGS_CAPS_ADMIN_CMD_TO_MASK: u32 = 0x000F0000
+
+# ============================================================================
+# Admin Queue Caps Register Masks
+# ============================================================================
+
+pub const ENA_REGS_AQ_CAPS_DEPTH_MASK: u32 = 0x0000FFFF
+pub const ENA_REGS_AQ_CAPS_ENTRY_SIZE_SHIFT: u32 = 16
+pub const ENA_REGS_AQ_CAPS_ENTRY_SIZE_MASK: u32 = 0xFFFF0000
+
+# ============================================================================
+# Admin Completion Queue Caps Register Masks
+# ============================================================================
+
+pub const ENA_REGS_ACQ_CAPS_DEPTH_MASK: u32 = 0x0000FFFF
+pub const ENA_REGS_ACQ_CAPS_ENTRY_SIZE_SHIFT: u32 = 16
+pub const ENA_REGS_ACQ_CAPS_ENTRY_SIZE_MASK: u32 = 0xFFFF0000
+
+# ============================================================================
+# AENQ Caps Register Masks
+# ============================================================================
+
+pub const ENA_REGS_AENQ_CAPS_DEPTH_MASK: u32 = 0x0000FFFF
+pub const ENA_REGS_AENQ_CAPS_ENTRY_SIZE_SHIFT: u32 = 16
+pub const ENA_REGS_AENQ_CAPS_ENTRY_SIZE_MASK: u32 = 0xFFFF0000
+
+# ============================================================================
+# Device Control Register Masks
+# ============================================================================
+
+pub const ENA_REGS_DEV_CTL_DEV_RESET_MASK: u32 = 0x00000001
+pub const ENA_REGS_DEV_CTL_AQ_RESTART_SHIFT: u32 = 1
+pub const ENA_REGS_DEV_CTL_AQ_RESTART_MASK: u32 = 0x00000002
+pub const ENA_REGS_DEV_CTL_QUIESCENT_SHIFT: u32 = 2
+pub const ENA_REGS_DEV_CTL_QUIESCENT_MASK: u32 = 0x00000004
+pub const ENA_REGS_DEV_CTL_IO_RESUME_SHIFT: u32 = 3
+pub const ENA_REGS_DEV_CTL_IO_RESUME_MASK: u32 = 0x00000008
+pub const ENA_REGS_DEV_CTL_RESET_REASON_SHIFT: u32 = 28
+pub const ENA_REGS_DEV_CTL_RESET_REASON_MASK: u32 = 0xF0000000
+
+# ============================================================================
+# Device Status Register Masks
+# ============================================================================
+
+pub const ENA_REGS_DEV_STS_READY_MASK: u32 = 0x00000001
+pub const ENA_REGS_DEV_STS_AQ_RESTART_IN_PROGRESS_SHIFT: u32 = 1
+pub const ENA_REGS_DEV_STS_AQ_RESTART_IN_PROGRESS_MASK: u32 = 0x00000002
+pub const ENA_REGS_DEV_STS_AQ_RESTART_FINISHED_SHIFT: u32 = 2
+pub const ENA_REGS_DEV_STS_AQ_RESTART_FINISHED_MASK: u32 = 0x00000004
+pub const ENA_REGS_DEV_STS_RESET_IN_PROGRESS_SHIFT: u32 = 3
+pub const ENA_REGS_DEV_STS_RESET_IN_PROGRESS_MASK: u32 = 0x00000008
+pub const ENA_REGS_DEV_STS_RESET_FINISHED_SHIFT: u32 = 4
+pub const ENA_REGS_DEV_STS_RESET_FINISHED_MASK: u32 = 0x00000010
+pub const ENA_REGS_DEV_STS_FATAL_ERROR_SHIFT: u32 = 5
+pub const ENA_REGS_DEV_STS_FATAL_ERROR_MASK: u32 = 0x00000020
+
+# ============================================================================
+# MMIO Reg Read Register Masks
+# ============================================================================
+
+pub const ENA_REGS_MMIO_REG_READ_REQ_ID_MASK: u32 = 0x0000FFFF
+pub const ENA_REGS_MMIO_REG_READ_REG_OFF_SHIFT: u32 = 16
+pub const ENA_REGS_MMIO_REG_READ_REG_OFF_MASK: u32 = 0xFFFF0000

--- a/projects/harland/kernel/src/drivers/netdev.ritz
+++ b/projects/harland/kernel/src/drivers/netdev.ritz
@@ -1,0 +1,257 @@
+# Network Device Abstraction Layer
+#
+# Provides a unified interface for network devices regardless of the
+# underlying driver (VirtIO-net, ENA, etc).
+#
+# This abstraction allows higher-level code (network stack, sockets)
+# to work with any network device without knowing the specifics.
+#
+# Usage:
+#   netdev_init()                    # Probe for network devices
+#   let dev = netdev_get_default()   # Get default device (first found)
+#   netdev_send(dev, data, len)      # Send packet
+#   netdev_poll(dev, buf, max_len)   # Receive packet
+
+import serial { prints, println, serial_print_dec, serial_print_hex8, serial_write_byte }
+import drivers.virtio.net { VirtioNetDevice, virtio_net_init, virtio_net_send, virtio_net_poll, virtio_net_is_ready, virtio_net_get_mac, virtio_net_get_device }
+import drivers.ena.device { EnaDevice, ena_init, ena_send, ena_poll, ena_is_ready, ena_get_mac, ena_get_device }
+
+# ============================================================================
+# Network Device Types
+# ============================================================================
+
+# Network device type enumeration
+pub const NETDEV_TYPE_NONE: u8 = 0
+pub const NETDEV_TYPE_VIRTIO: u8 = 1
+pub const NETDEV_TYPE_ENA: u8 = 2
+
+# Network device structure
+# This is a thin wrapper that knows which driver to call
+pub struct NetDevice
+    dev_type: u8              # NETDEV_TYPE_*
+    _padding1: [3]u8
+    device_idx: i32           # Device index within driver (for multi-device support)
+    handle: u64               # Opaque handle to underlying device
+    mac: [6]u8                # MAC address
+    _padding2: [2]u8
+    flags: u32                # Device flags
+    mtu: u32                  # Maximum transmission unit
+
+pub const NETDEV_SIZE: u64 = 32
+
+# Device flags
+pub const NETDEV_FLAG_UP: u32 = 1       # Device is up
+pub const NETDEV_FLAG_RUNNING: u32 = 2  # Device is running
+pub const NETDEV_FLAG_PROMISC: u32 = 4  # Promiscuous mode
+
+# ============================================================================
+# Global State
+# ============================================================================
+
+const MAX_NET_DEVICES: i32 = 8
+
+var net_devices: [8]NetDevice
+var net_device_count: i32 = 0
+var default_device_idx: i32 = -1  # First available device
+
+# ============================================================================
+# Initialization
+# ============================================================================
+
+# Probe for network devices
+# Tries VirtIO-net first, then ENA
+# Returns number of devices found
+pub fn netdev_init() -> i32
+    net_device_count = 0
+    default_device_idx = -1
+
+    # Try VirtIO-net first (QEMU environment)
+    let virtio_result: i32 = virtio_net_init()
+    if virtio_result == 0
+        let vdev: *VirtioNetDevice = virtio_net_get_device()
+        if vdev != 0 as *VirtioNetDevice
+            let idx: i32 = net_device_count
+            net_devices[idx].dev_type = NETDEV_TYPE_VIRTIO
+            net_devices[idx].device_idx = 0
+            net_devices[idx].handle = vdev as u64
+            net_devices[idx].flags = NETDEV_FLAG_UP | NETDEV_FLAG_RUNNING
+            net_devices[idx].mtu = 1500
+
+            # Copy MAC address
+            virtio_net_get_mac(@net_devices[idx].mac[0])
+
+            net_device_count = net_device_count + 1
+            if default_device_idx < 0
+                default_device_idx = idx
+
+            prints("[netdev] Registered VirtIO-net device, MAC: ")
+            netdev_print_mac(@net_devices[idx])
+            prints("\n")
+
+    # Try ENA (EC2 environment)
+    let ena_result: i32 = ena_init()
+    if ena_result == 0
+        let edev: *EnaDevice = ena_get_device()
+        if edev != 0 as *EnaDevice
+            let idx: i32 = net_device_count
+            net_devices[idx].dev_type = NETDEV_TYPE_ENA
+            net_devices[idx].device_idx = 0
+            net_devices[idx].handle = edev as u64
+            net_devices[idx].flags = NETDEV_FLAG_UP | NETDEV_FLAG_RUNNING
+            net_devices[idx].mtu = 1500
+
+            # Copy MAC address
+            ena_get_mac(@net_devices[idx].mac[0])
+
+            net_device_count = net_device_count + 1
+            if default_device_idx < 0
+                default_device_idx = idx
+
+            prints("[netdev] Registered ENA device, MAC: ")
+            netdev_print_mac(@net_devices[idx])
+            prints("\n")
+
+    prints("[netdev] Found ")
+    serial_print_dec(net_device_count as u64)
+    prints(" network device(s)\n")
+
+    net_device_count
+
+# ============================================================================
+# Device Access
+# ============================================================================
+
+# Get the default network device (first available)
+pub fn netdev_get_default() -> *NetDevice
+    if default_device_idx < 0
+        return 0 as *NetDevice
+    @net_devices[default_device_idx]
+
+# Get network device by index
+pub fn netdev_get(idx: i32) -> *NetDevice
+    if idx < 0 or idx >= net_device_count
+        return 0 as *NetDevice
+    @net_devices[idx]
+
+# Get number of network devices
+pub fn netdev_count() -> i32
+    net_device_count
+
+# ============================================================================
+# Network I/O Operations
+# ============================================================================
+
+# Send packet through a network device
+# data: Packet data (Ethernet frame)
+# len: Length of packet
+# Returns: 0 on success, negative on error
+pub fn netdev_send(dev: *NetDevice, data: *u8, len: u32) -> i32
+    if dev == 0 as *NetDevice
+        return -1
+
+    if (*dev).dev_type == NETDEV_TYPE_VIRTIO
+        return virtio_net_send(data, len)
+
+    else if (*dev).dev_type == NETDEV_TYPE_ENA
+        return ena_send(data, len)
+
+    -3  # Unknown device type
+
+# Poll for received packets
+# buf: Buffer to receive into
+# max_len: Maximum bytes to read
+# Returns: Number of bytes received, 0 if no packet, negative on error
+pub fn netdev_poll(dev: *NetDevice, buf: *u8, max_len: u32) -> i32
+    if dev == 0 as *NetDevice
+        return -1
+
+    if (*dev).dev_type == NETDEV_TYPE_VIRTIO
+        return virtio_net_poll(buf, max_len)
+
+    else if (*dev).dev_type == NETDEV_TYPE_ENA
+        return ena_poll(buf, max_len)
+
+    -3  # Unknown device type
+
+# ============================================================================
+# Device Properties
+# ============================================================================
+
+# Get MAC address
+pub fn netdev_get_mac(dev: *NetDevice, mac_out: *u8)
+    if dev == 0 as *NetDevice
+        var i: i32 = 0
+        while i < 6
+            *(mac_out + i as i64) = 0
+            i = i + 1
+        return
+
+    var i: i32 = 0
+    while i < 6
+        *(mac_out + i as i64) = (*dev).mac[i]
+        i = i + 1
+
+# Get device MTU
+pub fn netdev_get_mtu(dev: *NetDevice) -> u32
+    if dev == 0 as *NetDevice
+        return 0
+    (*dev).mtu
+
+# Check if device is up
+pub fn netdev_is_up(dev: *NetDevice) -> bool
+    if dev == 0 as *NetDevice
+        return false
+    ((*dev).flags & NETDEV_FLAG_UP) != 0
+
+# Check if device is running
+pub fn netdev_is_running(dev: *NetDevice) -> bool
+    if dev == 0 as *NetDevice
+        return false
+    ((*dev).flags & NETDEV_FLAG_RUNNING) != 0
+
+# Get device type
+pub fn netdev_type(dev: *NetDevice) -> u8
+    if dev == 0 as *NetDevice
+        return NETDEV_TYPE_NONE
+    (*dev).dev_type
+
+# Get device type as string
+pub fn netdev_type_name(dev: *NetDevice) -> *u8
+    if dev == 0 as *NetDevice
+        return c"none"
+    if (*dev).dev_type == NETDEV_TYPE_VIRTIO
+        return c"virtio-net"
+    if (*dev).dev_type == NETDEV_TYPE_ENA
+        return c"ena"
+    c"unknown"
+
+# ============================================================================
+# Utility Functions
+# ============================================================================
+
+# Print MAC address
+pub fn netdev_print_mac(dev: *NetDevice)
+    if dev == 0 as *NetDevice
+        prints("00:00:00:00:00:00")
+        return
+
+    let hex_chars: *u8 = c"0123456789ABCDEF"
+    var i: i32 = 0
+    while i < 6
+        if i > 0
+            prints(":")
+        let byte: u8 = (*dev).mac[i]
+        let hi: u8 = (byte >> 4) & 0x0F
+        let lo: u8 = byte & 0x0F
+        serial_write_byte(*(hex_chars + hi as i64))
+        serial_write_byte(*(hex_chars + lo as i64))
+        i = i + 1
+
+# Check if any network device is ready
+pub fn netdev_any_ready() -> bool
+    var i: i32 = 0
+    while i < net_device_count
+        if netdev_is_running(@net_devices[i])
+            return true
+        i = i + 1
+    false

--- a/projects/harland/kernel/src/drivers/pci.ritz
+++ b/projects/harland/kernel/src/drivers/pci.ritz
@@ -49,6 +49,7 @@ pub const PCI_VENDOR_INVALID: u16 = 0xFFFF
 pub const PCI_VENDOR_INTEL: u16 = 0x8086
 pub const PCI_VENDOR_QEMU: u16 = 0x1234
 pub const PCI_VENDOR_REDHAT: u16 = 0x1AF4   # VirtIO devices
+pub const PCI_VENDOR_AMAZON: u16 = 0x1D0F   # Amazon ENA devices
 
 # VirtIO device IDs (when vendor is 0x1AF4)
 pub const VIRTIO_DEVICE_NET: u16 = 0x1000
@@ -56,6 +57,13 @@ pub const VIRTIO_DEVICE_BLOCK: u16 = 0x1001
 pub const VIRTIO_DEVICE_CONSOLE: u16 = 0x1003
 pub const VIRTIO_DEVICE_RNG: u16 = 0x1005
 pub const VIRTIO_DEVICE_GPU: u16 = 0x1050
+
+# Amazon ENA device IDs (when vendor is 0x1D0F)
+pub const ENA_DEVICE_PF: u16 = 0x0EC2       # ENA Physical Function
+pub const ENA_DEVICE_LLQ_PF: u16 = 0x1EC2   # ENA Low Latency Queue PF
+pub const ENA_DEVICE_VF: u16 = 0xEC20       # ENA Virtual Function (EC2)
+pub const ENA_DEVICE_LLQ_VF: u16 = 0xEC21   # ENA Low Latency Queue VF
+pub const ENA_DEVICE_RESRV0: u16 = 0x0051   # Reserved
 
 # BAR type masks
 const PCI_BAR_TYPE_MASK: u32 = 0x01
@@ -346,6 +354,24 @@ pub fn pci_find_by_class(class_code: u8, subclass: u8) -> *PciDevice
 pub fn pci_find_virtio(virtio_device_id: u16) -> *PciDevice
     return pci_find_device(PCI_VENDOR_REDHAT, virtio_device_id)
 
+# Find any Amazon ENA network device
+pub fn pci_find_ena() -> *PciDevice
+    # Try each known ENA device ID
+    var dev: *PciDevice = pci_find_device(PCI_VENDOR_AMAZON, ENA_DEVICE_VF)
+    if dev != 0 as *PciDevice
+        return dev
+    dev = pci_find_device(PCI_VENDOR_AMAZON, ENA_DEVICE_LLQ_VF)
+    if dev != 0 as *PciDevice
+        return dev
+    dev = pci_find_device(PCI_VENDOR_AMAZON, ENA_DEVICE_PF)
+    if dev != 0 as *PciDevice
+        return dev
+    dev = pci_find_device(PCI_VENDOR_AMAZON, ENA_DEVICE_LLQ_PF)
+    if dev != 0 as *PciDevice
+        return dev
+    dev = pci_find_device(PCI_VENDOR_AMAZON, ENA_DEVICE_RESRV0)
+    return dev
+
 # Find the Nth VirtIO device of a given type (0-indexed)
 pub fn pci_find_virtio_nth(virtio_device_id: u16, n: i32) -> *PciDevice
     var found: i32 = 0
@@ -439,6 +465,18 @@ pub fn pci_print_device(dev: *PciDevice)
             prints("GPU")
         else
             serial_print_hex16((*dev).device_id)
+        prints(")")
+
+    if (*dev).vendor_id == PCI_VENDOR_AMAZON
+        prints(" (Amazon ENA")
+        if (*dev).device_id == ENA_DEVICE_VF
+            prints(" VF")
+        else if (*dev).device_id == ENA_DEVICE_LLQ_VF
+            prints(" LLQ VF")
+        else if (*dev).device_id == ENA_DEVICE_PF
+            prints(" PF")
+        else if (*dev).device_id == ENA_DEVICE_LLQ_PF
+            prints(" LLQ PF")
         prints(")")
 
     prints("\n")

--- a/projects/harland/kernel/src/net/arp.ritz
+++ b/projects/harland/kernel/src/net/arp.ritz
@@ -14,7 +14,10 @@
 import serial { prints, serial_print_dec }
 import net.types { ARP_OP_REQUEST, ARP_OP_REPLY, ARP_PACKET_SIZE, ARP_HW_ETHERNET, ARP_PROTO_IPV4, ETHERTYPE_ARP, ip_eq, mac_copy, ip_copy }
 import net.eth { eth_build_frame }
-import drivers.virtio.net { virtio_net_send, virtio_net_get_mac }
+
+# Forward declarations - use network stack's device abstraction
+extern fn net_send(data: *u8, len: u32) -> i32
+extern fn net_get_mac(mac_out: *u8)
 
 # ============================================================================
 # ARP Cache
@@ -122,7 +125,7 @@ pub fn arp_cache_clear()
 # Returns packet size (ARP_PACKET_SIZE = 28)
 fn arp_build_packet(buf: *u8, operation: u16, target_ip: *u8, target_mac: *u8) -> u32
     var our_mac: [6]u8
-    virtio_net_get_mac(@our_mac[0])
+    net_get_mac(@our_mac[0])
 
     # HW Type = Ethernet (big-endian)
     *(buf + 0) = 0
@@ -195,7 +198,7 @@ pub fn arp_send_request(target_ip: *u8) -> i32
     let frame_len: u32 = eth_build_frame(@frame[0], @broadcast_mac[0], ETHERTYPE_ARP, @arp_payload[0], arp_len)
 
     # Send via NIC
-    return virtio_net_send(@frame[0], frame_len)
+    return net_send(@frame[0], frame_len)
 
 # ============================================================================
 # Handle Received ARP Packet
@@ -225,7 +228,7 @@ pub fn arp_handle_packet(arp_buf: *u8, len: u32)
                 var arp_reply: [28]u8
                 let reply_len: u32 = arp_build_packet(@arp_reply[0], ARP_OP_REPLY, sender_ip, sender_mac)
                 let frame_len: u32 = eth_build_frame(@frame[0], sender_mac, ETHERTYPE_ARP, @arp_reply[0], reply_len)
-                virtio_net_send(@frame[0], frame_len)
+                net_send(@frame[0], frame_len)
 
                 prints("[arp] Sent reply to ")
                 arp_print_ip(sender_ip)

--- a/projects/harland/kernel/src/net/dhcp.ritz
+++ b/projects/harland/kernel/src/net/dhcp.ritz
@@ -8,7 +8,10 @@ import net.types { DHCP_SERVER_PORT, DHCP_CLIENT_PORT, DHCP_OP_REQUEST, DHCP_OP_
 import net.ip { ip_build_header, ip_set_config, ip_set_dns }
 import net.udp { udp_build_header }
 import net.eth { eth_build_frame, eth_get_broadcast_mac }
-import drivers.virtio.net { virtio_net_send, virtio_net_get_mac }
+
+# Forward declarations - use network stack's device abstraction
+extern fn net_send(data: *u8, len: u32) -> i32
+extern fn net_get_mac(mac_out: *u8)
 
 # ============================================================================
 # DHCP Client State
@@ -62,7 +65,7 @@ pub fn dhcp_discover() -> i32
     # ciaddr, yiaddr, siaddr, giaddr all zero (bytes 12-27)
 
     # Client MAC at offset 28
-    virtio_net_get_mac(@dhcp_buf[28])
+    net_get_mac(@dhcp_buf[28])
 
     # DHCP Magic cookie at offset 236
     dhcp_buf[236] = 0x63
@@ -122,7 +125,7 @@ pub fn dhcp_discover() -> i32
     dhcp_state = 1
     prints("[dhcp] Sending DISCOVER\n")
 
-    return virtio_net_send(@frame[0], frame_len)
+    return net_send(@frame[0], frame_len)
 
 # ============================================================================
 # DHCP Request
@@ -156,7 +159,7 @@ fn dhcp_send_request() -> i32
     dhcp_buf[10] = 0x80
 
     # Client MAC at offset 28
-    virtio_net_get_mac(@dhcp_buf[28])
+    net_get_mac(@dhcp_buf[28])
 
     # DHCP Magic cookie
     dhcp_buf[236] = 0x63
@@ -221,7 +224,7 @@ fn dhcp_send_request() -> i32
     dhcp_state = 2
     prints("[dhcp] Sending REQUEST\n")
 
-    return virtio_net_send(@frame[0], frame_len)
+    return net_send(@frame[0], frame_len)
 
 # ============================================================================
 # Handle DHCP Response

--- a/projects/harland/kernel/src/net/eth.ritz
+++ b/projects/harland/kernel/src/net/eth.ritz
@@ -10,7 +10,10 @@
 # FCS (Frame Check Sequence) is handled by hardware.
 
 import net.types { ETHERTYPE_IPV4, ETHERTYPE_ARP, ETH_HEADER_SIZE, memcpy }
-import drivers.virtio.net { virtio_net_get_mac }
+
+# Forward declaration - get MAC from active network device
+# Defined in net.stack to avoid circular imports
+extern fn net_get_mac(mac_out: *u8)
 
 # ============================================================================
 # Ethernet Header Structure
@@ -36,7 +39,7 @@ pub fn eth_build_frame(buf: *u8, dst_mac: *u8, ethertype: u16, payload: *u8, pay
         i = i + 1
 
     # Copy source MAC (our MAC)
-    virtio_net_get_mac(buf + 6)
+    net_get_mac(buf + 6)
 
     # Set EtherType (big-endian/network byte order)
     *(buf + 12) = ((ethertype >> 8) & 0xFF) as u8

--- a/projects/harland/kernel/src/net/icmp.ritz
+++ b/projects/harland/kernel/src/net/icmp.ritz
@@ -7,7 +7,9 @@ import net.types { IP_PROTO_ICMP, ETHERTYPE_IPV4, ICMP_ECHO_REQUEST, ICMP_ECHO_R
 import net.ip { ip_checksum, ip_build_header, ip_get_gateway, ip_is_local, ip_get_next_hop }
 import net.arp { arp_cache_lookup, arp_send_request }
 import net.eth { eth_build_frame }
-import drivers.virtio.net { virtio_net_send }
+
+# Forward declaration - send through active network device
+extern fn net_send(data: *u8, len: u32) -> i32
 
 # ============================================================================
 # ICMP State
@@ -87,7 +89,7 @@ pub fn icmp_ping(dst_ip: *u8) -> i32
     icmp_waiting = 1
 
     # Send
-    return virtio_net_send(@frame[0], frame_len)
+    return net_send(@frame[0], frame_len)
 
 # ============================================================================
 # Handle Received ICMP Packet
@@ -170,7 +172,7 @@ fn icmp_send_reply(request_buf: *u8, request_len: u32, dst_ip: *u8)
     let frame_len: u32 = eth_build_frame(@frame[0], @dst_mac[0], ETHERTYPE_IPV4, @ip_buf[0], ip_len + icmp_len)
 
     # Send
-    virtio_net_send(@frame[0], frame_len)
+    net_send(@frame[0], frame_len)
     prints("[icmp] Sent reply to ")
     icmp_print_ip(dst_ip)
     prints("\n")

--- a/projects/harland/kernel/src/net/stack.ritz
+++ b/projects/harland/kernel/src/net/stack.ritz
@@ -2,8 +2,11 @@
 #
 # Main network stack initialization, packet polling, and dispatch.
 # This is the central coordination point for all network layers.
+#
+# Uses the netdev abstraction layer to support multiple network backends
+# (VirtIO-net, ENA, etc) without protocol-level changes.
 
-import serial { prints, serial_print_dec }
+import serial { prints, serial_print_dec, serial_print }
 import net.types { ETHERTYPE_ARP, ETHERTYPE_IPV4, IP_PROTO_ICMP, IP_PROTO_UDP, IP_PROTO_TCP, IP_HEADER_SIZE, ETH_HEADER_SIZE, DHCP_SERVER_PORT, DHCP_CLIENT_PORT, UDP_HEADER_SIZE }
 import net.eth { eth_parse_header, EthHeader }
 import net.arp { arp_init, arp_handle_packet }
@@ -11,7 +14,7 @@ import net.ip { ip_init, ip_is_configured, ip_print_config, ip_get_header_len, i
 import net.icmp { icmp_handle_packet }
 import net.udp { udp_get_src_port, udp_get_dst_port }
 import net.dhcp { dhcp_discover, dhcp_handle_packet, dhcp_is_configured }
-import drivers.virtio.net { virtio_net_init, virtio_net_poll, virtio_net_is_ready }
+import drivers.netdev { NetDevice, netdev_init, netdev_get_default, netdev_poll, netdev_send, netdev_count, netdev_is_running, netdev_print_mac, netdev_type_name, netdev_get_mac }
 
 # ============================================================================
 # Network Stack State
@@ -19,6 +22,7 @@ import drivers.virtio.net { virtio_net_init, virtio_net_poll, virtio_net_is_read
 
 var net_rx_buf: [2048]u8
 var net_initialized: u8 = 0
+var net_device: *NetDevice = 0 as *NetDevice
 
 # ============================================================================
 # Initialization
@@ -31,11 +35,17 @@ pub fn net_stack_init() -> i32
     arp_init()
     ip_init()
 
-    # Initialize VirtIO-net driver
-    let result: i32 = virtio_net_init()
-    if result < 0
-        prints("[net] VirtIO-net init failed!\n")
-        return result
+    # Probe for network devices via netdev abstraction
+    let dev_count: i32 = netdev_init()
+    if dev_count <= 0
+        prints("[net] No network devices found!\n")
+        return -1
+
+    # Get the default network device
+    net_device = netdev_get_default()
+    if net_device == 0 as *NetDevice
+        prints("[net] Failed to get default network device!\n")
+        return -2
 
     net_initialized = 1
     prints("[net] Network stack initialized\n")
@@ -62,7 +72,8 @@ pub fn net_poll() -> i32
     if net_initialized == 0
         return 0
 
-    let len: i32 = virtio_net_poll(@net_rx_buf[0], 2048)
+    # Poll via netdev abstraction
+    let len: i32 = netdev_poll(net_device, @net_rx_buf[0], 2048)
     if len <= 0
         return 0
 
@@ -148,10 +159,25 @@ fn handle_udp_packet(udp_data: *u8, udp_len: u32, src_ip: *u8) -> i32
 # ============================================================================
 
 pub fn net_is_ready() -> bool
-    return net_initialized == 1 and virtio_net_is_ready() == 1
+    return net_initialized == 1 and net_device != 0 as *NetDevice and netdev_is_running(net_device)
 
 pub fn net_is_configured() -> bool
     return ip_is_configured()
+
+# Get the active network device
+pub fn net_get_device() -> *NetDevice
+    net_device
+
+# Get the MAC address of the active network device
+pub fn net_get_mac(mac_out: *u8)
+    netdev_get_mac(net_device, mac_out)
+    return
+
+# Send a packet through the active network device
+pub fn net_send(data: *u8, len: u32) -> i32
+    if net_device == 0 as *NetDevice
+        return -1
+    netdev_send(net_device, data, len)
 
 # ============================================================================
 # Debug
@@ -165,11 +191,20 @@ pub fn net_print_status()
     else
         prints("no\n")
 
-    prints("  VirtIO-net:  ")
-    if virtio_net_is_ready() == 1
-        prints("ready\n")
+    prints("  Device:      ")
+    if net_device != 0 as *NetDevice
+        serial_print(netdev_type_name(net_device))
+        prints(" (")
+        netdev_print_mac(net_device)
+        prints(")\n")
     else
-        prints("not ready\n")
+        prints("none\n")
+
+    prints("  Running:     ")
+    if net_device != 0 as *NetDevice and netdev_is_running(net_device)
+        prints("yes\n")
+    else
+        prints("no\n")
 
     prints("  DHCP:        ")
     if dhcp_is_configured()

--- a/projects/harland/kernel/src/net/udp.ritz
+++ b/projects/harland/kernel/src/net/udp.ritz
@@ -8,7 +8,9 @@ import net.types { UDP_HEADER_SIZE, IP_PROTO_UDP, ETHERTYPE_IPV4 }
 import net.ip { ip_checksum, ip_build_header, ip_get_next_hop, ip_get_our_addr }
 import net.arp { arp_cache_lookup, arp_send_request }
 import net.eth { eth_build_frame, eth_get_broadcast_mac }
-import drivers.virtio.net { virtio_net_send }
+
+# Forward declaration - send through active network device
+extern fn net_send(data: *u8, len: u32) -> i32
 
 # ============================================================================
 # UDP Header Structure
@@ -96,7 +98,7 @@ pub fn udp_send(dst_ip: *u8, dst_port: u16, src_port: u16, payload: *u8, payload
     # Build Ethernet frame
     let frame_len: u32 = eth_build_frame(@frame[0], @dst_mac[0], ETHERTYPE_IPV4, @packet[0], total_len)
 
-    return virtio_net_send(@frame[0], frame_len)
+    return net_send(@frame[0], frame_len)
 
 # ============================================================================
 # Send UDP Broadcast
@@ -135,7 +137,7 @@ pub fn udp_send_broadcast(dst_port: u16, src_port: u16, payload: *u8, payload_le
     let bcast_mac: *u8 = eth_get_broadcast_mac()
     let frame_len: u32 = eth_build_frame(@frame[0], bcast_mac, ETHERTYPE_IPV4, @packet[0], total_len)
 
-    return virtio_net_send(@frame[0], frame_len)
+    return net_send(@frame[0], frame_len)
 
 # ============================================================================
 # Get UDP Payload


### PR DESCRIPTION
## Summary

- **AWS ENA Driver**: Complete implementation of the Elastic Network Adapter driver for EC2 networking
- **Netdev Abstraction**: Unified network device interface that supports both VirtIO-net (QEMU) and ENA (EC2)
- **Protocol Updates**: All network protocols (ARP, DHCP, ICMP, UDP) now use the netdev abstraction

## New Files

| File | Lines | Description |
|------|-------|-------------|
| `drivers/ena/regs.ritz` | 151 | Register definitions and BAR layout |
| `drivers/ena/admin.ritz` | 366 | MMIO-based admin queue management |
| `drivers/ena/io.ritz` | 245 | I/O queue structures and descriptors |
| `drivers/ena/device.ritz` | 1319 | Device init, reset, and packet I/O |
| `drivers/netdev.ritz` | 258 | Network device abstraction layer |

## Key Features

**ENA Driver:**
- MMIO-based admin queue (no MSI-X required)
- Proper device reset sequence with timeout handling
- RX/TX queue setup with scatter-gather descriptors
- MAC address retrieval from device firmware
- Polling-based packet I/O

**Netdev Abstraction:**
- `netdev_init()` - Probes for available network devices
- `netdev_send(dev, data, len)` - Send packet
- `netdev_poll(dev, buf, max_len)` - Receive packet
- Supports multiple device types transparently

## Test Plan

- [x] Tested on QEMU with VirtIO-net (regression test)
- [x] Tested on AWS EC2 t3.micro with ENA
- [x] ENA reset completes successfully
- [x] MAC address retrieved from device
- [ ] DHCP + networking needs more testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)