### PR TITLE
ritz0: fix aliased and non-selective import resolution

### DIFF
--- a/projects/ritz/ritz0/import_resolver.py
+++ b/projects/ritz/ritz0/import_resolver.py
@@ -175,6 +175,8 @@ class ImportResolver:
         self.module_exports: Dict[str, ModuleExports] = {}
         # Import aliases: from_file -> {alias -> module_path}
         self.import_aliases: Dict[str, Dict[str, str]] = {}
+        # Qualified name rewrites: from_file -> {alias -> {name -> rewritten_name}}
+        self.qualified_rewrites: Dict[str, Dict[str, Dict[str, str]]] = {}
         # RFC #109 Phase 2: Dependency mappings for namespace resolution
         self.dependencies: Dict[str, DependencyMapping] = dependencies.copy() if dependencies else {}
         # Auto-detect dependencies from RITZ_PATH entries with ritz.toml
@@ -360,6 +362,76 @@ class ImportResolver:
             self.import_aliases[from_file] = {}
         self.import_aliases[from_file][alias] = module_path
 
+    def _mangle_qualified_name(self, alias: str, name: str) -> str:
+        """Create a collision-free symbol name for qualified alias imports."""
+        return f"__imp_{alias}_{name}"
+
+    def _find_export_item(self, entry: ExportEntry):
+        """Find a registered AST item matching an export entry."""
+        if entry.kind == "fn":
+            for fn in self.functions.get(entry.name, []):
+                if getattr(fn, 'source_file', None) == entry.module_path:
+                    return fn
+        elif entry.kind == "extern_fn":
+            ex = self.extern_fns.get(entry.name)
+            if ex and getattr(ex, 'source_file', None) == entry.module_path:
+                return ex
+        elif entry.kind == "const":
+            for const in self.constants.get(entry.name, []):
+                if getattr(const, 'source_file', None) == entry.module_path:
+                    return const
+        elif entry.kind == "var":
+            var = self.variables.get(entry.name)
+            if var and getattr(var, 'source_file', None) == entry.module_path:
+                return var
+        return None
+
+    def _register_alias_rewrites(self, imp: rast.Import, module_path: str, from_file: str):
+        """Register qualified-name rewrite mappings for an import alias."""
+        if not imp.alias:
+            return
+
+        exports = self.module_exports.get(module_path)
+        if exports is None:
+            return
+
+        selected = self._validate_selective_import(imp, exports)
+        if from_file not in self.qualified_rewrites:
+            self.qualified_rewrites[from_file] = {}
+        if imp.alias not in self.qualified_rewrites[from_file]:
+            self.qualified_rewrites[from_file][imp.alias] = {}
+
+        alias_map = self.qualified_rewrites[from_file][imp.alias]
+        for export_name, entry in selected.items():
+            rewritten = export_name
+            if entry.kind in ("fn", "extern_fn", "const", "var"):
+                rewritten = self._mangle_qualified_name(imp.alias, export_name)
+                export_item = self._find_export_item(entry)
+                if export_item is not None and rewritten != export_name:
+                    cloned = replace(export_item, name=rewritten)
+                    self._register_item(cloned, entry.module_path)
+            alias_map[export_name] = rewritten
+
+    def _build_export_map_from_metadata(self, cached_meta, module_path: str) -> ModuleExports:
+        """Build a module export map from cached metadata."""
+        exports = ModuleExports()
+
+        for fn in cached_meta.functions:
+            kind = "extern_fn" if fn.is_extern else "fn"
+            exports.add_export(ExportEntry(fn.name, kind, module_path, True))
+        for s in cached_meta.structs:
+            exports.add_export(ExportEntry(s.name, "struct", module_path, True))
+        for e in cached_meta.enums:
+            exports.add_export(ExportEntry(e.name, "enum", module_path, True))
+        for c in cached_meta.constants:
+            exports.add_export(ExportEntry(c.name, "const", module_path, True))
+        for t in cached_meta.type_aliases:
+            exports.add_export(ExportEntry(t.name, "type_alias", module_path, True))
+        for tr in cached_meta.traits:
+            exports.add_export(ExportEntry(tr.name, "trait", module_path, True))
+
+        return exports
+
     def resolve_qualified_name(
         self,
         qualifier: str,
@@ -399,7 +471,7 @@ class ImportResolver:
         Issue #99: Qualified import name resolution not implemented
         """
         source_path = str(Path(source_path).resolve())
-        aliases = self.import_aliases.get(source_path, {})
+        aliases = self.qualified_rewrites.get(source_path, {})
 
         if not aliases:
             # No aliases registered for this file - no transformation needed
@@ -412,7 +484,7 @@ class ImportResolver:
 
         return rast.Module(module.span, transformed_items)
 
-    def _transform_item(self, item: rast.Item, aliases: Dict[str, str]) -> rast.Item:
+    def _transform_item(self, item: rast.Item, aliases: Dict[str, Dict[str, str]]) -> rast.Item:
         """Transform QualifiedIdent nodes in an item."""
         # Helper to preserve source_file attribute through replace()
         def copy_source_file(old_item: rast.Item, new_item: rast.Item) -> rast.Item:
@@ -450,13 +522,13 @@ class ImportResolver:
         # Other items don't contain expressions that need transformation
         return item
 
-    def _transform_block(self, block: rast.Block, aliases: Dict[str, str]) -> rast.Block:
+    def _transform_block(self, block: rast.Block, aliases: Dict[str, Dict[str, str]]) -> rast.Block:
         """Transform expressions in a block."""
         new_stmts = [self._transform_stmt(stmt, aliases) for stmt in block.stmts]
         new_expr = self._transform_expr(block.expr, aliases) if block.expr else None
         return replace(block, stmts=new_stmts, expr=new_expr)
 
-    def _transform_stmt(self, stmt: rast.Stmt, aliases: Dict[str, str]) -> rast.Stmt:
+    def _transform_stmt(self, stmt: rast.Stmt, aliases: Dict[str, Dict[str, str]]) -> rast.Stmt:
         """Transform expressions in a statement."""
         if isinstance(stmt, rast.LetStmt):
             if stmt.value:
@@ -490,21 +562,26 @@ class ImportResolver:
             return replace(stmt, iter=new_iter, body=new_body)
         return stmt
 
-    def _transform_expr(self, expr: rast.Expr, aliases: Dict[str, str]) -> rast.Expr:
+    def _transform_expr(self, expr: rast.Expr, aliases: Dict[str, Dict[str, str]]) -> rast.Expr:
         """Transform QualifiedIdent and recursively transform sub-expressions."""
         if expr is None:
             return None
 
         # KEY TRANSFORMATION: QualifiedIdent -> Ident
         if isinstance(expr, rast.QualifiedIdent):
-            if expr.qualifier in aliases:
-                # Transform sys::write -> write
-                return rast.Ident(expr.span, expr.name)
-            else:
-                raise RitzImportError(
+            alias_map = aliases.get(expr.qualifier)
+            if alias_map is None:
+                raise ImportError(
                     f"Unknown import alias: '{expr.qualifier}' in '{expr.qualifier}::{expr.name}'",
                     expr.span
                 )
+            rewritten = alias_map.get(expr.name)
+            if rewritten is None:
+                raise ImportError(
+                    f"'{expr.name}' is not exported by aliased module '{expr.qualifier}'",
+                    expr.span
+                )
+            return rast.Ident(expr.span, rewritten)
 
         # Recursively transform sub-expressions using replace()
         if isinstance(expr, rast.BinOp):
@@ -698,13 +775,13 @@ class ImportResolver:
         if import_path is None:
             raise ImportError(f"Cannot find module: {'.'.join(imp.path)}")
 
-        # Register import alias if present (Issue #99: qualified import support)
-        # e.g., import ritzlib.sys as sys -> register 'sys' alias for from_file
+        # Register import alias if present
         if imp.alias:
             self._register_import_alias(imp.alias, import_path, from_file)
 
         # Skip if already processed
         if import_path in self.processed_files:
+            self._register_alias_rewrites(imp, import_path, from_file)
             return
 
         # Check for cycles
@@ -729,10 +806,12 @@ class ImportResolver:
                     if not has_generics:
                         # Use cached metadata - convert to AST items without reparsing
                         self._register_items_from_metadata(cached_meta, import_path)
+                        self.module_exports[import_path] = self._build_export_map_from_metadata(cached_meta, import_path)
                         # Recursively process cached imports
                         for nested_import_path in cached_meta.imports:
                             nested_imp = rast.Import(rast.Span("<cached>", 0, 0, 0), nested_import_path.split('.'))
                             self._process_import(nested_imp, import_path)
+                        self._register_alias_rewrites(imp, import_path, from_file)
                         return
 
             # Cache miss or disabled - read and parse the imported file
@@ -741,6 +820,7 @@ class ImportResolver:
             tokens = lexer.tokenize()
             parser = Parser(tokens)
             imported_module = parser.parse_module()
+            self.module_exports[import_path] = self._build_export_map(imported_module, import_path)
 
             # Process imports in the imported module
             for item in imported_module.items:
@@ -754,6 +834,8 @@ class ImportResolver:
                 meta = extract_metadata(imported_module, import_path)
                 self.generated_metadata[import_path] = meta
                 self.metadata_cache.put(meta)
+
+            self._register_alias_rewrites(imp, import_path, from_file)
 
         finally:
             self.processing_stack.pop()

--- a/projects/ritz/ritz0/test_export_map.py
+++ b/projects/ritz/ritz0/test_export_map.py
@@ -11,7 +11,7 @@ import tempfile
 import ritz_ast as rast
 from lexer import Lexer
 from parser import Parser
-from import_resolver import ImportResolver, ExportEntry, ModuleExports
+from import_resolver import ImportResolver, ExportEntry, ModuleExports, resolve_imports
 
 
 def parse_module(code: str, filename: str = "test.ritz") -> rast.Module:
@@ -563,6 +563,87 @@ pub import nonexistent
         resolver._process_re_exports(module, "test.ritz", exports)
         assert len(exports.exports) == 0
 
+
+
+class TestAliasedImportRewrites:
+    """Behavior tests for alias-qualified import rewrites."""
+
+    def test_alias_import_without_items_exposes_all_qualified(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "mod.ritz").write_text("""
+pub fn foo() -> i32
+    1
+
+pub fn bar() -> i32
+    2
+""")
+            main = parse_module("""
+import mod as m
+
+fn call_foo() -> i32
+    m::foo()
+
+fn call_bar() -> i32
+    m::bar()
+""", str(root / "main.ritz"))
+
+            merged = resolve_imports(main, str(root / "main.ritz"), project_root=str(root), use_cache=False)
+            fn_names = {item.name for item in merged.items if isinstance(item, rast.FnDef)}
+
+            assert "__imp_m_foo" in fn_names
+            assert "__imp_m_bar" in fn_names
+
+    def test_selective_alias_only_allows_selected_names(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "mod.ritz").write_text("""
+pub fn foo() -> i32
+    1
+
+pub fn bar() -> i32
+    2
+""")
+            main = parse_module("""
+import mod { foo } as m
+
+fn call_foo() -> i32
+    m::foo()
+
+fn call_bar() -> i32
+    m::bar()
+""", str(root / "main.ritz"))
+
+            with pytest.raises(Exception) as exc:
+                resolve_imports(main, str(root / "main.ritz"), project_root=str(root), use_cache=False)
+
+            assert "not exported by aliased module 'm'" in str(exc.value)
+
+    def test_two_aliases_can_call_same_export_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "a.ritz").write_text("""
+pub fn init() -> i32
+    10
+""")
+            (root / "b.ritz").write_text("""
+pub fn init() -> i32
+    20
+""")
+            main = parse_module("""
+import a as aa
+import b as bb
+
+fn main() -> i32
+    aa::init() + bb::init()
+""", str(root / "main.ritz"))
+
+            merged = resolve_imports(main, str(root / "main.ritz"), project_root=str(root), use_cache=False)
+            fn_names = {item.name for item in merged.items if isinstance(item, rast.FnDef)}
+
+            assert "__imp_aa_init" in fn_names
+            assert "__imp_bb_init" in fn_names
+            assert "main" in fn_names
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
### Motivation

- The resolver incorrectly handled aliased and non-selective import forms such as `import a.b`, `import a.b as y`, and `import a.b { x } as y`, which prevented `y::x` from resolving and forced callers to import every symbol individually.
- The language needs qualified access to work safely when multiple aliases export the same identifier (e.g., `aa::init()` and `bb::init()`), so symbol collisions must be avoided.

### Description

- Added per-file, per-alias qualified-rewrite maps to track which exported names are available via an alias and what symbol they should rewrite to, stored in `projects/ritz/ritz0/import_resolver.py`.
- Implemented stable name mangling for value-level qualified imports (functions/externs/constants/vars) and clone-registered mangled symbols so two aliases can expose the same exported name without collision (`__imp_<alias>_<name>`).
- Ensure module export maps are built in both the cached-metadata path and the fresh-parse path and register alias rewrites for both already-processed and newly-parsed imports so selective and non-selective aliased imports behave consistently.
- Updated AST transformation to consult the alias->name rewrite map when rewriting `alias::name` to a plain `Ident`, and to raise a clear error when the alias doesn't export the requested name.
- Added behavior tests in `projects/ritz/ritz0/test_export_map.py` to cover: non-selective aliased imports exposing all qualified names, selective alias rejecting unimported names, and multiple aliases exporting the same symbol name.

### Testing

- Ran `PYENV_VERSION=3.11.14 python3 -m pytest -q projects/ritz/ritz0/test_export_map.py` and all tests passed (`25 passed`).
- Ran targeted parser tests with `PYENV_VERSION=3.11.14 python3 -m pytest -q projects/ritz/ritz0/test_parser.py -k "import_alias or qualified_ident"` and the selected tests passed.
- Attempted to run the full `ritz0` integration test invoking `projects/ritz/ritz0/ritz0.py --test ...` but it failed in this environment due to a missing `llvmlite` dependency; this is an environment limitation and not a failure of the import logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699802339a448333a3fb955772e1d606)